### PR TITLE
Add ergonomic multi-workspace sync and tail support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Data stays on your machine. You can run it in API mode, desktop mode, or a hybri
 
 ## Current Coverage
 
-- one workspace at a time
+- multi-workspace storage and filtering
+- multi-workspace API sync when `[[workspaces]]` is configured
+- multi-workspace live tailing when per-workspace app tokens are configured
 - public channels
 - private channels
 - top-level messages
@@ -131,7 +133,7 @@ export SLACK_USER_TOKEN="xoxp-..."
 go run ./cmd/slacrawl init
 go run ./cmd/slacrawl doctor
 go run ./cmd/slacrawl sync --source api
-go run ./cmd/slacrawl search "incident"
+go run ./cmd/slacrawl search --workspace T01234567 "incident"
 go run ./cmd/slacrawl tail --repair-every 30m
 go run ./cmd/slacrawl watch --desktop-every 5m
 ```
@@ -152,9 +154,9 @@ Choose the path that matches your setup:
 - `init` creates a starter config file
 - `doctor` checks config, DB access, token presence, FTS, and desktop source availability
 - `sync` performs a one-shot crawl from API, desktop, or both
-- `tail` listens for live events through Socket Mode
+- `tail` listens for live events through Socket Mode, including one tail per configured workspace
 - `watch` refreshes desktop-local state on a schedule
-- `search` runs local FTS queries
+- `search` runs local FTS queries, optionally filtered by workspace
 - `messages` lists stored messages with filters
 - `mentions` lists structured mention records
 - `sql` runs read-only SQL against the local database
@@ -218,6 +220,28 @@ go run ./cmd/slacrawl completion zsh > "${HOME}/.zsh/completions/_slacrawl"
 - logs: `~/.slacrawl/logs`
 
 ## Configuration
+
+For one workspace, keep using the top-level `[slack.bot]`, `[slack.app]`, and `[slack.user]` token config.
+
+For multiple API workspaces or multiple live wiretap/tail sessions, add `[[workspaces]]` entries with per-workspace token env vars:
+
+```toml
+workspace_id = "T01234567"
+
+[[workspaces]]
+id = "T01234567"
+default = true
+
+[[workspaces]]
+id = "T08976543"
+bot_token_env = "SLACK_CLIENT_BOT_TOKEN"
+app_token_env = "SLACK_CLIENT_APP_TOKEN"
+user_token_env = "SLACK_CLIENT_USER_TOKEN"
+```
+
+By default, each workspace entry automatically looks for `SLACK_<WORKSPACE_ID>_BOT_TOKEN`, `SLACK_<WORKSPACE_ID>_APP_TOKEN`, and `SLACK_<WORKSPACE_ID>_USER_TOKEN`, so you only need the `id` in the common case. Top-level `enabled` flags still apply globally, which avoids repeating `enabled = true` per workspace.
+
+Without `--workspace`, `sync --source api` and `tail` fan out across every configured workspace entry. Read commands such as `search`, `messages`, `mentions`, `users`, and `channels` accept `--workspace` to scope the shared local database when needed.
 
 The starter config lives in [`config.example.toml`](./config.example.toml). By default it points to these environment variables:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,8 @@ Goal:
 
 V1 scope:
 
-- one workspace at a time in CLI UX
+- multi-workspace storage
+- one or many workspaces in CLI sync and tail when explicitly configured
 - public channels
 - private channels
 - top-level messages
@@ -199,6 +200,8 @@ Credential model:
 - each token source can be enabled or disabled independently
 - desktop source can be enabled or disabled independently
 - blank desktop path means auto-detect the supported macOS Slack path
+- optional `[[workspaces]]` entries can override bot/app/user token env vars per workspace
+- workspace token lookup should default to `SLACK_<WORKSPACE_ID>_BOT_TOKEN`, `SLACK_<WORKSPACE_ID>_APP_TOKEN`, and `SLACK_<WORKSPACE_ID>_USER_TOKEN`
 
 ## Sync Algorithm
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,6 +4,21 @@ db_path = "~/.slacrawl/slacrawl.db"
 cache_dir = "~/.slacrawl/cache"
 log_dir = "~/.slacrawl/logs"
 
+[[workspaces]]
+id = "T01234567"
+default = true
+# uses:
+# SLACK_T01234567_BOT_TOKEN
+# SLACK_T01234567_APP_TOKEN
+# SLACK_T01234567_USER_TOKEN
+
+[[workspaces]]
+id = "T08976543"
+# override only if you do not want the default SLACK_<WORKSPACE_ID>_* names
+bot_token_env = "SLACK_CLIENT_BOT_TOKEN"
+app_token_env = "SLACK_CLIENT_APP_TOKEN"
+user_token_env = "SLACK_CLIENT_USER_TOKEN"
+
 [slack.bot]
 enabled = true
 token_env = "SLACK_BOT_TOKEN"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,14 @@ db_path = "~/.slacrawl/slacrawl.db"
 cache_dir = "~/.slacrawl/cache"
 log_dir = "~/.slacrawl/logs"
 
+[[workspaces]]
+id = "T01234567"
+default = true
+# uses:
+# SLACK_T01234567_BOT_TOKEN
+# SLACK_T01234567_APP_TOKEN
+# SLACK_T01234567_USER_TOKEN
+
 [slack.bot]
 enabled = true
 token_env = "SLACK_BOT_TOKEN"
@@ -43,6 +51,34 @@ full_history = true
 [search]
 default_mode = "fts"
 ```
