### PR TITLE
Refresh README and contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,76 @@
-# Contributing
+# Contributing to slacrawl
 
-## Setup
+Thanks for contributing. This project is still early, so the main goal is to keep changes small, testable, and aligned with the current product contract in [`SPEC.md`](./SPEC.md).
+
+## Before You Start
+
+- Read [`SPEC.md`](./SPEC.md) before changing behavior or CLI surfaces.
+- Open an issue first for larger changes, new commands, or scope changes.
+- Keep secrets and real Slack workspace data out of git, screenshots, fixtures, and examples.
+
+## Local Setup
+
+Requirements:
+
+- Go `1.25+`
+- SQLite with FTS5 support
+
+Build and test:
 
 ```bash
 go test ./...
 go build ./cmd/slacrawl
 ```
 
-## Workflow
+Run the CLI locally:
 
-1. Create a dedicated worktree/branch with `gwt new <branch>`.
-2. Keep changes scoped and reviewable.
-3. Run `go test ./...` before opening a PR.
-4. Keep docs and code in sync. `SPEC.md` is the implementation contract.
+```bash
+go run ./cmd/slacrawl --help
+```
+
+## Development Workflow
+
+1. Create a dedicated worktree and branch with `gwt new <branch>`.
+2. Keep the branch focused on one change or one small related set of changes.
+3. Update docs when behavior, flags, config, or scope changes.
+4. Run tests before opening a pull request.
+5. Re-read your diff for accidental secret exposure, noisy refactors, or unrelated edits.
 
 ## Pull Requests
 
-- Use `gh` for PR operations.
-- Prefer draft PRs first.
-- Link issues with `Fixes: <issue>` when applicable.
-- Add tests for behavior changes and regressions.
-- Keep secrets out of git and out of command examples.
+- Use `gh` for pull request operations.
+- Prefer opening draft PRs first.
+- Link related issues with `Fixes: <issue>` when applicable.
+- Explain the user-visible behavior change and any important tradeoffs.
+- Add or update tests for behavior changes and regressions.
+- Keep PRs reviewable. Smaller is better.
 
-## Code Style
+## Coding Guidelines
 
-- Use Go stdlib and small stable dependencies.
-- Prefer explicit structs and straightforward control flow.
-- Keep Slack-specific behavior documented in code comments only when the reason is non-obvious.
-- Do not silently swallow partial-coverage states. Surface them in status or doctor output.
+- Prefer Go stdlib and small, stable dependencies.
+- Use explicit structs and straightforward control flow.
+- Preserve the local-first model. Do not introduce remote storage requirements for core usage.
+- Surface partial-coverage states explicitly in `doctor`, `status`, or command output instead of hiding them.
+- Add comments only when the reason for Slack-specific behavior is not obvious from the code.
+
+## Documentation
+
+- Keep [`README.md`](./README.md), [`SPEC.md`](./SPEC.md), and examples in sync with the implementation.
+- Do not document features as supported until they are actually implemented.
+- When changing config keys or defaults, update [`config.example.toml`](./config.example.toml).
+
+## Testing Expectations
+
+- Run `go test ./...` before opening a PR.
+- Add targeted tests when changing parsing, normalization, config loading, store behavior, or CLI output.
+- If a known failing test blocks your branch, call that out clearly in the PR description.
+
+## Reporting Bugs
+
+When filing an issue, include:
+
+- what you ran
+- what you expected
+- what happened instead
+- relevant config snippets with secrets removed
+- platform details such as OS, Go version, and whether Slack Desktop discovery was involved

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/vincentkoc/slacrawl/blob/main/LICENSE"><img src="https://img.shields.io/github/license/vincentkoc/slacrawl" alt="License"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/vincentkoc/slacrawl" alt="License"></a>
   <img src="https://img.shields.io/badge/go-1.25%2B-00ADD8" alt="Go 1.25+">
   <img src="https://img.shields.io/badge/storage-SQLite-003B57" alt="SQLite">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey" alt="Platform">

--- a/README.md
+++ b/README.md
@@ -1,47 +1,64 @@
-# slacrawl
+<h1 align="center">slacrawl</h1>
 
-`slacrawl` mirrors Slack workspace data into local SQLite so you can search, inspect, and query channel history without depending on Slack search.
+<p align="center">
+  <strong>Mirror Slack workspace data into local SQLite for fast search, structured queries, and offline inspection.</strong>
+</p>
 
-It is a local-first Go CLI. V1 supports Slack Web API ingestion and macOS Slack Desktop local-state discovery. Data stays local.
+<p align="center">
+  <a href="https://github.com/vincentkoc/slacrawl/blob/main/LICENSE"><img src="https://img.shields.io/github/license/vincentkoc/slacrawl" alt="License"></a>
+  <img src="https://img.shields.io/badge/go-1.25%2B-00ADD8" alt="Go 1.25+">
+  <img src="https://img.shields.io/badge/storage-SQLite-003B57" alt="SQLite">
+  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey" alt="Platform">
+</p>
 
-## What It Does
+## Why slacrawl?
 
-- discovers the configured workspace
-- syncs channels, users, and message history into SQLite
-- backfills thread replies when a user token is available
-- maintains FTS5 search indexes for fast local text search
-- records structured mentions for direct querying
-- exposes read-only SQL for ad hoc analysis
-- reports desktop-local Slack cache availability on macOS
+Slack search is convenient until you need your own workflow, your own retention, or your own queries. `slacrawl` is a local-first Go CLI that pulls Slack workspace metadata and message history into SQLite so you can inspect it without depending on the Slack UI.
+
+The current implementation focuses on API-based ingestion first, with macOS Slack Desktop discovery available as a read-only bootstrap source. Data stays on your machine.
+
+## What You Get
+
+- local SQLite storage with FTS5-backed search
+- workspace, channel, user, and message sync
+- thread reply backfill when a user token is available
+- mention extraction for structured querying
+- read-only SQL access for ad hoc analysis
+- `doctor` diagnostics for config, database, token, and desktop-source checks
+- optional Socket Mode live tailing via app token
 
 ## V1 Scope
 
