### PR TITLE
feat(cli): digest command for windowed per-channel summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Choose the path that matches your setup:
 - `users` lists synced users
 - `channels` lists synced channels
 - `status` prints workspace and sync status
+- `digest` prints a per-channel activity summary for a time window
 - `completion` prints shell completion for `bash` or `zsh`
 
 ## Output Modes
@@ -308,6 +309,7 @@ go run ./cmd/slacrawl init
 go run ./cmd/slacrawl sync --source api
 go run ./cmd/slacrawl status
 go run ./cmd/slacrawl report
+go run ./cmd/slacrawl digest --since 7d
 go run ./cmd/slacrawl channels
 go run ./cmd/slacrawl messages --channel C12345678 --limit 20
 go run ./cmd/slacrawl mentions --limit 20

--- a/SPEC.md
+++ b/SPEC.md
@@ -132,6 +132,7 @@ Commands:
 - `channels`
 - `status`
 - `report`
+- `digest`
 
 ### `sync`
 
@@ -183,6 +184,26 @@ Must include:
 - bounded windows for recent message activity
 - top channels, authors, and busiest days
 - git-share freshness state when share mode is enabled
+
+### `digest`
+
+Purpose:
+
+- windowed per-channel activity summary derived from the local store
+
+Expected flags:
+
+- `--since <duration>` lookback window, accepts Go durations (`72h`) or day shorthand (`7d`, `30d`). Default: `7d`.
+- `--workspace <id>`
+- `--channel <id-or-name>`
+- `--top-n <int>` top posters and top mention targets per channel. Default: `1`.
+
+Must include:
+
+- per-channel message count, thread count (parent messages with replies), and active-author count
+- top posters per channel (respects `--top-n`)
+- top mention targets per channel (respects `--top-n`)
+- window totals: messages, threads, channels, active authors
 
 ### `tail`
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -86,6 +87,8 @@ func (a *App) Run(ctx context.Context, args []string) error {
 		return a.runDoctor(ctx, *configPath, outputFormat)
 	case "report":
 		return a.runReport(ctx, *configPath, outputFormat)
+	case "digest":
+		return a.runDigest(ctx, *configPath, rest[1:], outputFormat)
 	case "publish":
 		return a.runPublish(ctx, *configPath, rest[1:], outputFormat)
 	case "subscribe":
@@ -591,6 +594,67 @@ func (a *App) runWatch(ctx context.Context, configPath string, args []string, fo
 			}
 		}
 	}
