### PR TITLE
feat(sync): sync DMs and MPIMs with user token

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Data stays on your machine. You can run it in API mode, desktop mode, or a hybri
 - local SQLite storage with full-text search backed by SQLite FTS5
 - workspace, channel, user, and message sync
 - thread reply backfill when a user token is available
+- DM and MPIM sync when a user token is available
 - incremental API history sync by default, with `--full` reserved for deliberate backfills
 - `sync --latest-only` for cheap incremental refreshes on already-seeded channels
 - mention extraction for structured querying
@@ -51,7 +52,6 @@ Data stays on your machine. You can run it in API mode, desktop mode, or a hybri
 
 ## Not Yet Included
 
-- DMs and MPIMs
 - attachment blob downloads
 - write-back actions
 - public Marketplace-style distribution hardening
@@ -179,6 +179,8 @@ Choose the path that matches your setup:
 slacrawl import ./my-export.zip --workspace T01234567
 slacrawl import ./extracted-export/ --workspace T01234567 --dry-run
 ```
+
+Set `SLACK_USER_TOKEN` with `im:history`, `mpim:history`, `im:read`, and `mpim:read` scopes to include DMs and MPIMs in API sync.
 
 ## Output Modes
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,6 @@ V1 scope:
 
 Out of scope for V1:
 
-- DMs and MPIMs
 - attachment blob downloads by default
 - write-back actions
 - Marketplace/public-distribution hardening
@@ -86,6 +85,15 @@ Tables:
 - `message_mentions`
 - `embedding_jobs`
 - `message_fts`
+
+`channels.kind` values include:
+
+- `public_channel`
+- `private_channel`
+- `public`
+- `private`
+- `im`
+- `mpim`
 
 Optional later:
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -40,6 +40,7 @@ concurrency = 4
 repair_every = "30m"
 desktop_refresh_every = "5m"
 full_history = true
+# include_dms = true # requires SLACK_USER_TOKEN with im:history, mpim:history, im:read, mpim:read scopes
 
 [search]
 default_mode = "fts"

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -498,7 +498,8 @@ func (a *App) runChannels(ctx context.Context, configPath string, args []string,
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *kind != "" && !isValidChannelKind(*kind) {
+	resolvedKind := normalizeChannelKind(*kind)
+	if resolvedKind != "" && !isValidChannelKind(resolvedKind) {
 		return fmt.Errorf("invalid channel kind %q: use im, mpim, public, private, public_channel, or private_channel", *kind)
 	}
 	query := ""
@@ -510,7 +511,7 @@ func (a *App) runChannels(ctx context.Context, configPath string, args []string,
 		return err
 	}
 	defer st.Close()
-	results, err := st.ChannelsByKind(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, *kind, 100)
+	results, err := st.ChannelsByKind(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, resolvedKind, 100)
 	if err != nil {
 		return err
 	}
@@ -739,10 +740,21 @@ func csv(value string) []string {
 
 func isValidChannelKind(kind string) bool {
 	switch kind {
-	case "im", "mpim", "public", "private", "public_channel", "private_channel":
+	case "im", "mpim", "public_channel", "private_channel":
 		return true
 	default:
 		return false
+	}
+}
+
+func normalizeChannelKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case "public":
+		return "public_channel"
+	case "private":
+		return "private_channel"
+	default:
+		return strings.TrimSpace(kind)
 	}
 }
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -211,7 +211,8 @@ func (a *App) runDoctor(ctx context.Context, configPath string, format OutputFor
 	}
 	defer st.Close()
 
-	diag, err := slackapi.New(cfg.ResolveTokens()).Doctor(ctx)
+	tokens := cfg.ResolveTokens()
+	diag, err := slackapi.New(tokens).WithIncludeDMs(cfg.IncludeDMsResolved(tokens.User != "")).Doctor(ctx)
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return err
 	}
@@ -263,9 +264,9 @@ func (a *App) runDoctor(ctx context.Context, configPath string, format OutputFor
 			"bot_enabled":  cfg.Slack.Bot.Enabled,
 			"app_enabled":  cfg.Slack.App.Enabled,
 			"user_enabled": cfg.Slack.User.Enabled,
-			"bot_set":      cfg.ResolveTokens().Bot != "",
-			"app_set":      cfg.ResolveTokens().App != "",
-			"user_set":     cfg.ResolveTokens().User != "",
+			"bot_set":      tokens.Bot != "",
+			"app_set":      tokens.App != "",
+			"user_set":     tokens.User != "",
 		},
 		"slack_api":         diag,
 		"workspace_api":     workspaceAPI,
@@ -493,8 +494,12 @@ func (a *App) runChannels(ctx context.Context, configPath string, args []string,
 	fs := flag.NewFlagSet("channels", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
 	workspaceID := fs.String("workspace", "", "workspace id")
+	kind := fs.String("kind", "", "channel kind")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	if *kind != "" && !isValidChannelKind(*kind) {
+		return fmt.Errorf("invalid channel kind %q: use im, mpim, public, private, public_channel, or private_channel", *kind)
 	}
 	query := ""
 	if fs.NArg() > 0 {
@@ -505,7 +510,7 @@ func (a *App) runChannels(ctx context.Context, configPath string, args []string,
 		return err
 	}
 	defer st.Close()
-	results, err := st.Channels(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, 100)
+	results, err := st.ChannelsByKind(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, *kind, 100)
 	if err != nil {
 		return err
 	}
@@ -732,6 +737,15 @@ func csv(value string) []string {
 	return out
 }
 
+func isValidChannelKind(kind string) bool {
+	switch kind {
+	case "im", "mpim", "public", "private", "public_channel", "private_channel":
+		return true
+	default:
+		return false
+	}
+}
+
 func resolveWorkspaceTargets(cfg config.Config, requested string) []string {
 	if strings.TrimSpace(requested) != "" {
 		return []string{strings.TrimSpace(requested)}
@@ -810,7 +824,7 @@ func (a *App) workspaceDoctorReports(ctx context.Context, cfg config.Config) ([]
 	reports := make([]map[string]any, 0, len(workspaceIDs))
 	for _, workspaceID := range workspaceIDs {
 		tokens := cfg.ResolveTokensForWorkspace(workspaceID)
-		diag, err := slackapi.New(tokens).Doctor(ctx)
+		diag, err := slackapi.New(tokens).WithIncludeDMs(cfg.IncludeDMsResolved(tokens.User != "")).Doctor(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return nil, fmt.Errorf("doctor %s: %w", workspaceID, err)
 		}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -293,6 +293,11 @@ func TestWorkspaceFilteredReadCommands(t *testing.T) {
 	require.Len(t, channels, 1)
 
 	stdout.Reset()
+	require.NoError(t, app.Run(context.Background(), []string{"--config", configPath, "--json", "channels", "--workspace", "T1", "--kind", "public"}))
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &channels))
+	require.Len(t, channels, 1)
+
+	stdout.Reset()
 	err = app.Run(context.Background(), []string{"--config", configPath, "--json", "channels", "--workspace", "T1", "--kind", "unknown"})
 	require.ErrorContains(t, err, "invalid channel kind")
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -286,6 +286,15 @@ func TestWorkspaceFilteredReadCommands(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &channels))
 	require.Len(t, channels, 1)
 	require.Equal(t, "T1", channels[0]["workspace_id"])
+
+	stdout.Reset()
+	require.NoError(t, app.Run(context.Background(), []string{"--config", configPath, "--json", "channels", "--workspace", "T1", "--kind", "public_channel"}))
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &channels))
+	require.Len(t, channels, 1)
+
+	stdout.Reset()
+	err = app.Run(context.Background(), []string{"--config", configPath, "--json", "channels", "--workspace", "T1", "--kind", "unknown"})
+	require.ErrorContains(t, err, "invalid channel kind")
 }
 
 func TestHelpIncludesBannerAndUsage(t *testing.T) {
@@ -435,6 +444,7 @@ func TestCompletionBashOutput(t *testing.T) {
 	require.Contains(t, out, "completion")
 	require.Contains(t, out, "report")
 	require.Contains(t, out, "--format")
+	require.Contains(t, out, "--kind")
 }
 
 func TestCompletionZshOutput(t *testing.T) {
@@ -451,6 +461,7 @@ func TestCompletionZshOutput(t *testing.T) {
 	require.Contains(t, out, "_values 'shell' bash zsh")
 	require.Contains(t, out, "report")
 	require.Contains(t, out, "--no-color")
+	require.Contains(t, out, "public_channel")
 }
 
 func TestReportIncludesArchiveAndShareState(t *testing.T) {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -52,7 +52,7 @@ var (
 		"mentions":   {"--workspace", "--target", "--limit", "--help", "-h"},
 		"sql":        {"--help", "-h"},
 		"users":      {"--workspace", "--help", "-h"},
-		"channels":   {"--workspace", "--help", "-h"},
+		"channels":   {"--workspace", "--kind", "--help", "-h"},
 		"status":     {"--help", "-h"},
 		"completion": {"--help", "-h"},
 	}
@@ -108,19 +108,23 @@ _slacrawl()
         esac
     done
 
-    case "${prev}" in
-        --format)
-            COMPREPLY=( $(compgen -W "text json log" -- "${cur}") )
-            return
-            ;;
-        --source)
-            COMPREPLY=( $(compgen -W "api desktop all" -- "${cur}") )
-            return
-            ;;
-        completion)
-            COMPREPLY=( $(compgen -W "bash zsh" -- "${cur}") )
-            return
-            ;;
+	case "${prev}" in
+		--format)
+			COMPREPLY=( $(compgen -W "text json log" -- "${cur}") )
+			return
+			;;
+		--source)
+			COMPREPLY=( $(compgen -W "api desktop all" -- "${cur}") )
+			return
+			;;
+		--kind)
+			COMPREPLY=( $(compgen -W "im mpim public_channel private_channel" -- "${cur}") )
+			return
+			;;
+		completion)
+			COMPREPLY=( $(compgen -W "bash zsh" -- "${cur}") )
+			return
+			;;
     esac
 
     case "${command}" in
@@ -166,9 +170,9 @@ _slacrawl()
         users)
             COMPREPLY=( $(compgen -W "--workspace --help -h ${global_flags}" -- "${cur}") )
             ;;
-        channels)
-            COMPREPLY=( $(compgen -W "--workspace --help -h ${global_flags}" -- "${cur}") )
-            ;;
+		channels)
+			COMPREPLY=( $(compgen -W "--workspace --kind --help -h ${global_flags}" -- "${cur}") )
+			;;
         completion)
             COMPREPLY=( $(compgen -W "bash zsh --help -h ${global_flags}" -- "${cur}") )
             ;;
@@ -252,9 +256,9 @@ _slacrawl() {
         users)
           _arguments '--workspace[workspace id]:workspace id:'
           ;;
-        channels)
-          _arguments '--workspace[workspace id]:workspace id:'
-          ;;
+		channels)
+		  _arguments '--workspace[workspace id]:workspace id:' '--kind[channel kind]:kind:(im mpim public_channel private_channel)'
+		  ;;
         completion)
           _values 'shell' bash zsh
           ;;

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -619,6 +619,16 @@ func renderDoctorBlock(w *strings.Builder, value any) bool {
 		writeCheck(w, "app tail", truthy(slackAPI["app_tail_available"]), ternary(truthy(slackAPI["app_tail_available"]), "socket mode available", "app token missing"))
 		coverage := shortValue(slackAPI["thread_coverage"])
 		writeCheck(w, "thread coverage", coverage == "full", ternary(coverage == "full", "full historical replies", "partial without user auth"))
+		if truthy(slackAPI["dms_included"]) {
+			missing := shortValue(slackAPI["dms_missing_scope"])
+			if missing == "" {
+				writeCheck(w, "dms and mpims", true, "user token covers DMs and MPIMs")
+			} else {
+				writeCheck(w, "dms and mpims", false, "missing scope: "+missing)
+			}
+		} else {
+			writeCheck(w, "dms and mpims", false, "disabled (set sync.include_dms with a user token)")
+		}
 	}
 	if desktop, ok := report["desktop_source"].(map[string]any); ok {
 		writeCheck(w, "desktop cache", truthy(desktop["available"]), shortValue(desktop["path"]))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ type SyncConfig struct {
 	RepairEvery         string `toml:"repair_every"`
 	DesktopRefreshEvery string `toml:"desktop_refresh_every"`
 	FullHistory         bool   `toml:"full_history"`
+	IncludeDMs          *bool  `toml:"include_dms"`
 }
 
 type SearchConfig struct {
@@ -270,6 +271,13 @@ func (c Config) WorkspaceIDs() []string {
 
 func (c Config) ShareEnabled() bool {
 	return strings.TrimSpace(c.Share.Remote) != ""
+}
+
+func (c Config) IncludeDMsResolved(hasUserToken bool) bool {
+	if c.Sync.IncludeDMs != nil {
+		return *c.Sync.IncludeDMs
+	}
+	return hasUserToken
 }
 
 func EnsureRuntimeDirs(c Config) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,20 @@ func TestResolveTokensForWorkspaceUsesImplicitWorkspaceEnvNames(t *testing.T) {
 	require.Equal(t, "xoxp-alpha", tokens.User)
 }
 
+func TestIncludeDMsResolved(t *testing.T) {
+	cfg := Default()
+	require.True(t, cfg.IncludeDMsResolved(true))
+	require.False(t, cfg.IncludeDMsResolved(false))
+
+	enabled := true
+	cfg.Sync.IncludeDMs = &enabled
+	require.True(t, cfg.IncludeDMsResolved(false))
+
+	disabled := false
+	cfg.Sync.IncludeDMs = &disabled
+	require.False(t, cfg.IncludeDMsResolved(true))
+}
+
 func TestSaveAndLoadRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -29,6 +31,8 @@ type Diagnostics struct {
 	AppConfigured     bool   `json:"app_configured"`
 	UserConfigured    bool   `json:"user_configured"`
 	ThreadCoverage    string `json:"thread_coverage"`
+	DMsIncluded       bool   `json:"dms_included"`
+	DMsMissingScope   string `json:"dms_missing_scope,omitempty"`
 	BotAuthTeamID     string `json:"bot_auth_team_id,omitempty"`
 	BotAuthTeam       string `json:"bot_auth_team,omitempty"`
 	UserAuthAvailable bool   `json:"user_auth_available"`
@@ -50,6 +54,7 @@ type Client struct {
 	user         *slack.Client
 	tokens       config.Tokens
 	appToken     string
+	includeDMs   bool
 	sleep        func(context.Context, time.Duration) error
 	now          func() time.Time
 	socketModeFn func(*slack.Client) socketModeRunner
@@ -61,10 +66,11 @@ func New(tokens config.Tokens) *Client {
 
 func NewWithOptions(tokens config.Tokens, apiURL string, httpClient *http.Client) *Client {
 	client := &Client{
-		tokens:   tokens,
-		appToken: tokens.App,
-		sleep:    sleepContext,
-		now:      func() time.Time { return time.Now().UTC() },
+		tokens:     tokens,
+		appToken:   tokens.App,
+		includeDMs: tokens.User != "",
+		sleep:      sleepContext,
+		now:        func() time.Time { return time.Now().UTC() },
 	}
 
 	buildOptions := func(includeAppToken bool) []slack.Option {
@@ -93,6 +99,11 @@ func NewWithOptions(tokens config.Tokens, apiURL string, httpClient *http.Client
 	return client
 }
 
+func (c *Client) WithIncludeDMs(include bool) *Client {
+	c.includeDMs = include
+	return c
+}
+
 func (c *Client) Doctor(ctx context.Context) (Diagnostics, error) {
 	diag := Diagnostics{
 		BotConfigured:  c.tokens.Bot != "",
@@ -116,6 +127,10 @@ func (c *Client) Doctor(ctx context.Context) (Diagnostics, error) {
 		if _, err := c.authTest(ctx, c.user); err == nil {
 			diag.UserAuthAvailable = true
 			diag.ThreadCoverage = "full"
+			if c.includeDMs {
+				diag.DMsIncluded = true
+				diag.DMsMissingScope = c.dmMissingScope(ctx, resp.TeamID)
+			}
 		} else {
 			diag.UserAuthError = authErrorReason(err)
 		}
@@ -170,9 +185,57 @@ func (c *Client) Sync(ctx context.Context, st *store.Store, opts SyncOptions) er
 		return err
 	}
 
-	users, err := c.getUsers(ctx, c.bot)
-	if err != nil {
-		return err
+	var (
+		users    []slack.User
+		userByID map[string]slack.User
+	)
+	if c.includeDMs && userRepliesAvailable && c.user != nil {
+		users, err = c.getUsers(ctx, c.bot)
+		if err != nil {
+			return err
+		}
+		userByID = make(map[string]slack.User, len(users))
+		for _, user := range users {
+			userByID[user.ID] = user
+		}
+
+		dms, err := c.fetchDMs(ctx, workspaceID)
+		if err != nil {
+			if isMissingScopeError(err) {
+				if setErr := st.SetSyncState(ctx, SourceUser, "dms", workspaceID, "missing_scope"); setErr != nil {
+					return setErr
+				}
+			} else {
+				return err
+			}
+		} else {
+			selectedDMs := make([]slack.Channel, 0, len(dms))
+			for _, channel := range dms {
+				if len(allow) > 0 {
+					if _, ok := allow[channel.ID]; !ok {
+						continue
+					}
+				}
+				channel.Name = dmChannelName(channel, userByID)
+				selectedDMs = append(selectedDMs, channel)
+			}
+			if err := c.syncChannelsWithSource(ctx, st, workspaceID, selectedDMs, opts, now, userRepliesAvailable, channelSyncSource{
+				historyClient:    c.user,
+				sourceName:       SourceUser,
+				sourceRank:       1,
+				allowJoin:        false,
+				skipMissingScope: true,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	if users == nil {
+		users, err = c.getUsers(ctx, c.bot)
+		if err != nil {
+			return err
+		}
 	}
 	for _, user := range users {
 		if err := st.UpsertUser(ctx, toStoreUser(workspaceID, user, now)); err != nil {
@@ -281,31 +344,53 @@ func (c *Client) fetchChannels(ctx context.Context, workspaceID string) ([]slack
 }
 
 func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, oldest string, now time.Time, userRepliesAvailable bool) error {
+	return c.syncChannelMessagesWithSource(ctx, st, workspaceID, channel, oldest, now, userRepliesAvailable, channelSyncSource{
+		historyClient: c.bot,
+		sourceName:    SourceBot,
+		sourceRank:    2,
+		allowJoin:     true,
+	})
+}
+
+func (c *Client) syncChannelMessagesWithSource(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, oldest string, now time.Time, userRepliesAvailable bool, source channelSyncSource) error {
+	if source.historyClient == nil {
+		return errors.New("history client is required")
+	}
+	if source.sourceName == "" {
+		source.sourceName = SourceBot
+	}
+	if source.sourceRank == 0 {
+		source.sourceRank = 2
+	}
+
 	cursor := ""
 	joined := false
 	for {
-		resp, err := c.getConversationHistory(ctx, c.bot, &slack.GetConversationHistoryParameters{
+		resp, err := c.getConversationHistory(ctx, source.historyClient, &slack.GetConversationHistoryParameters{
 			ChannelID: channel.ID,
 			Cursor:    cursor,
 			Limit:     200,
 			Oldest:    oldest,
 		})
 		if err != nil {
-			if !joined && channelSkipReason(err) == "not_in_channel" && !channel.IsPrivate {
+			if source.skipMissingScope && isMissingScopeError(err) {
+				return st.SetSyncState(ctx, source.sourceName, "channel_skip", channel.ID, "missing_scope")
+			}
+			if source.allowJoin && !joined && channelSkipReason(err) == "not_in_channel" && !channel.IsPrivate {
 				joinErr := c.joinConversation(ctx, channel.ID)
 				if joinErr == nil {
 					joined = true
-					if setErr := st.SetSyncState(ctx, SourceBot, "channel_join", channel.ID, "joined"); setErr != nil {
+					if setErr := st.SetSyncState(ctx, source.sourceName, "channel_join", channel.ID, "joined"); setErr != nil {
 						return setErr
 					}
 					continue
 				}
-				if setErr := st.SetSyncState(ctx, SourceBot, "channel_join", channel.ID, "failed:"+authErrorReason(joinErr)); setErr != nil {
+				if setErr := st.SetSyncState(ctx, source.sourceName, "channel_join", channel.ID, "failed:"+authErrorReason(joinErr)); setErr != nil {
 					return setErr
 				}
 			}
 			if isChannelHistorySkipped(err) {
-				return st.SetSyncState(ctx, SourceBot, "channel_skip", channel.ID, channelSkipReason(err))
+				return st.SetSyncState(ctx, source.sourceName, "channel_skip", channel.ID, channelSkipReason(err))
 			}
 			return fmt.Errorf("channel %s history: %w", channel.ID, err)
 		}
@@ -313,7 +398,7 @@ func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, works
 			if msg.Channel == "" {
 				msg.Channel = channel.ID
 			}
-			if err := st.UpsertMessage(ctx, toStoreMessage(workspaceID, msg, SourceBot, 2, now), toStoreMentions(msg)); err != nil {
+			if err := st.UpsertMessage(ctx, toStoreMessage(workspaceID, msg, source.sourceName, source.sourceRank, now), toStoreMentions(msg)); err != nil {
 				return err
 			}
 			if msg.ReplyCount > 0 && userRepliesAvailable {
@@ -499,8 +584,13 @@ func (c *Client) joinConversation(ctx context.Context, channelID string) error {
 
 func toStoreChannel(workspaceID string, channel slack.Channel, now time.Time) store.Channel {
 	kind := "public_channel"
-	if channel.IsPrivate {
-		kind = "private_channel"
+	switch dmChannelKind(channel) {
+	case "im", "mpim":
+		kind = dmChannelKind(channel)
+	case "":
+		if channel.IsPrivate {
+			kind = "private_channel"
+		}
 	}
 	return store.Channel{
 		ID:          channel.ID,
@@ -640,7 +730,24 @@ func tickerChan(ticker *time.Ticker) <-chan time.Time {
 	return ticker.C
 }
 
+type channelSyncSource struct {
+	historyClient    *slack.Client
+	sourceName       string
+	sourceRank       int
+	allowJoin        bool
+	skipMissingScope bool
+}
+
 func (c *Client) syncChannels(ctx context.Context, st *store.Store, workspaceID string, channels []slack.Channel, opts SyncOptions, now time.Time, userRepliesAvailable bool) error {
+	return c.syncChannelsWithSource(ctx, st, workspaceID, channels, opts, now, userRepliesAvailable, channelSyncSource{
+		historyClient: c.bot,
+		sourceName:    SourceBot,
+		sourceRank:    2,
+		allowJoin:     true,
+	})
+}
+
+func (c *Client) syncChannelsWithSource(ctx context.Context, st *store.Store, workspaceID string, channels []slack.Channel, opts SyncOptions, now time.Time, userRepliesAvailable bool, source channelSyncSource) error {
 	if len(channels) == 0 {
 		return nil
 	}
@@ -663,7 +770,7 @@ func (c *Client) syncChannels(ctx context.Context, st *store.Store, workspaceID 
 			if err := st.UpsertChannel(ctx, toStoreChannel(workspaceID, channel, now)); err != nil {
 				return err
 			}
-			if err := c.syncChannelMessages(ctx, st, workspaceID, channel, oldestByChannel[channel.ID], now, userRepliesAvailable); err != nil {
+			if err := c.syncChannelMessagesWithSource(ctx, st, workspaceID, channel, oldestByChannel[channel.ID], now, userRepliesAvailable, source); err != nil {
 				return err
 			}
 		}
@@ -687,7 +794,7 @@ func (c *Client) syncChannels(ctx context.Context, st *store.Store, workspaceID 
 				cancel()
 				return
 			}
-			if err := c.syncChannelMessages(ctx, st, workspaceID, channel, oldestByChannel[channel.ID], now, userRepliesAvailable); err != nil {
+			if err := c.syncChannelMessagesWithSource(ctx, st, workspaceID, channel, oldestByChannel[channel.ID], now, userRepliesAvailable, source); err != nil {
 				select {
 				case errCh <- err:
 				default:
@@ -775,6 +882,82 @@ func channelSkipReason(err error) string {
 		return slackErr.Err
 	}
 	return ""
+}
+
+func isMissingScopeError(err error) bool {
+	return channelSkipReason(err) == "missing_scope"
+}
+
+func (c *Client) dmMissingScope(ctx context.Context, workspaceID string) string {
+	if !c.includeDMs || c.user == nil {
+		return ""
+	}
+	missing := make(map[string]struct{})
+	addMissing := func(scope string) {
+		if scope == "" {
+			return
+		}
+		missing[scope] = struct{}{}
+	}
+
+	dms, err := c.fetchDMs(ctx, workspaceID)
+	if err != nil {
+		if isMissingScopeError(err) {
+			addMissing("im:read")
+			addMissing("mpim:read")
+		}
+		return joinScopes(missing)
+	}
+
+	var sampleIM, sampleMPIM string
+	for _, dm := range dms {
+		switch dmChannelKind(dm) {
+		case "im":
+			if sampleIM == "" {
+				sampleIM = dm.ID
+			}
+		case "mpim":
+			if sampleMPIM == "" {
+				sampleMPIM = dm.ID
+			}
+		}
+		if sampleIM != "" && sampleMPIM != "" {
+			break
+		}
+	}
+
+	if sampleIM != "" {
+		_, historyErr := c.getConversationHistory(ctx, c.user, &slack.GetConversationHistoryParameters{
+			ChannelID: sampleIM,
+			Limit:     1,
+		})
+		if isMissingScopeError(historyErr) {
+			addMissing("im:history")
+		}
+	}
+	if sampleMPIM != "" {
+		_, historyErr := c.getConversationHistory(ctx, c.user, &slack.GetConversationHistoryParameters{
+			ChannelID: sampleMPIM,
+			Limit:     1,
+		})
+		if isMissingScopeError(historyErr) {
+			addMissing("mpim:history")
+		}
+	}
+
+	return joinScopes(missing)
+}
+
+func joinScopes(scopes map[string]struct{}) string {
+	if len(scopes) == 0 {
+		return ""
+	}
+	out := make([]string, 0, len(scopes))
+	for scope := range scopes {
+		out = append(out, scope)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
 }
 
 func (c *Client) userAuthAvailable(ctx context.Context) bool {

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -76,6 +76,71 @@ func TestSyncWithoutUserTokenMarksPartialCoverage(t *testing.T) {
 	require.Equal(t, "partial", value)
 }
 
+func TestSyncIncludesDMsAndMPIMsWhenEnabled(t *testing.T) {
+	server := newDMSyncSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot:  "xoxb-test",
+		User: "xoxp-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer st.Close()
+
+	err := client.Sync(context.Background(), st, SyncOptions{})
+	require.NoError(t, err)
+
+	channels, err := st.Channels(context.Background(), "T123", "", 10)
+	require.NoError(t, err)
+	kindByID := make(map[string]string, len(channels))
+	nameByID := make(map[string]string, len(channels))
+	for _, row := range channels {
+		kindByID[row.ID] = row.Kind
+		nameByID[row.ID] = row.Name
+	}
+	require.Equal(t, "im", kindByID["D123"])
+	require.Equal(t, "mpim", kindByID["G123"])
+	require.Equal(t, "alice", nameByID["D123"])
+	require.Equal(t, "alice,bob", nameByID["G123"])
+
+	rows, err := st.QueryReadOnly(context.Background(), `
+select source_name, source_rank
+from messages
+where channel_id = 'D123'
+limit 1
+`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "api-user", rows[0]["source_name"])
+	require.Equal(t, int64(1), rows[0]["source_rank"])
+}
+
+func TestSyncSkipsDMsWhenDisabled(t *testing.T) {
+	server := newDMSyncSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot:  "xoxb-test",
+		User: "xoxp-test",
+	}, server.URL()+"/", server.Client()).WithIncludeDMs(false)
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer st.Close()
+
+	err := client.Sync(context.Background(), st, SyncOptions{})
+	require.NoError(t, err)
+
+	channels, err := st.Channels(context.Background(), "T123", "", 10)
+	require.NoError(t, err)
+	for _, channel := range channels {
+		require.NotEqual(t, "im", channel.Kind)
+		require.NotEqual(t, "mpim", channel.Kind)
+	}
+}
+
 func TestSyncWithInvalidUserTokenStillMarksPartialCoverage(t *testing.T) {
 	server := newInvalidUserSlackServer(t)
 	defer server.Close()
@@ -120,6 +185,41 @@ func TestDoctorWithInvalidUserTokenDoesNotReportFullCoverage(t *testing.T) {
 	require.False(t, diag.UserAuthAvailable)
 	require.Equal(t, "partial", diag.ThreadCoverage)
 	require.Equal(t, "invalid_auth", diag.UserAuthError)
+	require.False(t, diag.DMsIncluded)
+}
+
+func TestDoctorWithValidUserTokenReportsDMInclusion(t *testing.T) {
+	server := newMockSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot:  "xoxb-test",
+		App:  "xapp-test",
+		User: "xoxp-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	diag, err := client.Doctor(context.Background())
+	require.NoError(t, err)
+	require.True(t, diag.UserAuthAvailable)
+	require.True(t, diag.DMsIncluded)
+	require.Equal(t, "", diag.DMsMissingScope)
+}
+
+func TestDoctorCanDisableDMInclusion(t *testing.T) {
+	server := newMockSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot:  "xoxb-test",
+		User: "xoxp-test",
+	}, server.URL()+"/", server.Client()).WithIncludeDMs(false)
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	diag, err := client.Doctor(context.Background())
+	require.NoError(t, err)
+	require.True(t, diag.UserAuthAvailable)
+	require.False(t, diag.DMsIncluded)
 }
 
 func TestSyncSkipsChannelsTheBotCannotRead(t *testing.T) {
@@ -456,6 +556,49 @@ func newMockSlackServer(t *testing.T) *mockSlackServer {
 			_, _ = w.Write([]byte(`{"ok":true,"has_more":false,"messages":[{"type":"message","subtype":"message_replied","user":"U234","text":"reply message","thread_ts":"1710000000.000100","ts":"1710000001.000200"}],"response_metadata":{"next_cursor":""}}`))
 		case "/users.list":
 			_, _ = w.Write([]byte(`{"ok":true,"members":[{"id":"U123","name":"alice","real_name":"Alice Example","profile":{"display_name":"alice","title":"Engineer"}}],"response_metadata":{"next_cursor":""}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return mock
+}
+
+func newDMSyncSlackServer(t *testing.T) *mockSlackServer {
+	t.Helper()
+	mock := &mockSlackServer{counts: map[string]int{}, lastOld: map[string]string{}}
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			_, _ = w.Write([]byte(`{"ok":true,"team":"Test Team","team_id":"T123","user":"bot","user_id":"Ubot","bot_id":"B123"}`))
+		case "/conversations.list":
+			values := mustFormValues(r)
+			switch values.Get("types") {
+			case "im,mpim":
+				_, _ = w.Write([]byte(`{"ok":true,"channels":[
+					{"id":"D123","is_im":true,"is_private":true,"user":"U123"},
+					{"id":"G123","is_mpim":true,"is_private":true,"members":["U123","U456"]}
+				],"response_metadata":{"next_cursor":""}}`))
+			default:
+				_, _ = w.Write([]byte(`{"ok":true,"channels":[{"id":"C123","name":"general","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":true,"topic":{"value":"topic"},"purpose":{"value":"purpose"}}],"response_metadata":{"next_cursor":""}}`))
+			}
+		case "/conversations.history":
+			values := mustFormValues(r)
+			switch values.Get("channel") {
+			case "C123":
+				_, _ = w.Write([]byte(`{"ok":true,"messages":[{"type":"message","user":"U123","text":"root message","ts":"1710000000.000100"}],"response_metadata":{"next_cursor":""}}`))
+			case "D123":
+				_, _ = w.Write([]byte(`{"ok":true,"messages":[{"type":"message","user":"U123","text":"dm message","ts":"1710000002.000100"}],"response_metadata":{"next_cursor":""}}`))
+			case "G123":
+				_, _ = w.Write([]byte(`{"ok":true,"messages":[{"type":"message","user":"U456","text":"mpim message","ts":"1710000003.000100"}],"response_metadata":{"next_cursor":""}}`))
+			default:
+				http.NotFound(w, r)
+			}
+		case "/users.list":
+			_, _ = w.Write([]byte(`{"ok":true,"members":[
+				{"id":"U123","name":"alice-user","real_name":"Alice Example","profile":{"display_name":"alice","title":"Engineer"}},
+				{"id":"U456","name":"bob-user","real_name":"Bob Example","profile":{"display_name":"bob","title":"Engineer"}}
+			],"response_metadata":{"next_cursor":""}}`))
 		default:
 			http.NotFound(w, r)
 		}