-- one workspace at a time in the CLI
+- one workspace at a time
 - public channels
 - private channels
 - top-level messages
 - channel threads
-- FTS5 search
+- local FTS search
 - read-only SQL access
+- macOS Slack Desktop discovery
 
 Out of scope for V1:
 
 - Slack export ZIP import
 - DMs and MPIMs
-- attachment binary downloads
+- attachment blob downloads
 - write-back actions
-- Marketplace/public-distribution guarantees
+- public Marketplace-style distribution hardening
 - desktop-local message extraction beyond the documented bootstrap surface
 
 ## Requirements
 
 - Go `1.25+`
-- a Slack app with a bot token
-- an app-level token for Socket Mode if you want `tail`
-- an optional user token for complete historical thread replies in public/private channels
-- macOS Slack Desktop only if you want desktop-local discovery in V1
+- a Slack bot token for standard API sync
+- an app token if you want to use `tail`
+- an optional user token for fuller historical thread coverage
+- macOS Slack Desktop only if you want desktop-local discovery
 
 ## Install
+
+<details>
+<summary>Build from source</summary>
 
 ```bash
 git clone https://github.com/vincentkoc/slacrawl.git
@@ -50,6 +67,19 @@ go build -o bin/slacrawl ./cmd/slacrawl
 ./bin/slacrawl --help
 ```
 
+</details>
+
+<details>
+<summary>Run without building a binary</summary>
+
+```bash
+git clone https://github.com/vincentkoc/slacrawl.git
+cd slacrawl
+go run ./cmd/slacrawl --help
+```
+
+</details>
+
 ## Quick Start
 
 ```bash
@@ -57,33 +87,76 @@ export SLACK_BOT_TOKEN="xoxb-..."
 export SLACK_APP_TOKEN="xapp-..."
 export SLACK_USER_TOKEN="xoxp-..."
 
-bin/slacrawl init
-bin/slacrawl doctor
-bin/slacrawl sync --source api --full
-bin/slacrawl search "incident"
+go run ./cmd/slacrawl init
+go run ./cmd/slacrawl doctor
+go run ./cmd/slacrawl sync --source api --full
+go run ./cmd/slacrawl search "incident"
 ```
+
+If you built the binary, replace `go run ./cmd/slacrawl` with `./bin/slacrawl`.
 
 ## Commands
 
-- `init`
-- `doctor`
-- `sync`
-- `tail`
-- `search`
-- `messages`
-- `mentions`
-- `sql`
-- `users`
-- `channels`
-- `status`
+- `init` creates a starter config file
+- `doctor` checks config, DB access, token presence, FTS, and desktop source availability
+- `sync` performs a one-shot crawl from API, desktop, or both
+- `tail` listens for live events through Socket Mode
+- `search` runs local FTS queries
+- `messages` lists stored messages with filters
+- `mentions` lists structured mention records
+- `sql` runs read-only SQL against the local database
+- `users` lists synced users
+- `channels` lists synced channels
+- `status` prints workspace and sync status
 
-## Config
-
-Default runtime paths:
+## Default Paths
 
 - config: `~/.slacrawl/config.toml`
 - database: `~/.slacrawl/slacrawl.db`
-- cache: `~/.slacrawl/cache/`
-- logs: `~/.slacrawl/logs/`
+- cache: `~/.slacrawl/cache`
+- logs: `~/.slacrawl/logs`
 
-See [`SPEC.md`](./SPEC.md) for the full product contract and [`config.example.toml`](./config.example.toml) for a starting config.
+## Configuration
+
+The starter config lives in [`config.example.toml`](./config.example.toml). By default it points to these environment variables:
+
+- `SLACK_BOT_TOKEN`
+- `SLACK_APP_TOKEN`
+- `SLACK_USER_TOKEN`
+
+Desktop discovery is enabled by default and uses:
+
+```text
+~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack
+```
+
+## Typical Workflow
+
+```bash
+go run ./cmd/slacrawl init
+go run ./cmd/slacrawl sync --source api --full
+go run ./cmd/slacrawl status
+go run ./cmd/slacrawl channels
+go run ./cmd/slacrawl messages --channel C12345678 --limit 20
+go run ./cmd/slacrawl mentions --limit 20
+go run ./cmd/slacrawl sql 'select channel_id, count(*) as messages from messages group by channel_id order by messages desc limit 10;'
+```
+
+## Notes on Coverage
+
+- Full historical thread reply coverage in public and private channels depends on providing a user token.
+- `tail` requires an app token because it uses Socket Mode.
+- Desktop-local support is currently discovery-first and bootstrap-oriented, not a full alternative ingestion path.
+
+## Development
+
+```bash
+go test ./...
+go build ./cmd/slacrawl
+```
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for contribution workflow and [`SPEC.md`](./SPEC.md) for the implementation contract.
+
+---
+
+Built by <a href="https://github.com/vincentkoc">Vincent Koc</a> · <a href="./LICENSE">MIT</a>


### PR DESCRIPTION
## Summary
- replace the minimal README with a more complete project overview
- expand CONTRIBUTING.md into a fuller community guide
- keep license references aligned with MIT

## Notes
- docs-only follow-up branch