### PR TITLE
fix: populate channel ID on messages from history and replies

### DIFF
--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -309,6 +309,9 @@ func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, works
 			return fmt.Errorf("channel %s history: %w", channel.ID, err)
 		}
 		for _, msg := range resp.Messages {
+			if msg.Channel == "" {
+				msg.Channel = channel.ID
+			}
 			if err := st.UpsertMessage(ctx, toStoreMessage(workspaceID, msg, SourceBot, 2, now), toStoreMentions(msg)); err != nil {
 				return err
 			}
@@ -338,6 +341,9 @@ func (c *Client) syncThread(ctx context.Context, st *store.Store, workspaceID st
 			return err
 		}
 		for _, msg := range msgs {
+			if msg.Channel == "" {
+				msg.Channel = channelID
+			}
 			if err := st.UpsertMessage(ctx, toStoreMessage(workspaceID, msg, SourceUser, 1, now), toStoreMentions(msg)); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

- Slack's `conversations.history` and `conversations.replies` endpoints don't include the channel ID on each message in the response — it's implicit from the request parameter
- This caused all messages to be stored with an empty `channel_id` (`"-"`) in the database, making it impossible to filter or query messages by channel
- Sets `msg.Channel` from the request context before converting to a store message, matching the pattern already used in `messageFromEvent()`

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Run `slacrawl sync --source api` and verify `channel_id` is populated on stored messages
- [x] Verify `slacrawl sql 'SELECT DISTINCT channel_id FROM messages'` returns actual channel IDs instead of `-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)