+
+## Workspace Selection
+
+`workspace_id` remains the default CLI workspace.
+
+Use `[[workspaces]]` when you want separate bot/app/user tokens per Slack workspace, especially for multi-workspace API sync and live tailing:
+
+```toml
+[[workspaces]]
+id = "T01234567"
+default = true
+
+[[workspaces]]
+id = "T08976543"
+bot_token_env = "SLACK_CLIENT_BOT_TOKEN"
+app_token_env = "SLACK_CLIENT_APP_TOKEN"
+user_token_env = "SLACK_CLIENT_USER_TOKEN"
+```
+
+Behavior:
+
+- each workspace automatically tries `SLACK_<WORKSPACE_ID>_BOT_TOKEN`, `SLACK_<WORKSPACE_ID>_APP_TOKEN`, and `SLACK_<WORKSPACE_ID>_USER_TOKEN`
+- top-level `enabled` flags are inherited, so you do not need to repeat `enabled = true` for every workspace
+- `bot_token_env`, `app_token_env`, and `user_token_env` are optional overrides when you do not want the default env naming convention
+- `sync --source api` without `--workspace` runs against every configured `[[workspaces]]` entry
+- `tail` without `--workspace` starts one live tail per configured `[[workspaces]]` entry
+- `search`, `messages`, `mentions`, `users`, and `channels` accept `--workspace` to filter the shared SQLite database
+- if `[[workspaces]]` is empty, the legacy top-level `[slack.*]` token config is used
 
 ## Token Sources
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vincentkoc/slacrawl/internal/config"
@@ -194,6 +195,10 @@ func (a *App) runDoctor(ctx context.Context, configPath string, format OutputFor
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return err
 	}
+	workspaceAPI, err := a.workspaceDoctorReports(ctx, cfg)
+	if err != nil {
+		return err
+	}
 	desktop := slackdesktop.Source{Path: cfg.Slack.Desktop.Path, Available: false}
 	if cfg.Slack.Desktop.Enabled {
 		desktop, err = slackdesktop.Inspect(cfg.Slack.Desktop.Path)
@@ -202,6 +207,9 @@ func (a *App) runDoctor(ctx context.Context, configPath string, format OutputFor
 		}
 	}
 	threadCoverage := diag.ThreadCoverage
+	if len(workspaceAPI) > 0 {
+		threadCoverage = aggregateThreadCoverage(workspaceAPI)
+	}
 	if threadCoverage == "" {
 		threadCoverage = "partial"
 	}
@@ -236,6 +244,7 @@ func (a *App) runDoctor(ctx context.Context, configPath string, format OutputFor
 			"user_set":     cfg.ResolveTokens().User != "",
 		},
 		"slack_api":         diag,
+		"workspace_api":     workspaceAPI,
 		"desktop_source":    desktop,
 		"api_channel_skips": channelSkips,
 		"tail_state":        tailState,
@@ -286,14 +295,15 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	}
 	defer st.Close()
 
-	summary, err := syncer.Run(ctx, cfg, st, syncer.Options{
+	runOptions := syncer.Options{
 		Source:      syncer.Source(*source),
 		WorkspaceID: coalesce(*workspaceID, cfg.WorkspaceID),
 		Channels:    csv(*channels),
 		Since:       *since,
 		Full:        *full,
 		Concurrency: *concurrency,
-	})
+	}
+	summary, err := a.runSyncTargets(ctx, cfg, st, runOptions)
 	if err != nil {
 		return err
 	}