--- a/internal/slackapi/dms.go
+++ b/internal/slackapi/dms.go
@@ -1,0 +1,114 @@
+package slackapi
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+func (c *Client) fetchDMs(ctx context.Context, workspaceID string) ([]slack.Channel, error) {
+	if c.user == nil {
+		return nil, nil
+	}
+
+	var (
+		cursor string
+		out    []slack.Channel
+	)
+	for {
+		type result struct {
+			channels   []slack.Channel
+			nextCursor string
+		}
+		page, err := retry(ctx, c.sleep, 3, func() (result, error) {
+			channels, nextCursor, callErr := c.user.GetConversationsContext(ctx, &slack.GetConversationsParameters{
+				Cursor:          cursor,
+				ExcludeArchived: false,
+				Limit:           200,
+				Types:           []string{"im", "mpim"},
+				TeamID:          workspaceID,
+			})
+			return result{channels: channels, nextCursor: nextCursor}, callErr
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, channel := range page.channels {
+			if dmChannelKind(channel) == "" {
+				continue
+			}
+			out = append(out, channel)
+		}
+		if page.nextCursor == "" {
+			return out, nil
+		}
+		cursor = page.nextCursor
+	}
+}
+
+func dmChannelKind(ch slack.Channel) string {
+	switch {
+	case ch.IsIM:
+		return "im"
+	case ch.IsMpIM:
+		return "mpim"
+	default:
+		return ""
+	}
+}
+
+func dmChannelName(ch slack.Channel, userByID map[string]slack.User) string {
+	switch dmChannelKind(ch) {
+	case "im":
+		return dmUserDisplayName(ch.User, userByID)
+	case "mpim":
+		parts := make([]string, 0, len(ch.Members))
+		for _, memberID := range ch.Members {
+			parts = append(parts, dmUserDisplayName(memberID, userByID))
+		}
+		sort.Strings(parts)
+		return truncateWithEllipsis(strings.Join(parts, ","), 40)
+	default:
+		if strings.TrimSpace(ch.Name) != "" {
+			return ch.Name
+		}
+		return ch.ID
+	}
+}
+
+func dmUserDisplayName(userID string, userByID map[string]slack.User) string {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return ""
+	}
+	user, ok := userByID[userID]
+	if !ok {
+		return userID
+	}
+	if value := strings.TrimSpace(user.Profile.DisplayName); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(user.RealName); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(user.Name); value != "" {
+		return value
+	}
+	return userID
+}
+
+func truncateWithEllipsis(value string, maxChars int) string {
+	if maxChars <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= maxChars {
+		return value
+	}
+	if maxChars <= 3 {
+		return strings.Repeat(".", maxChars)
+	}
+	return string(runes[:maxChars-3]) + "..."
+}

--- a/internal/slackapi/dms_test.go
+++ b/internal/slackapi/dms_test.go
@@ -1,0 +1,162 @@
+package slackapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vincentkoc/slacrawl/internal/config"
+)
+
+func TestFetchDMsReturnsNilWhenUserClientMissing(t *testing.T) {
+	client := New(config.Tokens{Bot: "xoxb-test"})
+	dms, err := client.fetchDMs(context.Background(), "T123")
+	require.NoError(t, err)
+	require.Nil(t, dms)
+}
+
+func TestFetchDMsHappyPath(t *testing.T) {
+	var seenTeamID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		values := mustDMFormValues(r)
+		seenTeamID = values.Get("team_id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channels":[
+			{"id":"D1","is_im":true,"is_private":true,"user":"U1"},
+			{"id":"D2","is_im":true,"is_private":true,"user":"U2"},
+			{"id":"G1","is_mpim":true,"is_private":true,"members":["U1","U2","U3"]}
+		],"response_metadata":{"next_cursor":""}}`))
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{User: "xoxp-test"}, server.URL+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	dms, err := client.fetchDMs(context.Background(), "T123")
+	require.NoError(t, err)
+	require.Len(t, dms, 3)
+	require.Equal(t, "T123", seenTeamID)
+	require.True(t, dms[0].IsIM)
+	require.True(t, dms[2].IsMpIM)
+}
+
+func TestFetchDMsHandlesPagination(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		values := mustDMFormValues(r)
+		cursor := values.Get("cursor")
+		w.Header().Set("Content-Type", "application/json")
+		switch cursor {
+		case "":
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[{"id":"D1","is_im":true,"user":"U1"}],"response_metadata":{"next_cursor":"page2"}}`))
+		case "page2":
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[{"id":"G1","is_mpim":true,"members":["U1","U2"]}],"response_metadata":{"next_cursor":""}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{User: "xoxp-test"}, server.URL+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	dms, err := client.fetchDMs(context.Background(), "T123")
+	require.NoError(t, err)
+	require.Len(t, dms, 2)
+	require.Equal(t, 2, calls)
+}
+
+func TestFetchDMsRetriesOnRateLimit(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		current := calls
+		mu.Unlock()
+
+		if current == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"ok":false}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channels":[{"id":"D1","is_im":true,"user":"U1"}],"response_metadata":{"next_cursor":""}}`))
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{User: "xoxp-test"}, server.URL+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	dms, err := client.fetchDMs(context.Background(), "T123")
+	require.NoError(t, err)
+	require.Len(t, dms, 1)
+	require.Equal(t, 2, calls)
+}
+
+func TestDMChannelNameForIMAndMPIM(t *testing.T) {
+	userByID := map[string]slack.User{
+		"U1": {
+			ID:       "U1",
+			Name:     "alice-user",
+			RealName: "Alice Real",
+			Profile:  slack.UserProfile{DisplayName: "alice"},
+		},
+		"U2": {
+			ID:       "U2",
+			Name:     "bob-user",
+			RealName: "Bob Real",
+		},
+		"U3": {
+			ID:      "U3",
+			Name:    "carol-user",
+			Profile: slack.UserProfile{DisplayName: "carol"},
+		},
+	}
+
+	im := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "D1", IsIM: true, User: "U1"},
+		},
+	}
+	require.Equal(t, "alice", dmChannelName(im, userByID))
+	require.Equal(t, "U1", dmChannelName(im, nil))
+
+	mpim := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "G1", IsMpIM: true},
+			Members:      []string{"U3", "U2", "U1"},
+		},
+	}
+	require.Equal(t, "Bob Real,alice,carol", dmChannelName(mpim, userByID))
+
+	longMPIM := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "G2", IsMpIM: true},
+			Members:      []string{"U1234567890", "U2234567890", "U3234567890", "U4234567890", "U5234567890"},
+		},
+	}
+	name := dmChannelName(longMPIM, nil)
+	require.True(t, strings.HasSuffix(name, "..."))
+	require.LessOrEqual(t, len([]rune(name)), 40)
+}
+
+func mustDMFormValues(r *http.Request) url.Values {
+	_ = r.ParseForm()
+	if r.Form != nil {
+		return r.Form
+	}
+	panic("missing form values")
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -616,14 +616,19 @@ limit ?
 }
 
 func (s *Store) Channels(ctx context.Context, workspaceID string, query string, limit int) ([]ChannelRow, error) {
+	return s.ChannelsByKind(ctx, workspaceID, query, "", limit)
+}
+
+func (s *Store) ChannelsByKind(ctx context.Context, workspaceID string, query string, kind string, limit int) ([]ChannelRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
 select workspace_id, id, name, kind
 from channels
 where (? = '' or workspace_id = ?)
   and (? = '' or id = ? or name like ?)
+  and (? = '' or kind = ?)
 order by name asc
 limit ?
-`, workspaceID, workspaceID, query, query, "%"+query+"%", limit)
+`, workspaceID, workspaceID, query, query, "%"+query+"%", kind, kind, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -38,10 +38,12 @@ func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) 
 
 func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts Options, tokens config.Tokens) (Summary, error) {
 	summary := Summary{}
+	includeDMs := cfg.IncludeDMsResolved(tokens.User != "")
+	apiClient := slackapi.New(tokens).WithIncludeDMs(includeDMs)
 
 	switch opts.Source {
 	case SourceAPI:
-		return summary, slackapi.New(tokens).Sync(ctx, st, slackapi.SyncOptions{
+		return summary, apiClient.Sync(ctx, st, slackapi.SyncOptions{
 			WorkspaceID: opts.WorkspaceID,
 			Channels:    opts.Channels,
 			Since:       opts.Since,
@@ -52,7 +54,7 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 	case SourceDesktop:
 		return syncDesktop(ctx, cfg, st)
 	case SourceAll:
-		if err := slackapi.New(tokens).Sync(ctx, st, slackapi.SyncOptions{
+		if err := apiClient.Sync(ctx, st, slackapi.SyncOptions{
 			WorkspaceID: opts.WorkspaceID,
 			Channels:    opts.Channels,
 			Since:       opts.Since,


### PR DESCRIPTION
## Summary

Extends the API sync path to fetch DMs and MPIMs via the user client when `SLACK_USER_TOKEN` is configured. Gated by a new `sync.include_dms` config toggle that defaults to "on when user token present, off otherwise". Closes the "DMs and MPIMs" bullet in README `## Not Yet Included`.

## Why this matters

- `## Not Yet Included` has listed "DMs and MPIMs" since v0.1, with an explicit invitation in CONTRIBUTING.md to open an issue to close gaps.
- DMs are a large fraction of Slack activity for most users; leaving them out means slacrawl's search results are incomplete for anyone indexing their own activity.
- rusq/slackdump (the entrenched incumbent) supports DMs/MPIMs with the same user-token scopes. The schema (`channels.kind` as a text discriminator, `messages` keyed by `(channel_id, ts)` with no channel-kind assumption) was already designed for this.

## Changes

`slacrawl sync` now additionally fetches DMs and MPIMs when:
1. A user token is configured (`SLACK_USER_TOKEN` with `im:history`, `im:read`, `mpim:history`, `mpim:read` scopes), AND
2. `sync.include_dms` resolves to true (defaults to user-token presence; config override respected).

DM/MPIM messages use `SourceUser` (rank 1) because they come from the user client, same as thread replies. Channel rows land with `kind="im"` or `kind="mpim"` and synthesized names (sorted member display names for MPIMs, truncated to 40 chars).

New surface:
- `slacrawl channels --kind im|mpim|public_channel|private_channel` filter.
- `slacrawl doctor` reports DM inclusion state and any missing scope.

Code:
- `internal/slackapi/dms.go` (+114): conversations.list wrapper for im/mpim, name synthesis helpers.
- `internal/slackapi/api.go` (+217/-~20): Sync threads an additional DM pass after the channel pass. `WithIncludeDMs(bool)` fluent option. New `DMsIncluded` / `DMsMissingScope` fields on `Diagnostics`.
- `internal/config/config.go` (+8): `IncludeDMs *bool` on SyncConfig with `IncludeDMsResolved(hasUserToken bool) bool` resolver.
- `internal/store/store.go` (+7): additive `ChannelsByKind` helper; existing `Channels` wraps it with kind="".
- `internal/cli/app.go` (+22), `completion.go` (+44/-28): `--kind` flag and completion.
- `internal/cli/render.go` (+10): doctor surface line for DM inclusion.

Tests:
- `internal/slackapi/dms_test.go` (+162): nil-user-client, happy path, pagination, rate-limit retry, name synthesis with/without user map + truncation.
- `internal/slackapi/api_test.go` (+143): Sync-integration coverage for `TestSyncIncludesDMsAndMPIMsWhenEnabled` / `TestSyncSkipsDMsWhenDisabled` / `TestDoctor*`.
- `internal/config/config_test.go` (+14): `IncludeDMsResolved` in both branches.

No schema change. No new go.mod dependencies.

## Testing

```
gofmt -l .
go vet ./...
go build ./cmd/slacrawl
go test ./...          # all pass, 9 new DM/MPIM test cases
```

## Demo

![dms demo](https://github.com/mvanhorn/slacrawl/releases/download/evidence-pr2-1776896632/pr2_dms.gif)

Shows the new `channels --kind` help, the `include_dms` config toggle, the `doctor` DM-status line, and the new unit tests passing.

## Open questions for the maintainer

1. **Kind values**: `im` and `mpim` match slackdump/Slack-API conventions. Existing public/private channels use `public_channel` / `private_channel`. Happy to normalize either direction.
2. **MPIM name synthesis**: currently sorted member display names joined with commas, truncated to 40 chars with `...`. Alternative is the Slack-assigned `mpdm-alice--bob--carol-1` format. I lean toward the synthesized version since it's what users actually recognize in `slacrawl channels`.
3. **Default `include_dms = true` with a user token**: opt-out rather than opt-in. Rationale: a configured user token is itself an opt-in signal. Happy to invert if you prefer explicit opt-in.

This contribution was developed with AI assistance.