+}
+
+func (a *App) runDigest(ctx context.Context, configPath string, args []string, format OutputFormat) error {
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
+	fs := flag.NewFlagSet("digest", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	since := fs.String("since", "7d", "lookback window, e.g. 24h, 7d, 30d")
+	workspaceID := fs.String("workspace", "", "workspace id")
+	channel := fs.String("channel", "", "channel id or name")
+	topN := fs.Int("top-n", 1, "number of top posters and mentions per channel")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	lookback, err := parseLookback(*since)
+	if err != nil {
+		return fmt.Errorf("parse --since: %w", err)
+	}
+	st, err := a.openReadableStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+	digest, err := report.BuildDigest(ctx, st, report.DigestOptions{
+		Since:       lookback,
+		WorkspaceID: coalesce(*workspaceID, cfg.WorkspaceID),
+		Channel:     *channel,
+		TopN:        *topN,
+	})
+	if err != nil {
+		return err
+	}
+	return a.writeOutput("Digest", digest, format, true)
+}
+
+// parseLookback accepts Go durations (72h) plus the shorthand Nd for N days.
+func parseLookback(value string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, errors.New("empty duration")
+	}
+	if strings.HasSuffix(value, "d") {
+		days, err := strconv.Atoi(strings.TrimSuffix(value, "d"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid day count: %w", err)
+		}
+		if days < 0 {
+			return 0, errors.New("negative duration")
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, err
+	}
+	if d < 0 {
+		return 0, errors.New("negative duration")
+	}
+	return d, nil
 }
 
 func (a *App) runReport(ctx context.Context, configPath string, format OutputFormat) error {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,83 @@ import (
 	"github.com/vincentkoc/slacrawl/internal/config"
 	"github.com/vincentkoc/slacrawl/internal/store"
 )
+
+func TestParseLookback(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+		err  bool
+	}{
+		{"7d", 7 * 24 * time.Hour, false},
+		{"1d", 24 * time.Hour, false},
+		{"0d", 0, false},
+		{"72h", 72 * time.Hour, false},
+		{"30m", 30 * time.Minute, false},
+		{"90s", 90 * time.Second, false},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"-2d", 0, true},
+		{"-1h", 0, true},
+	}
+	for _, c := range cases {
+		d, err := parseLookback(c.in)
+		if c.err {
+			require.Error(t, err, "input=%q", c.in)
+			continue
+		}
+		require.NoError(t, err, "input=%q", c.in)
+		require.Equal(t, c.want, d, "input=%q", c.in)
+	}
+}
+
+func TestDigestCommandJSON(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	dbPath := filepath.Join(tmp, "slacrawl.db")
+
+	var stdout bytes.Buffer
+	app := &App{Stdout: &stdout, Stderr: &stdout}
+	ctx := context.Background()
+	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}))
+
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	defer st.Close()
+	now := time.Now().UTC()
+	makeTS := func(offset time.Duration, micros int) string {
+		return fmt.Sprintf("%d.%06d", now.Add(-offset).Unix(), micros)
+	}
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T1", Name: "team", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C1", WorkspaceID: "T1", Name: "engineering", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertUser(ctx, store.User{ID: "U1", WorkspaceID: "T1", Name: "alice", DisplayName: "Alice", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: makeTS(1*time.Hour, 100), WorkspaceID: "T1", UserID: "U1",
+		Text: "hello", NormalizedText: "hello", SourceRank: 2, SourceName: "api-bot", RawJSON: "{}",
+		UpdatedAt: now,
+	}, nil))
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: makeTS(2*time.Hour, 200), WorkspaceID: "T1", UserID: "U1",
+		Text: "world", NormalizedText: "world", SourceRank: 2, SourceName: "api-bot", RawJSON: "{}",
+		UpdatedAt: now,
+	}, nil))
+
+	stdout.Reset()
+	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "--json", "digest", "--since", "7d"}))
+	var digest map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &digest))
+	require.Equal(t, "7d", digest["window_label"])
+	require.Equal(t, float64(1), digest["top_n"])
+	totals, ok := digest["totals"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(2), totals["messages"])
+	require.Equal(t, float64(1), totals["channels"])
+	channels, ok := digest["channels"].([]any)
+	require.True(t, ok)
+	require.Len(t, channels, 1)
+	row := channels[0].(map[string]any)
+	require.Equal(t, "engineering", row["channel_name"])
+	require.Equal(t, float64(2), row["messages"])
+}
 
 func TestInitStatusAndSQL(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -76,6 +76,7 @@ func (a *App) printHelp() {
 	b.WriteString("  init       Create a starter config.\n")
 	b.WriteString("  doctor     Check config, DB, tokens, and desktop coverage.\n")
 	b.WriteString("  report     Show archive activity and share freshness.\n")
+	b.WriteString("  digest     Per-channel activity summary for a window.\n")
 	b.WriteString("  publish    Export a git-backed archive snapshot.\n")
 	b.WriteString("  subscribe  Configure a git-backed archive reader.\n")
 	b.WriteString("  update     Pull and import the latest git snapshot.\n")
@@ -95,6 +96,7 @@ func (a *App) printHelp() {
 	b.WriteString("  slacrawl init\n")
 	b.WriteString("  slacrawl doctor\n")
 	b.WriteString("  slacrawl report\n")
+	b.WriteString("  slacrawl digest --since 7d\n")
 	b.WriteString("  slacrawl subscribe --db ~/.slacrawl/slacrawl.db https://example.com/private/slacrawl-archive.git\n")
 	b.WriteString("  slacrawl sync --source api --latest-only\n")
 	b.WriteString("  slacrawl search incident\n")
@@ -153,6 +155,8 @@ func renderSpecialBlock(w *strings.Builder, title string, value any) bool {
 		return renderStatusBlock(w, value)
 	case "Report":
 		return renderReportBlock(w, value)
+	case "Digest":
+		return renderDigestBlock(w, value)
 	case "Sync", "Watch":
 		return renderSyncBlock(w, title, value)
 	case "Search":
@@ -809,6 +813,108 @@ func renderReportBlock(w *strings.Builder, value any) bool {
 		renderShareBlock(w, shareState, false)
 	}
 	return true
+}
+
+func renderDigestBlock(w *strings.Builder, value any) bool {
+	digest, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	writeTitle(w, "DIGEST")
+
+	w.WriteString(colorize(ansiGreen, "● Window"))
+	w.WriteByte('\n')
+	label := shortValue(digest["window_label"])
+	since := shortValue(digest["since"])
+	until := shortValue(digest["until"])
+	w.WriteString("  window       ")
+	w.WriteString(label)
+	w.WriteByte('\n')
+	w.WriteString("  range        ")
+	w.WriteString(since)
+	w.WriteString(colorize(ansiDim, " → "))
+	w.WriteString(until)
+	w.WriteByte('\n')
+	if ws := shortValue(digest["workspace"]); ws != "-" {
+		w.WriteString("  workspace    ")
+		w.WriteString(ws)
+		w.WriteByte('\n')
+	}
+	if ch := shortValue(digest["channel"]); ch != "-" {
+		w.WriteString("  channel      ")
+		w.WriteString(ch)
+		w.WriteByte('\n')
+	}
+
+	if totals, ok := digest["totals"].(map[string]any); ok {
+		w.WriteByte('\n')
+		w.WriteString(colorize(ansiCyan, "Totals"))
+		w.WriteByte('\n')
+		writeMetricRow(w, []metric{
+			{"messages", shortValue(totals["messages"]), ansiGreen},
+			{"threads", shortValue(totals["threads"]), ansiGreen},
+			{"channels", shortValue(totals["channels"]), ansiGreen},
+			{"authors", shortValue(totals["active_authors"]), ansiGreen},
+		})
+	}
+
+	channels, _ := digest["channels"].([]any)
+	w.WriteByte('\n')
+	w.WriteString(colorize(ansiCyan, "Channels"))
+	w.WriteByte('\n')
+	if len(channels) == 0 {
+		w.WriteString(colorize(ansiDim, "  no activity in window"))
+		w.WriteByte('\n')
+		return true
+	}
+	for _, item := range channels {
+		row, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := shortValue(row["channel_name"])
+		if name == "-" {
+			name = shortValue(row["channel_id"])
+		}
+		w.WriteString("  • ")
+		w.WriteString(colorize(ansiBold, name))
+		if kind := shortValue(row["kind"]); kind != "-" && kind != "" {
+			w.WriteString(colorize(ansiDim, " ("+kind+")"))
+		}
+		w.WriteByte('\n')
+		w.WriteString("      messages=")
+		w.WriteString(shortValue(row["messages"]))
+		w.WriteString(" threads=")
+		w.WriteString(shortValue(row["threads"]))
+		w.WriteString(" authors=")
+		w.WriteString(shortValue(row["active_authors"]))
+		w.WriteByte('\n')
+		if posters, ok := row["top_posters"].([]any); ok && len(posters) > 0 {
+			w.WriteString("      top posters  ")
+			w.WriteString(joinRankedCounts(posters))
+			w.WriteByte('\n')
+		}
+		if mentions, ok := row["top_mentions"].([]any); ok && len(mentions) > 0 {
+			w.WriteString("      top mentions ")
+			w.WriteString(joinRankedCounts(mentions))
+			w.WriteByte('\n')
+		}
+	}
+	return true
+}
+
+func joinRankedCounts(items []any) string {
+	var parts []string
+	for _, item := range items {
+		row, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := shortValue(row["name"])
+		count := shortValue(row["count"])
+		parts = append(parts, fmt.Sprintf("%s (%s)", name, count))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func renderMessageListBlock(w *strings.Builder, title string, value any, includeNormalized bool) bool {

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -1,0 +1,259 @@
+package report
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vincentkoc/slacrawl/internal/store"
+)
+
+// DigestOptions controls how a Digest is built.
+//
+// Since is the lookback duration from Now. Zero means the caller did not
+// specify a window and the default (7 days) is used. A negative Since is
+// treated as its absolute value.
+type DigestOptions struct {
+	Now         time.Time
+	Since       time.Duration
+	WorkspaceID string
+	Channel     string
+	TopN        int
+}
+
+// Digest summarizes recent activity for each channel inside a window.
+type Digest struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	Since       time.Time       `json:"since"`
+	Until       time.Time       `json:"until"`
+	WindowLabel string          `json:"window_label"`
+	Workspace   string          `json:"workspace,omitempty"`
+	Channel     string          `json:"channel,omitempty"`
+	TopN        int             `json:"top_n"`
+	Channels    []ChannelDigest `json:"channels"`
+	Totals      DigestTotals    `json:"totals"`
+}
+
+// ChannelDigest is the per-channel roll-up inside a Digest.
+type ChannelDigest struct {
+	ChannelID     string        `json:"channel_id"`
+	ChannelName   string        `json:"channel_name"`
+	Kind          string        `json:"kind,omitempty"`
+	WorkspaceID   string        `json:"workspace_id"`
+	Messages      int           `json:"messages"`
+	Threads       int           `json:"threads"`
+	ActiveAuthors int           `json:"active_authors"`
+	TopPosters    []RankedCount `json:"top_posters"`
+	TopMentions   []RankedCount `json:"top_mentions"`
+}
+
+// DigestTotals sums message and channel counts across the digest window.
+type DigestTotals struct {
+	Messages      int `json:"messages"`
+	Threads       int `json:"threads"`
+	Channels      int `json:"channels"`
+	ActiveAuthors int `json:"active_authors"`
+}
+
+// BuildDigest computes a per-channel activity digest from the local store.
+func BuildDigest(ctx context.Context, s *store.Store, opts DigestOptions) (Digest, error) {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	since := opts.Since
+	if since < 0 {
+		since = -since
+	}
+	if since == 0 {
+		since = 7 * 24 * time.Hour
+	}
+	topN := opts.TopN
+	if topN <= 0 {
+		topN = 1
+	}
+
+	digest := Digest{
+		GeneratedAt: now,
+		Since:       now.Add(-since),
+		Until:       now,
+		WindowLabel: humanDuration(since),
+		Workspace:   opts.WorkspaceID,
+		Channel:     opts.Channel,
+		TopN:        topN,
+	}
+
+	channels, err := perChannel(ctx, s.DB(), digest.Since, opts.WorkspaceID, opts.Channel)
+	if err != nil {
+		return Digest{}, err
+	}
+	for i := range channels {
+		channels[i].TopPosters, err = topPostersForChannel(ctx, s.DB(), digest.Since, channels[i].WorkspaceID, channels[i].ChannelID, topN)
+		if err != nil {
+			return Digest{}, err
+		}
+		channels[i].TopMentions, err = topMentionsForChannel(ctx, s.DB(), digest.Since, channels[i].WorkspaceID, channels[i].ChannelID, topN)
+		if err != nil {
+			return Digest{}, err
+		}
+	}
+	digest.Channels = channels
+
+	totals, err := digestTotals(ctx, s.DB(), digest.Since, opts.WorkspaceID, opts.Channel)
+	if err != nil {
+		return Digest{}, err
+	}
+	digest.Totals = totals
+
+	return digest, nil
+}
+
+// perChannel returns one row per channel with messages, threads, and active-author counts for the window.
+func perChannel(ctx context.Context, db *sql.DB, since time.Time, workspaceID, channel string) ([]ChannelDigest, error) {
+	query := &strings.Builder{}
+	query.WriteString(`
+select
+	m.workspace_id,
+	m.channel_id,
+	coalesce(nullif(c.name, ''), m.channel_id) as channel_name,
+	coalesce(c.kind, '') as kind,
+	count(*) as messages,
+	count(distinct case when m.thread_ts != '' and m.thread_ts = m.ts then m.ts else null end) as threads,
+	count(distinct nullif(m.user_id, '')) as active_authors
+from messages m
+left join channels c on c.id = m.channel_id and c.workspace_id = m.workspace_id
+where m.ts not like 'draft:%'
+  and instr(m.ts, '.') > 0
+  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) >= ?
+`)
+	args := []any{since.Unix()}
+	if workspaceID != "" {
+		query.WriteString("  and m.workspace_id = ?\n")
+		args = append(args, workspaceID)
+	}
+	if channel != "" {
+		query.WriteString("  and (m.channel_id = ? or c.name = ?)\n")
+		args = append(args, channel, channel)
+	}
+	query.WriteString(`group by m.workspace_id, m.channel_id
+order by messages desc, channel_name asc
+`)
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("digest per-channel query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []ChannelDigest
+	for rows.Next() {
+		var row ChannelDigest
+		if err := rows.Scan(&row.WorkspaceID, &row.ChannelID, &row.ChannelName, &row.Kind, &row.Messages, &row.Threads, &row.ActiveAuthors); err != nil {
+			return nil, fmt.Errorf("digest per-channel scan: %w", err)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// topPostersForChannel returns the top posters for a single channel.
+func topPostersForChannel(ctx context.Context, db *sql.DB, since time.Time, workspaceID, channelID string, limit int) ([]RankedCount, error) {
+	return ranked(ctx, db, `
+select
+	coalesce(
+		nullif(u.display_name, ''),
+		nullif(u.real_name, ''),
+		nullif(u.name, ''),
+		nullif(m.user_id, ''),
+		'unknown'
+	) as name,
+	count(*) as total
+from messages m
+left join users u on u.id = m.user_id and u.workspace_id = m.workspace_id
+where m.ts not like 'draft:%'
+  and instr(m.ts, '.') > 0
+  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) >= ?
+  and m.workspace_id = ?
+  and m.channel_id = ?
+group by m.workspace_id, m.user_id
+order by total desc, name asc
+limit ?
+`, since.Unix(), workspaceID, channelID, limit)
+}
+
+// topMentionsForChannel returns the top mention targets for a single channel.
+func topMentionsForChannel(ctx context.Context, db *sql.DB, since time.Time, workspaceID, channelID string, limit int) ([]RankedCount, error) {
+	return ranked(ctx, db, `
+select
+	coalesce(
+		nullif(mm.display_text, ''),
+		nullif(u.display_name, ''),
+		nullif(u.real_name, ''),
+		nullif(u.name, ''),
+		nullif(c.name, ''),
+		mm.target_id
+	) as name,
+	count(*) as total
+from message_mentions mm
+join messages m on m.channel_id = mm.channel_id and m.ts = mm.ts
+left join users u on u.id = mm.target_id and u.workspace_id = m.workspace_id
+left join channels c on c.id = mm.target_id and c.workspace_id = m.workspace_id
+where m.ts not like 'draft:%'
+  and instr(m.ts, '.') > 0
+  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) >= ?
+  and m.workspace_id = ?
+  and m.channel_id = ?
+group by mm.target_id
+order by total desc, name asc
+limit ?
+`, since.Unix(), workspaceID, channelID, limit)
+}
+
+// digestTotals sums messages/threads/channels/authors across the whole window.
+func digestTotals(ctx context.Context, db *sql.DB, since time.Time, workspaceID, channel string) (DigestTotals, error) {
+	query := &strings.Builder{}
+	query.WriteString(`
+select
+	count(*) as messages,
+	count(distinct case when m.thread_ts != '' and m.thread_ts = m.ts then m.ts else null end) as threads,
+	count(distinct m.workspace_id || '|' || m.channel_id) as channels,
+	count(distinct nullif(m.user_id, '')) as active_authors
+from messages m
+left join channels c on c.id = m.channel_id and c.workspace_id = m.workspace_id
+where m.ts not like 'draft:%'
+  and instr(m.ts, '.') > 0
+  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) >= ?
+`)
+	args := []any{since.Unix()}
+	if workspaceID != "" {
+		query.WriteString("  and m.workspace_id = ?\n")
+		args = append(args, workspaceID)
+	}
+	if channel != "" {
+		query.WriteString("  and (m.channel_id = ? or c.name = ?)\n")
+		args = append(args, channel, channel)
+	}
+
+	var totals DigestTotals
+	if err := db.QueryRowContext(ctx, query.String(), args...).Scan(&totals.Messages, &totals.Threads, &totals.Channels, &totals.ActiveAuthors); err != nil {
+		return DigestTotals{}, fmt.Errorf("digest totals: %w", err)
+	}
+	return totals, nil
+}
+
+// humanDuration renders a window duration as a compact human string (e.g. "7d", "36h").
+func humanDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0"
+	}
+	if d%(24*time.Hour) == 0 {
+		days := int(d / (24 * time.Hour))
+		return fmt.Sprintf("%dd", days)
+	}
+	if d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	return d.String()
+}

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -1,0 +1,181 @@
+package report
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vincentkoc/slacrawl/internal/store"
+)
+
+func TestBuildDigest(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "digest.db")
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	defer st.Close()
+
+	ctx := context.Background()
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	earlier := now.Add(-48 * time.Hour)
+	stale := now.Add(-20 * 24 * time.Hour)
+
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T1", Name: "team", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C1", WorkspaceID: "T1", Name: "engineering", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C2", WorkspaceID: "T1", Name: "ops", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C3", WorkspaceID: "T1", Name: "old-stuff", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+
+	require.NoError(t, st.UpsertUser(ctx, store.User{ID: "U1", WorkspaceID: "T1", Name: "alice", DisplayName: "Alice", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertUser(ctx, store.User{ID: "U2", WorkspaceID: "T1", Name: "bob", RealName: "Bob", RawJSON: "{}", UpdatedAt: now}))
+
+	// C1: 3 messages from Alice within the 7d window, one thread parent
+	addMsg(t, ctx, st, "C1", tsEpoch(earlier, 100), "T1", "U1", "", "hello team")
+	addMsg(t, ctx, st, "C1", tsEpoch(earlier, 200), "T1", "U1", tsEpoch(earlier, 200), "thread parent")
+	addMsg(t, ctx, st, "C1", tsEpoch(earlier.Add(time.Hour), 300), "T1", "U2", tsEpoch(earlier, 200), "replying")
+
+	// Mention of U2 inside C1 during window
+	addMsgWithMentions(t, ctx, st, "C1", tsEpoch(earlier.Add(2*time.Hour), 400), "T1", "U1", "", "yo <@U2>", []store.Mention{
+		{Type: "user", TargetID: "U2", DisplayText: "Bob"},
+	})
+
+	// C2: 1 message from Bob in window
+	addMsg(t, ctx, st, "C2", tsEpoch(earlier.Add(3*time.Hour), 500), "T1", "U2", "", "ops only")
+
+	// C3: old message (outside 7d window) - should not appear in digest
+	addMsg(t, ctx, st, "C3", tsEpoch(stale, 600), "T1", "U1", "", "old news")
+
+	// Draft message - should be ignored
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID:      "C2",
+		TS:             "draft:" + tsEpoch(earlier, 999) + ":C2",
+		WorkspaceID:    "T1",
+		UserID:         "U2",
+		Text:           "not-yet-sent",
+		NormalizedText: "not-yet-sent",
+		SourceRank:     2,
+		SourceName:     "desktop",
+		RawJSON:        "{}",
+		UpdatedAt:      now,
+	}, nil))
+
+	t.Run("default window lists recent channels only", func(t *testing.T) {
+		d, err := BuildDigest(ctx, st, DigestOptions{Now: now})
+		require.NoError(t, err)
+		require.Equal(t, "7d", d.WindowLabel)
+		require.Equal(t, 1, d.TopN)
+		// C3 has only a message 20d ago; it must not appear in the 7d digest
+		require.Len(t, d.Channels, 2)
+		require.Equal(t, "C1", d.Channels[0].ChannelID)
+		require.Equal(t, "engineering", d.Channels[0].ChannelName)
+		require.Equal(t, 4, d.Channels[0].Messages)
+		require.Equal(t, 1, d.Channels[0].Threads)
+		require.Equal(t, 2, d.Channels[0].ActiveAuthors)
+		require.Equal(t, "C2", d.Channels[1].ChannelID)
+		require.Equal(t, 1, d.Channels[1].Messages)
+		require.Equal(t, 0, d.Channels[1].Threads)
+		// Top poster of C1 is Alice with 3 messages
+		require.Len(t, d.Channels[0].TopPosters, 1)
+		require.Equal(t, "Alice", d.Channels[0].TopPosters[0].Name)
+		require.Equal(t, 3, d.Channels[0].TopPosters[0].Count)
+		// Top mention of C1 is Bob (single mention)
+		require.Len(t, d.Channels[0].TopMentions, 1)
+		require.Equal(t, "Bob", d.Channels[0].TopMentions[0].Name)
+		// Totals
+		require.Equal(t, 5, d.Totals.Messages)
+		require.Equal(t, 1, d.Totals.Threads)
+		require.Equal(t, 2, d.Totals.Channels)
+	})
+
+	t.Run("channel filter drills into one channel", func(t *testing.T) {
+		d, err := BuildDigest(ctx, st, DigestOptions{Now: now, Channel: "engineering", TopN: 5})
+		require.NoError(t, err)
+		require.Len(t, d.Channels, 1)
+		require.Equal(t, "C1", d.Channels[0].ChannelID)
+		// With TopN=5 we still see only the two actual posters
+		require.Len(t, d.Channels[0].TopPosters, 2)
+	})
+
+	t.Run("extended window picks up old channel", func(t *testing.T) {
+		d, err := BuildDigest(ctx, st, DigestOptions{Now: now, Since: 30 * 24 * time.Hour})
+		require.NoError(t, err)
+		require.Equal(t, "30d", d.WindowLabel)
+		require.Len(t, d.Channels, 3)
+	})
+
+	t.Run("workspace filter respects scope", func(t *testing.T) {
+		d, err := BuildDigest(ctx, st, DigestOptions{Now: now, WorkspaceID: "T-other"})
+		require.NoError(t, err)
+		require.Empty(t, d.Channels)
+		require.Equal(t, 0, d.Totals.Messages)
+	})
+
+	t.Run("hour-granular window renders label", func(t *testing.T) {
+		d, err := BuildDigest(ctx, st, DigestOptions{Now: now, Since: 72 * time.Hour})
+		require.NoError(t, err)
+		require.Equal(t, "3d", d.WindowLabel)
+	})
+
+	t.Run("negative since is normalized", func(t *testing.T) {
+		d, err := BuildDigest(ctx, st, DigestOptions{Now: now, Since: -48 * time.Hour})
+		require.NoError(t, err)
+		require.Equal(t, "2d", d.WindowLabel)
+	})
+}
+
+func TestHumanDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "0"},
+		{24 * time.Hour, "1d"},
+		{7 * 24 * time.Hour, "7d"},
+		{36 * time.Hour, "36h"},
+		{90 * time.Minute, "1h30m0s"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, humanDuration(c.in), "duration=%s", c.in)
+	}
+}
+
+// tsEpoch renders a Slack-style message TS in the form "SECONDS.MICROSECONDS".
+func tsEpoch(at time.Time, micros int) string {
+	return fmt.Sprintf("%d.%06d", at.UTC().Unix(), micros)
+}
+
+func addMsg(t *testing.T, ctx context.Context, st *store.Store, channelID, ts, workspaceID, userID, threadTS, text string) {
+	t.Helper()
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID:      channelID,
+		TS:             ts,
+		WorkspaceID:    workspaceID,
+		UserID:         userID,
+		ThreadTS:       threadTS,
+		Text:           text,
+		NormalizedText: text,
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      time.Unix(0, 0).UTC(),
+	}, nil))
+}
+
+func addMsgWithMentions(t *testing.T, ctx context.Context, st *store.Store, channelID, ts, workspaceID, userID, threadTS, text string, mentions []store.Mention) {
+	t.Helper()
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID:      channelID,
+		TS:             ts,
+		WorkspaceID:    workspaceID,
+		UserID:         userID,
+		ThreadTS:       threadTS,
+		Text:           text,
+		NormalizedText: text,
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      time.Unix(0, 0).UTC(),
+	}, mentions))
+}