@@ -313,7 +323,13 @@ func (a *App) runSearch(ctx context.Context, configPath string, args []string, f
 	if err != nil {
 		return err
 	}
-	if len(args) == 0 {
+	fs := flag.NewFlagSet("search", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	workspaceID := fs.String("workspace", "", "workspace id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
 		return errors.New("search query required")
 	}
 	st, err := store.Open(cfg.DBPath)
@@ -321,7 +337,7 @@ func (a *App) runSearch(ctx context.Context, configPath string, args []string, f
 		return err
 	}
 	defer st.Close()
-	results, err := st.Search(ctx, strings.Join(args, " "), 50)
+	results, err := st.Search(ctx, coalesce(*workspaceID, cfg.WorkspaceID), strings.Join(fs.Args(), " "), 50)
 	if err != nil {
 		return err
 	}
@@ -335,6 +351,7 @@ func (a *App) runMessages(ctx context.Context, configPath string, args []string,
 	}
 	fs := flag.NewFlagSet("messages", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
+	workspaceID := fs.String("workspace", "", "workspace id")
 	channelID := fs.String("channel", "", "channel id")
 	userID := fs.String("author", "", "user id")
 	limit := fs.Int("limit", 50, "row limit")
@@ -346,7 +363,7 @@ func (a *App) runMessages(ctx context.Context, configPath string, args []string,
 		return err
 	}
 	defer st.Close()
-	results, err := st.Messages(ctx, *channelID, *userID, store.RequireLimit(*limit))
+	results, err := st.Messages(ctx, coalesce(*workspaceID, cfg.WorkspaceID), *channelID, *userID, store.RequireLimit(*limit))
 	if err != nil {
 		return err
 	}
@@ -360,6 +377,7 @@ func (a *App) runMentions(ctx context.Context, configPath string, args []string,
 	}
 	fs := flag.NewFlagSet("mentions", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
+	workspaceID := fs.String("workspace", "", "workspace id")
 	target := fs.String("target", "", "target id or label")
 	limit := fs.Int("limit", 50, "row limit")
 	if err := fs.Parse(args); err != nil {
@@ -370,7 +388,7 @@ func (a *App) runMentions(ctx context.Context, configPath string, args []string,
 		return err
 	}
 	defer st.Close()
-	results, err := st.Mentions(ctx, *target, store.RequireLimit(*limit))
+	results, err := st.Mentions(ctx, coalesce(*workspaceID, cfg.WorkspaceID), *target, store.RequireLimit(*limit))
 	if err != nil {
 		return err
 	}
@@ -410,16 +428,22 @@ func (a *App) runUsers(ctx context.Context, configPath string, args []string, fo
 	if err != nil {
 		return err
 	}
+	fs := flag.NewFlagSet("users", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	workspaceID := fs.String("workspace", "", "workspace id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 	query := ""
-	if len(args) > 0 {
-		query = args[0]
+	if fs.NArg() > 0 {
+		query = fs.Arg(0)
 	}
 	st, err := store.Open(cfg.DBPath)
 	if err != nil {
 		return err
 	}
 	defer st.Close()
-	results, err := st.Users(ctx, query, 100)
+	results, err := st.Users(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, 100)
 	if err != nil {
 		return err
 	}
@@ -431,16 +455,22 @@ func (a *App) runChannels(ctx context.Context, configPath string, args []string,
 	if err != nil {
 		return err
 	}
+	fs := flag.NewFlagSet("channels", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	workspaceID := fs.String("workspace", "", "workspace id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 	query := ""
-	if len(args) > 0 {
-		query = args[0]
+	if fs.NArg() > 0 {
+		query = fs.Arg(0)
 	}
 	st, err := store.Open(cfg.DBPath)
 	if err != nil {
 		return err
 	}
 	defer st.Close()
-	results, err := st.Channels(ctx, query, 100)
+	results, err := st.Channels(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, 100)
 	if err != nil {
 		return err
 	}
@@ -468,7 +498,14 @@ func (a *App) runTail(ctx context.Context, configPath string, args []string) err
 	if err != nil {
 		return err
 	}
-	return slackapi.New(cfg.ResolveTokens()).Tail(ctx, st, coalesce(*workspaceID, cfg.WorkspaceID), repairDuration)
+	targets := resolveWorkspaceTargets(cfg, *workspaceID)
+	if len(targets) == 0 {
+		targets = []string{coalesce(*workspaceID, cfg.WorkspaceID)}
+	}
+	if len(targets) == 1 {
+		return slackapi.New(cfg.ResolveTokensForWorkspace(targets[0])).Tail(ctx, st, targets[0], repairDuration)
+	}
+	return a.runTailTargets(ctx, st, cfg, targets, repairDuration)
 }
 
 func (a *App) runWatch(ctx context.Context, configPath string, args []string, format OutputFormat) error {
@@ -558,6 +595,114 @@ func csv(value string) []string {
 		}
 	}
 	return out
+}
+
+func resolveWorkspaceTargets(cfg config.Config, requested string) []string {
+	if strings.TrimSpace(requested) != "" {
+		return []string{strings.TrimSpace(requested)}
+	}
+	if ids := cfg.WorkspaceIDs(); len(ids) > 0 {
+		return ids
+	}
+	if cfg.WorkspaceID != "" {
+		return []string{cfg.WorkspaceID}
+	}
+	return nil
+}
+
+func (a *App) runSyncTargets(ctx context.Context, cfg config.Config, st *store.Store, opts syncer.Options) (syncer.Summary, error) {
+	targets := resolveWorkspaceTargets(cfg, opts.WorkspaceID)
+	if opts.Source == syncer.SourceDesktop {
+		return syncer.Run(ctx, cfg, st, opts)
+	}
+	if len(targets) == 0 {
+		return syncer.Run(ctx, cfg, st, opts)
+	}
+
+	var last syncer.Summary
+	for _, workspaceID := range targets {
+		runOpts := opts
+		runOpts.WorkspaceID = workspaceID
+		summary, err := syncer.RunWithTokens(ctx, cfg, st, runOpts, cfg.ResolveTokensForWorkspace(workspaceID))
+		if err != nil {
+			return syncer.Summary{}, err
+		}
+		last = summary
+	}
+	return last, nil
+}
+
+func (a *App) runTailTargets(ctx context.Context, st *store.Store, cfg config.Config, workspaceIDs []string, repairEvery time.Duration) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errCh := make(chan error, len(workspaceIDs))
+	var wg sync.WaitGroup
+	for _, workspaceID := range workspaceIDs {
+		workspaceID := workspaceID
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := slackapi.New(cfg.ResolveTokensForWorkspace(workspaceID)).Tail(ctx, st, workspaceID, repairEvery)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				errCh <- fmt.Errorf("tail %s: %w", workspaceID, err)
+				cancel()
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-done:
+		return ctx.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (a *App) workspaceDoctorReports(ctx context.Context, cfg config.Config) ([]map[string]any, error) {
+	workspaceIDs := cfg.WorkspaceIDs()
+	if len(workspaceIDs) == 0 {
+		return nil, nil
+	}
+	reports := make([]map[string]any, 0, len(workspaceIDs))
+	for _, workspaceID := range workspaceIDs {
+		tokens := cfg.ResolveTokensForWorkspace(workspaceID)
+		diag, err := slackapi.New(tokens).Doctor(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return nil, fmt.Errorf("doctor %s: %w", workspaceID, err)
+		}
+		reports = append(reports, map[string]any{
+			"workspace_id": workspaceID,
+			"tokens": map[string]any{
+				"bot_set":  tokens.Bot != "",
+				"app_set":  tokens.App != "",
+				"user_set": tokens.User != "",
+			},
+			"slack_api": diag,
+		})
+	}
+	return reports, nil
+}
+
+func aggregateThreadCoverage(reports []map[string]any) string {
+	if len(reports) == 0 {
+		return "partial"
+	}
+	for _, report := range reports {
+		slackAPI, ok := report["slack_api"].(slackapi.Diagnostics)
+		if !ok || slackAPI.ThreadCoverage != "full" {
+			return "partial"
+		}
+	}
+	return "full"
 }
 
 func coalesce(primary string, fallback string) string {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -144,6 +145,68 @@ func TestDoctorIncludesOperationalSyncState(t *testing.T) {
 	require.Equal(t, "T123", state["entity_id"])
 }
 
+func TestWorkspaceFilteredReadCommands(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	dbPath := filepath.Join(tmp, "slacrawl.db")
+
+	cfg := config.Default()
+	cfg.DBPath = dbPath
+	cfg.WorkspaceID = ""
+	require.NoError(t, cfg.Save(configPath))
+
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	now := mustTime(t, "2026-03-08T18:20:43Z")
+	require.NoError(t, st.UpsertWorkspace(context.Background(), store.Workspace{ID: "T1", Name: "one", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertWorkspace(context.Background(), store.Workspace{ID: "T2", Name: "two", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(context.Background(), store.Channel{ID: "C1", WorkspaceID: "T1", Name: "alpha", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(context.Background(), store.Channel{ID: "C2", WorkspaceID: "T2", Name: "beta", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertUser(context.Background(), store.User{ID: "U1", WorkspaceID: "T1", Name: "alice", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertUser(context.Background(), store.User{ID: "U2", WorkspaceID: "T2", Name: "bob", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertMessage(context.Background(), store.Message{
+		ChannelID:      "C1",
+		TS:             "1.0",
+		WorkspaceID:    "T1",
+		UserID:         "U1",
+		Text:           "incident alpha",
+		NormalizedText: "incident alpha",
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      now,
+	}, []store.Mention{{Type: "user", TargetID: "U1", DisplayText: "alice"}}))
+	require.NoError(t, st.UpsertMessage(context.Background(), store.Message{
+		ChannelID:      "C2",
+		TS:             "2.0",
+		WorkspaceID:    "T2",
+		UserID:         "U2",
+		Text:           "incident beta",
+		NormalizedText: "incident beta",
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      now,
+	}, []store.Mention{{Type: "user", TargetID: "U2", DisplayText: "bob"}}))
+	require.NoError(t, st.Close())
+
+	var stdout bytes.Buffer
+	app := &App{Stdout: &stdout, Stderr: &stdout}
+
+	require.NoError(t, app.Run(context.Background(), []string{"--config", configPath, "--json", "search", "--workspace", "T2", "incident"}))
+	var searchRows []map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &searchRows))
+	require.Len(t, searchRows, 1)
+	require.Equal(t, "T2", searchRows[0]["workspace_id"])
+
+	stdout.Reset()
+	require.NoError(t, app.Run(context.Background(), []string{"--config", configPath, "--json", "channels", "--workspace", "T1"}))
+	var channels []map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &channels))
+	require.Len(t, channels, 1)
+	require.Equal(t, "T1", channels[0]["workspace_id"])
+}
+
 func TestHelpIncludesBannerAndUsage(t *testing.T) {
 	var stdout bytes.Buffer
 	app := &App{
@@ -159,6 +222,13 @@ func TestHelpIncludesBannerAndUsage(t *testing.T) {
 	require.Contains(t, out, "slacrawl [global flags] <command> [args]")
 	require.Contains(t, out, "--format <kind>")
 	require.Contains(t, out, "--no-color")
+}
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+	return parsed
 }
 
 func TestStatusHumanOutputIsStructured(t *testing.T) {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -37,12 +37,12 @@ var (
 		"sync":       {"--source", "--workspace", "--channels", "--since", "--full", "--concurrency", "--help", "-h"},
 		"tail":       {"--workspace", "--repair-every", "--help", "-h"},
 		"watch":      {"--desktop-every", "--help", "-h"},
-		"search":     {"--help", "-h"},
-		"messages":   {"--channel", "--author", "--limit", "--help", "-h"},
-		"mentions":   {"--target", "--limit", "--help", "-h"},
+		"search":     {"--workspace", "--help", "-h"},
+		"messages":   {"--workspace", "--channel", "--author", "--limit", "--help", "-h"},
+		"mentions":   {"--workspace", "--target", "--limit", "--help", "-h"},
 		"sql":        {"--help", "-h"},
-		"users":      {"--help", "-h"},
-		"channels":   {"--help", "-h"},
+		"users":      {"--workspace", "--help", "-h"},
+		"channels":   {"--workspace", "--help", "-h"},
 		"status":     {"--help", "-h"},
 		"completion": {"--help", "-h"},
 	}
@@ -129,11 +129,20 @@ _slacrawl()
         watch)
             COMPREPLY=( $(compgen -W "--desktop-every --help -h ${global_flags}" -- "${cur}") )
             ;;
+        search)
+            COMPREPLY=( $(compgen -W "--workspace --help -h ${global_flags}" -- "${cur}") )
+            ;;
         messages)
-            COMPREPLY=( $(compgen -W "--channel --author --limit --help -h ${global_flags}" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "--workspace --channel --author --limit --help -h ${global_flags}" -- "${cur}") )
             ;;
         mentions)
-            COMPREPLY=( $(compgen -W "--target --limit --help -h ${global_flags}" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "--workspace --target --limit --help -h ${global_flags}" -- "${cur}") )
+            ;;
+        users)
+            COMPREPLY=( $(compgen -W "--workspace --help -h ${global_flags}" -- "${cur}") )
+            ;;
+        channels)
+            COMPREPLY=( $(compgen -W "--workspace --help -h ${global_flags}" -- "${cur}") )
             ;;
         completion)
             COMPREPLY=( $(compgen -W "bash zsh --help -h ${global_flags}" -- "${cur}") )
@@ -191,11 +200,20 @@ _slacrawl() {
         watch)
           _arguments '--desktop-every[desktop refresh interval]:duration:'
           ;;
+        search)
+          _arguments '--workspace[workspace id]:workspace id:'
+          ;;
         messages)
-          _arguments '--channel[channel id]:channel id:' '--author[user id]:user id:' '--limit[row limit]:limit:'
+          _arguments '--workspace[workspace id]:workspace id:' '--channel[channel id]:channel id:' '--author[user id]:user id:' '--limit[row limit]:limit:'
           ;;
         mentions)
-          _arguments '--target[target id or label]:target:' '--limit[row limit]:limit:'
+          _arguments '--workspace[workspace id]:workspace id:' '--target[target id or label]:target:' '--limit[row limit]:limit:'
+          ;;
+        users)
+          _arguments '--workspace[workspace id]:workspace id:'
+          ;;
+        channels)
+          _arguments '--workspace[workspace id]:workspace id:'
           ;;
         completion)
           _values 'shell' bash zsh

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ const (
 type Config struct {
 	Version     int          `toml:"version"`
 	WorkspaceID string       `toml:"workspace_id"`
+	Workspaces  []Workspace  `toml:"workspaces"`
 	DBPath      string       `toml:"db_path"`
 	CacheDir    string       `toml:"cache_dir"`
 	LogDir      string       `toml:"log_dir"`
@@ -31,6 +32,15 @@ type SlackConfig struct {
 	App     TokenConfig   `toml:"app"`
 	User    TokenConfig   `toml:"user"`
 	Desktop DesktopConfig `toml:"desktop"`
+}
+
+type Workspace struct {
+	ID           string      `toml:"id"`
+	Default      bool        `toml:"default"`
+	BotTokenEnv  string      `toml:"bot_token_env"`
+	AppTokenEnv  string      `toml:"app_token_env"`
+	UserTokenEnv string      `toml:"user_token_env"`
+	Slack        SlackConfig `toml:"slack"`
 }
 
 type TokenConfig struct {
@@ -155,6 +165,15 @@ func (c *Config) Normalize() error {
 		}
 		*candidate = expanded
 	}
+	for i := range c.Workspaces {
+		if strings.TrimSpace(c.Workspaces[i].ID) == "" {
+			return fmt.Errorf("workspaces[%d].id is required", i)
+		}
+		c.Workspaces[i].ID = strings.TrimSpace(c.Workspaces[i].ID)
+	}
+	if c.WorkspaceID == "" {
+		c.WorkspaceID = c.DefaultWorkspaceID()
+	}
 	return nil
 }
 
@@ -176,17 +195,132 @@ func ExpandPath(path string) (string, error) {
 }
 
 func (c Config) ResolveTokens() Tokens {
+	return resolveTokens(c.Slack)
+}
+
+func (c Config) ResolveTokensForWorkspace(workspaceID string) Tokens {
+	if workspaceID == "" {
+		return c.ResolveTokens()
+	}
+	if workspace, ok := c.Workspace(workspaceID); ok {
+		return Tokens{
+			Bot:  c.resolveWorkspaceToken(c.Slack.Bot, workspace, "bot"),
+			App:  c.resolveWorkspaceToken(c.Slack.App, workspace, "app"),
+			User: c.resolveWorkspaceToken(c.Slack.User, workspace, "user"),
+		}
+	}
+	return c.ResolveTokens()
+}
+
+func (c Config) Workspace(workspaceID string) (Workspace, bool) {
+	for _, workspace := range c.Workspaces {
+		if workspace.ID == workspaceID {
+			return workspace, true
+		}
+	}
+	return Workspace{}, false
+}
+
+func (c Config) DefaultWorkspaceID() string {
+	if strings.TrimSpace(c.WorkspaceID) != "" {
+		return strings.TrimSpace(c.WorkspaceID)
+	}
+	for _, workspace := range c.Workspaces {
+		if workspace.Default {
+			return workspace.ID
+		}
+	}
+	if len(c.Workspaces) == 1 {
+		return c.Workspaces[0].ID
+	}
+	return ""
+}
+
+func (c Config) WorkspaceIDs() []string {
+	ids := make([]string, 0, len(c.Workspaces))
+	for _, workspace := range c.Workspaces {
+		ids = append(ids, workspace.ID)
+	}
+	return ids
+}
+
+func resolveTokens(cfg SlackConfig) Tokens {
 	tokens := Tokens{}
-	if c.Slack.Bot.Enabled {
-		tokens.Bot = os.Getenv(c.Slack.Bot.TokenEnv)
+	if cfg.Bot.Enabled {
+		tokens.Bot = os.Getenv(cfg.Bot.TokenEnv)
 	}
-	if c.Slack.App.Enabled {
-		tokens.App = os.Getenv(c.Slack.App.TokenEnv)
+	if cfg.App.Enabled {
+		tokens.App = os.Getenv(cfg.App.TokenEnv)
 	}
-	if c.Slack.User.Enabled {
-		tokens.User = os.Getenv(c.Slack.User.TokenEnv)
+	if cfg.User.Enabled {
+		tokens.User = os.Getenv(cfg.User.TokenEnv)
 	}
 	return tokens
+}
+
+func (c Config) resolveWorkspaceToken(global TokenConfig, workspace Workspace, kind string) string {
+	if !global.Enabled {
+		return ""
+	}
+	for _, envName := range []string{
+		workspaceTokenEnvOverride(workspace, kind),
+		workspace.SlackTokenEnv(kind),
+		workspaceTokenEnvName(workspace.ID, kind),
+		global.TokenEnv,
+	} {
+		if envName == "" {
+			continue
+		}
+		if value := os.Getenv(envName); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (w Workspace) SlackTokenEnv(kind string) string {
+	switch kind {
+	case "bot":
+		return w.Slack.Bot.TokenEnv
+	case "app":
+		return w.Slack.App.TokenEnv
+	case "user":
+		return w.Slack.User.TokenEnv
+	default:
+		return ""
+	}
+}
+
+func workspaceTokenEnvOverride(workspace Workspace, kind string) string {
+	switch kind {
+	case "bot":
+		return workspace.BotTokenEnv
+	case "app":
+		return workspace.AppTokenEnv
+	case "user":
+		return workspace.UserTokenEnv
+	default:
+		return ""
+	}
+}
+
+func workspaceTokenEnvName(workspaceID string, kind string) string {
+	if workspaceID == "" {
+		return ""
+	}
+	return "SLACK_" + sanitizeEnvSegment(workspaceID) + "_" + strings.ToUpper(kind) + "_TOKEN"
+}
+
+func sanitizeEnvSegment(value string) string {
+	var b strings.Builder
+	for _, r := range strings.ToUpper(strings.TrimSpace(value)) {
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	return b.String()
 }
 
 func DetectDesktopPath() (string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,43 @@ func TestResolveTokensHonorsEnabledFlags(t *testing.T) {
 	require.Equal(t, "", tokens.User)
 }
 
+func TestResolveTokensForWorkspace(t *testing.T) {
+	t.Setenv("SLACK_BOT_TOKEN", "xoxb-default")
+	t.Setenv("SLACK_APP_TOKEN", "xapp-default")
+	t.Setenv("SLACK_USER_TOKEN", "xoxp-default")
+	t.Setenv("SLACK_ALPHA_BOT_TOKEN", "xoxb-alpha")
+	t.Setenv("SLACK_ALPHA_APP_TOKEN", "xapp-alpha")
+	t.Setenv("SLACK_ALPHA_USER_TOKEN", "xoxp-alpha")
+
+	cfg := Default()
+	cfg.Workspaces = []Workspace{{
+		ID:           "TALPHA",
+		BotTokenEnv:  "SLACK_ALPHA_BOT_TOKEN",
+		AppTokenEnv:  "SLACK_ALPHA_APP_TOKEN",
+		UserTokenEnv: "SLACK_ALPHA_USER_TOKEN",
+	}}
+
+	tokens := cfg.ResolveTokensForWorkspace("TALPHA")
+	require.Equal(t, "xoxb-alpha", tokens.Bot)
+	require.Equal(t, "xapp-alpha", tokens.App)
+	require.Equal(t, "xoxp-alpha", tokens.User)
+	require.Equal(t, "xoxb-default", cfg.ResolveTokensForWorkspace("TUNKNOWN").Bot)
+}
+
+func TestResolveTokensForWorkspaceUsesImplicitWorkspaceEnvNames(t *testing.T) {
+	t.Setenv("SLACK_TALPHA_BOT_TOKEN", "xoxb-alpha")
+	t.Setenv("SLACK_TALPHA_APP_TOKEN", "xapp-alpha")
+	t.Setenv("SLACK_TALPHA_USER_TOKEN", "xoxp-alpha")
+
+	cfg := Default()
+	cfg.Workspaces = []Workspace{{ID: "TALPHA"}}
+
+	tokens := cfg.ResolveTokensForWorkspace("TALPHA")
+	require.Equal(t, "xoxb-alpha", tokens.Bot)
+	require.Equal(t, "xapp-alpha", tokens.App)
+	require.Equal(t, "xoxp-alpha", tokens.User)
+}
+
 func TestSaveAndLoadRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
@@ -66,6 +103,17 @@ func TestNormalizeAutoDetectsDesktopPath(t *testing.T) {
 	cfg.Slack.Desktop.Path = ""
 	require.NoError(t, cfg.Normalize())
 	require.True(t, filepath.IsAbs(cfg.Slack.Desktop.Path))
+}
+
+func TestNormalizeSetsDefaultWorkspaceFromWorkspaceList(t *testing.T) {
+	cfg := Default()
+	cfg.Workspaces = []Workspace{
+		{ID: "T123"},
+		{ID: "T456", Default: true},
+	}
+	require.NoError(t, cfg.Normalize())
+	require.Equal(t, "T456", cfg.WorkspaceID)
+	require.Equal(t, []string{"T123", "T456"}, cfg.WorkspaceIDs())
 }
 
 func mustHome(t *testing.T) string {

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -46,7 +46,7 @@ func TestSyncHandlesRateLimitAndThreadCoverage(t *testing.T) {
 	require.Equal(t, 2, status.Messages)
 	require.Equal(t, "full", status.ThreadState)
 
-	rows, err := st.Messages(context.Background(), "C123", "", 10)
+	rows, err := st.Messages(context.Background(), "", "C123", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	require.Equal(t, "message_replied", rows[0].Subtype)
@@ -92,7 +92,7 @@ func TestSyncWithInvalidUserTokenStillMarksPartialCoverage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "partial", value)
 
-	rows, err := st.Messages(context.Background(), "C123", "", 10)
+	rows, err := st.Messages(context.Background(), "", "C123", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, "root message", rows[0].Text)
@@ -133,7 +133,7 @@ func TestSyncSkipsChannelsTheBotCannotRead(t *testing.T) {
 	err := client.Sync(context.Background(), st, SyncOptions{})
 	require.NoError(t, err)
 
-	rows, err := st.Messages(context.Background(), "C222", "", 10)
+	rows, err := st.Messages(context.Background(), "", "C222", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, "accessible message", rows[0].Text)
@@ -159,7 +159,7 @@ func TestSyncUsesConfiguredConcurrencyForChannelHistory(t *testing.T) {
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, server.maxConcurrentHistory(), 2)
 
-	rows, err := st.Messages(context.Background(), "", "", 10)
+	rows, err := st.Messages(context.Background(), "", "", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 }
@@ -179,7 +179,7 @@ func TestSyncJoinsPublicChannelBeforeRetryingHistory(t *testing.T) {
 	err := client.Sync(context.Background(), st, SyncOptions{})
 	require.NoError(t, err)
 
-	rows, err := st.Messages(context.Background(), "C111", "", 10)
+	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, "joined message", rows[0].Text)
@@ -292,12 +292,12 @@ func TestHandleEventsAPIEventUpdatesStore(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, client.HandleEventsAPIEvent(ctx, st, "T123", renameEvent))
 
-	rows, err := st.Messages(ctx, "C123", "", 10)
+	rows, err := st.Messages(ctx, "", "C123", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.True(t, strings.Contains(rows[0].NormalizedText, "@alex"))
 
-	channels, err := st.Channels(ctx, "renamed", 10)
+	channels, err := st.Channels(ctx, "", "renamed", 10)
 	require.NoError(t, err)
 	require.Len(t, channels, 1)
 }
@@ -344,7 +344,7 @@ func TestHandleSocketModeEventAcksAndPersists(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, socket.acks)
 
-	rows, err := st.Messages(ctx, "C123", "", 10)
+	rows, err := st.Messages(ctx, "", "C123", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, "tail message", rows[0].Text)
@@ -396,7 +396,7 @@ func TestRepairWorkspaceReconcilesIncrementalHistory(t *testing.T) {
 
 	require.NoError(t, client.repairWorkspace(ctx, st, "T123"))
 
-	rows, err := st.Messages(ctx, "C123", "", 10)
+	rows, err := st.Messages(ctx, "", "C123", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	require.Equal(t, "new repair message", rows[0].Text)

--- a/internal/slackdesktop/desktop_test.go
+++ b/internal/slackdesktop/desktop_test.go
@@ -101,11 +101,11 @@ func TestIngestDesktopState(t *testing.T) {
 	require.Equal(t, 1, status.Users)
 	require.Equal(t, 1, status.Messages)
 
-	channels, err := st.Channels(context.Background(), "", 10)
+	channels, err := st.Channels(context.Background(), "", "", 10)
 	require.NoError(t, err)
 	require.Len(t, channels, 3)
 
-	users, err := st.Users(context.Background(), "", 10)
+	users, err := st.Users(context.Background(), "", "", 10)
 	require.NoError(t, err)
 	require.Len(t, users, 1)
 	require.Equal(t, "desktop_local_user | :airplane: Travel", users[0].Title)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -195,6 +195,7 @@ type Status struct {
 }
 
 type MessageRow struct {
+	WorkspaceID    string `json:"workspace_id"`
 	ChannelID      string `json:"channel_id"`
 	TS             string `json:"ts"`
 	UserID         string `json:"user_id"`
@@ -205,6 +206,7 @@ type MessageRow struct {
 }
 
 type MentionRow struct {
+	WorkspaceID string `json:"workspace_id"`
 	ChannelID   string `json:"channel_id"`
 	TS          string `json:"ts"`
 	MentionType string `json:"mention_type"`
@@ -213,6 +215,7 @@ type MentionRow struct {
 }
 
 type UserRow struct {
+	WorkspaceID string `json:"workspace_id"`
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	RealName    string `json:"real_name"`
@@ -221,9 +224,10 @@ type UserRow struct {
 }
 
 type ChannelRow struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Kind string `json:"kind"`
+	WorkspaceID string `json:"workspace_id"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Kind        string `json:"kind"`
 }
 
 type ChannelSyncCursor struct {
@@ -441,15 +445,17 @@ func (s *Store) Status(ctx context.Context) (Status, error) {
 	return status, nil
 }
 
-func (s *Store) Search(ctx context.Context, query string, limit int) ([]MessageRow, error) {
-	rows, err := s.db.QueryContext(ctx, `
-select m.channel_id, m.ts, m.user_id, m.text, m.normalized_text, m.thread_ts, m.subtype
+func (s *Store) Search(ctx context.Context, workspaceID string, query string, limit int) ([]MessageRow, error) {
+	sqlQuery := `
+select m.workspace_id, m.channel_id, m.ts, m.user_id, m.text, m.normalized_text, m.thread_ts, m.subtype
 from message_fts f
 join messages m on f.message_key = m.channel_id || '|' || m.ts
 where message_fts match ?
+  and (? = '' or m.workspace_id = ?)
 order by m.ts desc
 limit ?
-`, query, limit)
+`
+	rows, err := s.db.QueryContext(ctx, sqlQuery, query, workspaceID, workspaceID, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -457,12 +463,16 @@ limit ?
 	return scanMessageRows(rows)
 }
 
-func (s *Store) Messages(ctx context.Context, channelID string, userID string, limit int) ([]MessageRow, error) {
+func (s *Store) Messages(ctx context.Context, workspaceID string, channelID string, userID string, limit int) ([]MessageRow, error) {
 	query := `
-select channel_id, ts, user_id, text, normalized_text, thread_ts, subtype
+select workspace_id, channel_id, ts, user_id, text, normalized_text, thread_ts, subtype
 from messages
 where 1=1`
 	args := []any{}
+	if workspaceID != "" {
+		query += ` and workspace_id = ?`
+		args = append(args, workspaceID)
+	}
 	if channelID != "" {
 		query += ` and channel_id = ?`
 		args = append(args, channelID)
@@ -481,17 +491,22 @@ where 1=1`
 	return scanMessageRows(rows)
 }
 
-func (s *Store) Mentions(ctx context.Context, target string, limit int) ([]MentionRow, error) {
+func (s *Store) Mentions(ctx context.Context, workspaceID string, target string, limit int) ([]MentionRow, error) {
 	query := `
-select channel_id, ts, mention_type, target_id, coalesce(display_text, '')
-from message_mentions
+select m.workspace_id, mm.channel_id, mm.ts, mm.mention_type, mm.target_id, coalesce(mm.display_text, '')
+from message_mentions mm
+join messages m on m.channel_id = mm.channel_id and m.ts = mm.ts
 where 1=1`
 	args := []any{}
+	if workspaceID != "" {
+		query += ` and m.workspace_id = ?`
+		args = append(args, workspaceID)
+	}
 	if target != "" {
-		query += ` and (target_id = ? or display_text like ?)`
+		query += ` and (mm.target_id = ? or mm.display_text like ?)`
 		args = append(args, target, "%"+target+"%")
 	}
-	query += ` order by ts desc limit ?`
+	query += ` order by mm.ts desc limit ?`
 	args = append(args, limit)
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -502,7 +517,7 @@ where 1=1`
 	var out []MentionRow
 	for rows.Next() {
 		var row MentionRow
-		if err := rows.Scan(&row.ChannelID, &row.TS, &row.MentionType, &row.TargetID, &row.DisplayText); err != nil {
+		if err := rows.Scan(&row.WorkspaceID, &row.ChannelID, &row.TS, &row.MentionType, &row.TargetID, &row.DisplayText); err != nil {
 			return nil, err
 		}
 		out = append(out, row)
@@ -544,14 +559,15 @@ func (s *Store) QueryReadOnly(ctx context.Context, query string) ([]map[string]a
 	return results, rows.Err()
 }
 
-func (s *Store) Users(ctx context.Context, query string, limit int) ([]UserRow, error) {
+func (s *Store) Users(ctx context.Context, workspaceID string, query string, limit int) ([]UserRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
-select id, name, coalesce(real_name, ''), coalesce(display_name, ''), coalesce(title, '')
+select workspace_id, id, name, coalesce(real_name, ''), coalesce(display_name, ''), coalesce(title, '')
 from users
-where (? = '' or id = ? or name like ? or real_name like ? or display_name like ?)
+where (? = '' or workspace_id = ?)
+  and (? = '' or id = ? or name like ? or real_name like ? or display_name like ?)
 order by name asc
 limit ?
-`, query, query, "%"+query+"%", "%"+query+"%", "%"+query+"%", limit)
+`, workspaceID, workspaceID, query, query, "%"+query+"%", "%"+query+"%", "%"+query+"%", limit)
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +575,7 @@ limit ?
 	var out []UserRow
 	for rows.Next() {
 		var row UserRow
-		if err := rows.Scan(&row.ID, &row.Name, &row.RealName, &row.DisplayName, &row.Title); err != nil {
+		if err := rows.Scan(&row.WorkspaceID, &row.ID, &row.Name, &row.RealName, &row.DisplayName, &row.Title); err != nil {
 			return nil, err
 		}
 		out = append(out, row)
@@ -567,14 +583,15 @@ limit ?
 	return out, rows.Err()
 }
 
-func (s *Store) Channels(ctx context.Context, query string, limit int) ([]ChannelRow, error) {
+func (s *Store) Channels(ctx context.Context, workspaceID string, query string, limit int) ([]ChannelRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
-select id, name, kind
+select workspace_id, id, name, kind
 from channels
-where (? = '' or id = ? or name like ?)
+where (? = '' or workspace_id = ?)
+  and (? = '' or id = ? or name like ?)
 order by name asc
 limit ?
-`, query, query, "%"+query+"%", limit)
+`, workspaceID, workspaceID, query, query, "%"+query+"%", limit)
 	if err != nil {
 		return nil, err
 	}
@@ -582,7 +599,7 @@ limit ?
 	var out []ChannelRow
 	for rows.Next() {
 		var row ChannelRow
-		if err := rows.Scan(&row.ID, &row.Name, &row.Kind); err != nil {
+		if err := rows.Scan(&row.WorkspaceID, &row.ID, &row.Name, &row.Kind); err != nil {
 			return nil, err
 		}
 		out = append(out, row)
@@ -682,7 +699,7 @@ func scanMessageRows(rows *sql.Rows) ([]MessageRow, error) {
 	var out []MessageRow
 	for rows.Next() {
 		var row MessageRow
-		if err := rows.Scan(&row.ChannelID, &row.TS, &row.UserID, &row.Text, &row.NormalizedText, &row.ThreadTS, &row.Subtype); err != nil {
+		if err := rows.Scan(&row.WorkspaceID, &row.ChannelID, &row.TS, &row.UserID, &row.Text, &row.NormalizedText, &row.ThreadTS, &row.Subtype); err != nil {
 			return nil, err
 		}
 		out = append(out, row)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -42,9 +42,10 @@ func TestStoreRoundTrip(t *testing.T) {
 		UpdatedAt:      time.Now().UTC(),
 	}, nil))
 
-	results, err := s.Search(ctx, "hello", 10)
+	results, err := s.Search(ctx, "", "hello", 10)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
+	require.Equal(t, "T1", results[0].WorkspaceID)
 	status, err := s.Status(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, status.Messages)
@@ -76,4 +77,69 @@ func TestUpsertMessageDeduplicatesMentions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, int64(1), rows[0]["n"])
+}
+
+func TestWorkspaceFiltersApplyToReadQueries(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	defer s.Close()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	require.NoError(t, s.UpsertWorkspace(ctx, Workspace{ID: "T1", Name: "one", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, s.UpsertWorkspace(ctx, Workspace{ID: "T2", Name: "two", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, s.UpsertChannel(ctx, Channel{ID: "C1", WorkspaceID: "T1", Name: "eng", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, s.UpsertChannel(ctx, Channel{ID: "C2", WorkspaceID: "T2", Name: "ops", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, s.UpsertUser(ctx, User{ID: "U1", WorkspaceID: "T1", Name: "alice", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, s.UpsertUser(ctx, User{ID: "U2", WorkspaceID: "T2", Name: "bob", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, s.UpsertMessage(ctx, Message{
+		ChannelID:      "C1",
+		TS:             "1.0",
+		WorkspaceID:    "T1",
+		UserID:         "U1",
+		Text:           "hello alpha",
+		NormalizedText: "hello alpha",
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      now,
+	}, []Mention{{Type: "user", TargetID: "U1", DisplayText: "alice"}}))
+	require.NoError(t, s.UpsertMessage(ctx, Message{
+		ChannelID:      "C2",
+		TS:             "2.0",
+		WorkspaceID:    "T2",
+		UserID:         "U2",
+		Text:           "hello beta",
+		NormalizedText: "hello beta",
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      now,
+	}, []Mention{{Type: "user", TargetID: "U2", DisplayText: "bob"}}))
+
+	messages, err := s.Messages(ctx, "T1", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, "T1", messages[0].WorkspaceID)
+
+	search, err := s.Search(ctx, "T2", "hello", 10)
+	require.NoError(t, err)
+	require.Len(t, search, 1)
+	require.Equal(t, "T2", search[0].WorkspaceID)
+
+	mentions, err := s.Mentions(ctx, "T1", "U1", 10)
+	require.NoError(t, err)
+	require.Len(t, mentions, 1)
+	require.Equal(t, "T1", mentions[0].WorkspaceID)
+
+	users, err := s.Users(ctx, "T2", "", 10)
+	require.NoError(t, err)
+	require.Len(t, users, 1)
+	require.Equal(t, "T2", users[0].WorkspaceID)
+
+	channels, err := s.Channels(ctx, "T1", "", 10)
+	require.NoError(t, err)
+	require.Len(t, channels, 1)
+	require.Equal(t, "T1", channels[0].WorkspaceID)
 }

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -32,7 +32,10 @@ type Summary struct {
 }
 
 func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) (Summary, error) {
-	tokens := cfg.ResolveTokens()
+	return RunWithTokens(ctx, cfg, st, opts, cfg.ResolveTokens())
+}
+
+func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts Options, tokens config.Tokens) (Summary, error) {
 	summary := Summary{}
 
 	switch opts.Source {


### PR DESCRIPTION
## Summary
- add workspace-aware sync and tail fanout with shared-db workspace filters
- simplify multi-workspace config by auto-discovering per-workspace token env names
- update docs and tests for the new config and CLI behavior

## Testing
- go test ./...