### PR DESCRIPTION
Fixes #10.

## Summary

Adds `slacrawl digest`, a companion to `report` that gives you a per-channel activity summary over a time window instead of an archive-wide roll-up. "What happened in my workspace this week" is my most common question against a Slack archive and it's a single SQL recipe away with the existing schema.

```
./slacrawl digest --since 7d
```

![digest demo](https://files.catbox.moe/ffz7dt.gif)

## Output

- messages, threads (parent messages with replies), active authors per channel
- top posters per channel (respects `--top-n`)
- top mention targets per channel (via `message_mentions`)
- window totals across all channels

```
Channels
  • engineering (public_channel)
      messages=11 threads=1 authors=4
      top posters  Alice Chen (4)
      top mentions Alice Chen (2)
  • incidents (public_channel)
      messages=5 threads=0 authors=3
      top posters  Alice Chen (2)
      top mentions oncall-bot (2)
```

## Flags

- `--since` lookback window. Accepts Go durations (`72h`) plus a `Nd` day shorthand (`7d`, `30d`). Default `7d`.
- `--workspace` filter to one workspace
- `--channel` drill into one channel by id or name
- `--top-n` number of top posters / mentions per channel. Default `1`.
- `--format text|json|log` and `--no-color` inherit from the root CLI.

## Scope

- No schema changes. Runs against the existing `messages` / `channels` / `users` / `message_mentions` tables.
- No new dependencies.
- ~230 lines of query logic in `internal/report/digest.go`, ~65 lines of CLI wiring in `internal/cli/app.go`, ~100 lines of render helpers. Tests cover happy path, window filter, channel filter, workspace filter, negative-duration normalization, and the new `--since` parser.

## Test plan

- `go test ./...` passes (all packages cached green in CI-equivalent local runs)
- `go vet ./...` clean
- Dogfooded against a seeded fixture (`T01ABCD`) with four channels, five users, threaded messages, and mentions. Output in the GIF above and in the checkbox list below.

## Notes

CONTRIBUTING asks for an issue first on new commands. Happy to split this into an issue plus a draft PR if you'd rather. I bundled them because the change is small and self-contained, but I'll follow whichever flow you prefer.

Naming-wise, `digest` matched the natural framing vs `summary` or folding it into `report --digest`. Let me know if you want a different name and I'll rename.

## Acceptance

- [x] `slacrawl digest` prints a per-channel table over the last 7 days
- [x] `--since`, `--workspace`, `--channel`, `--top-n`, `--format` all work
- [x] JSON output is a stable schema
- [x] `--channel <id-or-name>` gives a drill-down view
- [x] `go test ./...` passes
- [x] README and SPEC updated
- [x] No new dependency in go.mod
