### PR TITLE
feat(analytics): analytics subcommand group (digest shim, quiet, trends)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ go run ./cmd/slacrawl init
 go run ./cmd/slacrawl doctor
 go run ./cmd/slacrawl sync --source api
 go run ./cmd/slacrawl search --workspace T01234567 "incident"
+go run ./cmd/slacrawl analytics trends --weeks 4
 go run ./cmd/slacrawl tail --repair-every 30m
 go run ./cmd/slacrawl watch --desktop-every 5m
 ```
@@ -171,6 +172,7 @@ Choose the path that matches your setup:
 - `channels` lists synced channels
 - `status` prints workspace and sync status
 - `digest` prints a per-channel activity summary for a time window
+- `analytics` groups analytics subcommands (`digest`, `quiet`, `trends`)
 - `completion` prints shell completion for `bash` or `zsh`
 
 ## Importing a Slack Export
@@ -181,6 +183,14 @@ slacrawl import ./extracted-export/ --workspace T01234567 --dry-run
 ```
 
 Set `SLACK_USER_TOKEN` with `im:history`, `mpim:history`, `im:read`, and `mpim:read` scopes to include DMs and MPIMs in API sync.
+
+## Analytics
+
+- `analytics digest [--since 7d] [--workspace X] [--channel C]`
+- `analytics quiet [--since 30d] [--workspace X]`
+- `analytics trends [--weeks 8] [--workspace X] [--channel C]`
+
+Planned follow-ups: `health`, `response-times`, `threads-stale`, `activity`.
 
 ## Output Modes
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -141,6 +141,7 @@ Commands:
 - `status`
 - `report`
 - `digest`
+- `analytics`
 
 ### `sync`
 
@@ -212,6 +213,18 @@ Must include:
 - top posters per channel (respects `--top-n`)
 - top mention targets per channel (respects `--top-n`)
 - window totals: messages, threads, channels, active authors
+
+### `analytics`
+
+Purpose:
+
+- grouped analytics subcommands derived from local store data
+
+Subcommands in this phase:
+
+- `analytics digest [--since 7d] [--workspace <id>] [--channel <id-or-name>]`
+- `analytics quiet [--since 30d] [--workspace <id>]`
+- `analytics trends [--weeks 8] [--workspace <id>] [--channel <id-or-name>]`
 
 ### `tail`
 

--- a/internal/cli/analytics.go
+++ b/internal/cli/analytics.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/vincentkoc/slacrawl/internal/report"
+)
+
+func (a *App) runAnalytics(ctx context.Context, configPath string, args []string, format OutputFormat) error {
+	if len(args) == 0 {
+		a.printAnalyticsUsage()
+		return nil
+	}
+
+	subcommand := args[0]
+	subArgs := args[1:]
+	switch subcommand {
+	case "digest":
+		return a.runDigest(ctx, configPath, subArgs, format)
+	case "quiet":
+		return a.runAnalyticsQuiet(ctx, configPath, subArgs, format)
+	case "trends":
+		return a.runAnalyticsTrends(ctx, configPath, subArgs, format)
+	default:
+		return fmt.Errorf("unknown analytics subcommand: %s. Known: digest, quiet, trends.", subcommand)
+	}
+}
+
+func (a *App) printAnalyticsUsage() {
+	_, _ = fmt.Fprintln(a.Stdout, "Usage: slacrawl analytics <subcommand> [flags]")
+	_, _ = fmt.Fprintln(a.Stdout, "")
+	_, _ = fmt.Fprintln(a.Stdout, "Subcommands:")
+	_, _ = fmt.Fprintln(a.Stdout, "  digest  Per-channel activity summary for a window.")
+	_, _ = fmt.Fprintln(a.Stdout, "  quiet   Channels with no activity in the lookback window.")
+	_, _ = fmt.Fprintln(a.Stdout, "  trends  Week-over-week message counts per channel.")
+}
+
+func (a *App) runAnalyticsQuiet(ctx context.Context, configPath string, args []string, defaultFormat OutputFormat) error {
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	fs := flag.NewFlagSet("analytics quiet", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	since := fs.String("since", "30d", "lookback window, e.g. 7d, 30d")
+	workspaceID := fs.String("workspace", "", "workspace id")
+	formatFlag := fs.String("format", string(defaultFormat), "output format: text|json|log")
+	jsonOut := fs.Bool("json", false, "json output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	lookback, err := parseLookback(*since)
+	if err != nil {
+		return fmt.Errorf("parse --since: %w", err)
+	}
+	outputFormat, err := resolveOutputFormat(*formatFlag, *jsonOut)
+	if err != nil {
+		return err
+	}
+
+	st, err := a.openReadableStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+
+	quiet, err := report.BuildQuiet(ctx, st, report.QuietOptions{
+		Since:       lookback,
+		WorkspaceID: coalesce(*workspaceID, cfg.WorkspaceID),
+	})
+	if err != nil {
+		return err
+	}
+	return a.writeOutput("Analytics Quiet", quiet, outputFormat, true)
+}
+
+func (a *App) runAnalyticsTrends(ctx context.Context, configPath string, args []string, defaultFormat OutputFormat) error {
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	fs := flag.NewFlagSet("analytics trends", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	weeks := fs.Int("weeks", 8, "number of weeks")
+	workspaceID := fs.String("workspace", "", "workspace id")
+	channel := fs.String("channel", "", "channel id or name")
+	formatFlag := fs.String("format", string(defaultFormat), "output format: text|json|log")
+	jsonOut := fs.Bool("json", false, "json output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *weeks < 0 {
+		return errors.New("--weeks must be zero or greater")
+	}
+	outputFormat, err := resolveOutputFormat(*formatFlag, *jsonOut)
+	if err != nil {
+		return err
+	}
+
+	st, err := a.openReadableStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+
+	trends, err := report.BuildTrends(ctx, st, report.TrendsOptions{
+		Weeks:       *weeks,
+		WorkspaceID: coalesce(*workspaceID, cfg.WorkspaceID),
+		Channel:     *channel,
+	})
+	if err != nil {
+		return err
+	}
+	return a.writeOutput("Analytics Trends", trends, outputFormat, true)
+}

--- a/internal/cli/analytics_test.go
+++ b/internal/cli/analytics_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vincentkoc/slacrawl/internal/store"
+)
+
+func TestAnalyticsDigestCommand(t *testing.T) {
+	ctx := context.Background()
+	app, configPath, dbPath, stdout := setupAnalyticsApp(t)
+
+	now := time.Now().UTC()
+	seedCommonWorkspace(t, ctx, dbPath, now)
+
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID:      "C1",
+		TS:             fmt.Sprintf("%d.%06d", now.Add(-2*time.Hour).Unix(), 1),
+		WorkspaceID:    "T1",
+		UserID:         "U1",
+		Text:           "hello",
+		NormalizedText: "hello",
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      now,
+	}, nil))
+	require.NoError(t, st.Close())
+
+	stdout.Reset()
+	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "--json", "analytics", "digest", "--since", "7d", "--workspace", "T1"}))
+	var analyticsDigest map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &analyticsDigest))
+
+	stdout.Reset()
+	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "--json", "digest", "--since", "7d", "--workspace", "T1"}))
+	var digest map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &digest))
+
+	require.Equal(t, digest["window_label"], analyticsDigest["window_label"])
+	require.Equal(t, digest["top_n"], analyticsDigest["top_n"])
+	require.Equal(t, digest["totals"], analyticsDigest["totals"])
+	require.Equal(t, digest["channels"], analyticsDigest["channels"])
+}
+
+func TestAnalyticsQuietCommand(t *testing.T) {
+	ctx := context.Background()
+	app, configPath, dbPath, stdout := setupAnalyticsApp(t)
+
+	now := time.Now().UTC()
+	seedCommonWorkspace(t, ctx, dbPath, now)
+
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C2", WorkspaceID: "T1", Name: "stale", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C3", WorkspaceID: "T1", Name: "recent", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID:      "C2",
+		TS:             fmt.Sprintf("%d.%06d", now.Add(-45*24*time.Hour).Unix(), 2),
+		WorkspaceID:    "T1",
+		UserID:         "U1",
+		Text:           "old",
+		NormalizedText: "old",
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      now,
+	}, nil))
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID:      "C3",
+		TS:             fmt.Sprintf("%d.%06d", now.Add(-24*time.Hour).Unix(), 3),
+		WorkspaceID:    "T1",
+		UserID:         "U1",
+		Text:           "new",
+		NormalizedText: "new",
+		SourceRank:     2,
+		SourceName:     "api-bot",
+		RawJSON:        "{}",
+		UpdatedAt:      now,
+	}, nil))
+	require.NoError(t, st.Close())
+
+	stdout.Reset()
+	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "analytics", "quiet", "--workspace", "T1", "--since", "30d", "--format", "json"}))
+	var quiet map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &quiet))
+
+	rows := quiet["channels"].([]any)
+	require.Len(t, rows, 2)
+	ids := map[string]bool{}
+	for _, item := range rows {
+		row := item.(map[string]any)
+		ids[row["channel_id"].(string)] = true
+	}
+	require.True(t, ids["C1"])
+	require.True(t, ids["C2"])
+	require.False(t, ids["C3"])
+}
+
+func TestAnalyticsTrendsCommand(t *testing.T) {
+	ctx := context.Background()
+	app, configPath, dbPath, stdout := setupAnalyticsApp(t)
+
+	now := time.Now().UTC()
+	nowBucket := now.Unix() / (7 * 24 * 60 * 60)
+	seedCommonWorkspace(t, ctx, dbPath, now)
+
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C2", WorkspaceID: "T1", Name: "beta", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+
+	seed := func(channelID string, bucket int64, count int) {
+		for i := 0; i < count; i++ {
+			ts := fmt.Sprintf("%d.%06d", bucket*(7*24*60*60)+int64(100+i), i+1)
+			require.NoError(t, st.UpsertMessage(ctx, store.Message{
+				ChannelID:      channelID,
+				TS:             ts,
+				WorkspaceID:    "T1",
+				UserID:         "U1",
+				Text:           "msg",
+				NormalizedText: "msg",
+				SourceRank:     2,
+				SourceName:     "api-bot",
+				RawJSON:        "{}",
+				UpdatedAt:      now,
+			}, nil))
+		}
+	}
+
+	seed("C1", nowBucket-2, 2)
+	seed("C1", nowBucket-1, 1)
+	seed("C1", nowBucket, 1)
+	seed("C2", nowBucket-1, 2)
+	seed("C2", nowBucket, 2)
+	require.NoError(t, st.Close())
+
+	stdout.Reset()
+	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "analytics", "trends", "--workspace", "T1", "--weeks", "3", "--format", "json"}))
+	var trends map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &trends))
+
+	rows := trends["rows"].([]any)
+	require.Len(t, rows, 2)
+
+	alpha := rows[0].(map[string]any)
+	require.Equal(t, "alpha", alpha["channel_name"])
+	alphaWeekly := alpha["weekly"].([]any)
+	require.Equal(t, float64(2), alphaWeekly[0].(map[string]any)["messages"])
+
+	beta := rows[1].(map[string]any)
+	require.Equal(t, "beta", beta["channel_name"])
+	betaWeekly := beta["weekly"].([]any)
+	require.Equal(t, float64(0), betaWeekly[0].(map[string]any)["messages"])
+	require.Equal(t, float64(2), betaWeekly[1].(map[string]any)["messages"])
+	require.Equal(t, float64(2), betaWeekly[2].(map[string]any)["messages"])
+}
+
+func setupAnalyticsApp(t *testing.T) (*App, string, string, *bytes.Buffer) {
+	t.Helper()
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	dbPath := filepath.Join(tmp, "slacrawl.db")
+	stdout := &bytes.Buffer{}
+	app := &App{Stdout: stdout, Stderr: stdout}
+	require.NoError(t, app.Run(context.Background(), []string{"--config", configPath, "init", "--db", dbPath}))
+	return app, configPath, dbPath, stdout
+}
+
+func seedCommonWorkspace(t *testing.T, ctx context.Context, dbPath string, now time.Time) {
+	t.Helper()
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T1", Name: "team", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C1", WorkspaceID: "T1", Name: "alpha", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertUser(ctx, store.User{ID: "U1", WorkspaceID: "T1", Name: "alice", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.Close())
+}

--- a/internal/cli/analytics_test.go
+++ b/internal/cli/analytics_test.go
@@ -112,16 +112,16 @@ func TestAnalyticsTrendsCommand(t *testing.T) {
 	app, configPath, dbPath, stdout := setupAnalyticsApp(t)
 
 	now := time.Now().UTC()
-	nowBucket := now.Unix() / (7 * 24 * 60 * 60)
+	currentWeekStart := startOfWeekForTest(now)
 	seedCommonWorkspace(t, ctx, dbPath, now)
 
 	st, err := store.Open(dbPath)
 	require.NoError(t, err)
 	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C2", WorkspaceID: "T1", Name: "beta", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
 
-	seed := func(channelID string, bucket int64, count int) {
+	seed := func(channelID string, weekStart time.Time, count int) {
 		for i := 0; i < count; i++ {
-			ts := fmt.Sprintf("%d.%06d", bucket*(7*24*60*60)+int64(100+i), i+1)
+			ts := fmt.Sprintf("%d.%06d", weekStart.Add(time.Duration(i+1)*time.Hour).Unix(), i+1)
 			require.NoError(t, st.UpsertMessage(ctx, store.Message{
 				ChannelID:      channelID,
 				TS:             ts,
@@ -137,11 +137,11 @@ func TestAnalyticsTrendsCommand(t *testing.T) {
 		}
 	}
 
-	seed("C1", nowBucket-2, 2)
-	seed("C1", nowBucket-1, 1)
-	seed("C1", nowBucket, 1)
-	seed("C2", nowBucket-1, 2)
-	seed("C2", nowBucket, 2)
+	seed("C1", currentWeekStart.AddDate(0, 0, -14), 2)
+	seed("C1", currentWeekStart.AddDate(0, 0, -7), 1)
+	seed("C1", currentWeekStart, 1)
+	seed("C2", currentWeekStart.AddDate(0, 0, -7), 2)
+	seed("C2", currentWeekStart, 2)
 	require.NoError(t, st.Close())
 
 	stdout.Reset()
@@ -165,6 +165,33 @@ func TestAnalyticsTrendsCommand(t *testing.T) {
 	require.Equal(t, float64(2), betaWeekly[2].(map[string]any)["messages"])
 }
 
+func TestAnalyticsTrendsCommandIncludesRequestedQuietChannel(t *testing.T) {
+	ctx := context.Background()
+	app, configPath, dbPath, stdout := setupAnalyticsApp(t)
+
+	now := time.Now().UTC()
+	seedCommonWorkspace(t, ctx, dbPath, now)
+
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C2", WorkspaceID: "T1", Name: "quiet", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.Close())
+
+	stdout.Reset()
+	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "analytics", "trends", "--workspace", "T1", "--channel", "quiet", "--weeks", "2", "--format", "json"}))
+	var trends map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &trends))
+
+	rows := trends["rows"].([]any)
+	require.Len(t, rows, 1)
+	row := rows[0].(map[string]any)
+	require.Equal(t, "quiet", row["channel_name"])
+	weekly := row["weekly"].([]any)
+	require.Len(t, weekly, 2)
+	require.Equal(t, float64(0), weekly[0].(map[string]any)["messages"])
+	require.Equal(t, float64(0), weekly[1].(map[string]any)["messages"])
+}
+
 func setupAnalyticsApp(t *testing.T) (*App, string, string, *bytes.Buffer) {
 	t.Helper()
 	tmp := t.TempDir()
@@ -184,4 +211,11 @@ func seedCommonWorkspace(t *testing.T, ctx context.Context, dbPath string, now t
 	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C1", WorkspaceID: "T1", Name: "alpha", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
 	require.NoError(t, st.UpsertUser(ctx, store.User{ID: "U1", WorkspaceID: "T1", Name: "alice", RawJSON: "{}", UpdatedAt: now}))
 	require.NoError(t, st.Close())
+}
+
+func startOfWeekForTest(t time.Time) time.Time {
+	t = t.UTC()
+	dayStart := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	offset := (int(dayStart.Weekday()) + 6) % 7
+	return dayStart.AddDate(0, 0, -offset)
 }

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -94,6 +94,8 @@ func (a *App) Run(ctx context.Context, args []string) error {
 		return a.runReport(ctx, *configPath, outputFormat)
 	case "digest":
 		return a.runDigest(ctx, *configPath, rest[1:], outputFormat)
+	case "analytics":
+		return a.runAnalytics(ctx, *configPath, rest[1:], outputFormat)
 	case "publish":
 		return a.runPublish(ctx, *configPath, rest[1:], outputFormat)
 	case "subscribe":

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -12,6 +12,8 @@ var (
 		"init",
 		"doctor",
 		"report",
+		"digest",
+		"analytics",
 		"publish",
 		"subscribe",
 		"update",
@@ -40,6 +42,8 @@ var (
 		"init":       {"--workspace", "--db", "--help", "-h"},
 		"doctor":     {"--help", "-h"},
 		"report":     {"--help", "-h"},
+		"digest":     {"--since", "--workspace", "--channel", "--top-n", "--help", "-h"},
+		"analytics":  {"digest", "quiet", "trends", "--help", "-h"},
 		"publish":    {"--repo", "--remote", "--branch", "--message", "--no-commit", "--push", "--help", "-h"},
 		"subscribe":  {"--repo", "--db", "--remote", "--branch", "--stale-after", "--no-auto-update", "--no-import", "--help", "-h"},
 		"update":     {"--repo", "--remote", "--branch", "--help", "-h"},
@@ -101,7 +105,7 @@ _slacrawl()
     local i
     for ((i=1; i < ${#words[@]}; i++)); do
         case "${words[i]}" in
-            init|doctor|report|publish|subscribe|update|sync|import|tail|watch|search|messages|mentions|sql|users|channels|status|completion)
+            init|doctor|report|digest|analytics|publish|subscribe|update|sync|import|tail|watch|search|messages|mentions|sql|users|channels|status|completion)
                 command="${words[i]}"
                 break
                 ;;
@@ -125,6 +129,10 @@ _slacrawl()
 			COMPREPLY=( $(compgen -W "bash zsh" -- "${cur}") )
 			return
 			;;
+		analytics)
+			COMPREPLY=( $(compgen -W "digest quiet trends --help -h ${global_flags}" -- "${cur}") )
+			return
+			;;
     esac
 
     case "${command}" in
@@ -136,6 +144,34 @@ _slacrawl()
             ;;
         report)
             COMPREPLY=( $(compgen -W "--help -h ${global_flags}" -- "${cur}") )
+            ;;
+        digest)
+            COMPREPLY=( $(compgen -W "--since --workspace --channel --top-n --help -h ${global_flags}" -- "${cur}") )
+            ;;
+        analytics)
+            local analytics_subcommand=""
+            for ((i=2; i < ${#words[@]}; i++)); do
+                case "${words[i]}" in
+                    digest|quiet|trends)
+                        analytics_subcommand="${words[i]}"
+                        break
+                        ;;
+                esac
+            done
+            case "${analytics_subcommand}" in
+                digest)
+                    COMPREPLY=( $(compgen -W "--since --workspace --channel --top-n --help -h ${global_flags}" -- "${cur}") )
+                    ;;
+                quiet)
+                    COMPREPLY=( $(compgen -W "--since --workspace --format --json --help -h ${global_flags}" -- "${cur}") )
+                    ;;
+                trends)
+                    COMPREPLY=( $(compgen -W "--weeks --workspace --channel --format --json --help -h ${global_flags}" -- "${cur}") )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -W "digest quiet trends --help -h ${global_flags}" -- "${cur}") )
+                    ;;
+            esac
             ;;
         publish)
             COMPREPLY=( $(compgen -W "--repo --remote --branch --message --no-commit --push --help -h ${global_flags}" -- "${cur}") )
@@ -222,6 +258,29 @@ _slacrawl() {
           ;;
         report)
           _arguments '--help[show help]'
+          ;;
+        digest)
+          _arguments '--since[lookback window]:duration:' '--workspace[workspace id]:workspace id:' '--channel[channel id or name]:channel:' '--top-n[top posters and mentions per channel]:count:'
+          ;;
+        analytics)
+          if (( CURRENT == 3 )); then
+            _values 'analytics subcommand' digest quiet trends
+          else
+            case $words[3] in
+              digest)
+                _arguments '--since[lookback window]:duration:' '--workspace[workspace id]:workspace id:' '--channel[channel id or name]:channel:' '--top-n[top posters and mentions per channel]:count:'
+                ;;
+              quiet)
+                _arguments '--since[lookback window]:duration:' '--workspace[workspace id]:workspace id:' '--format[output format]:format:(text json log)' '--json[json output]'
+                ;;
+              trends)
+                _arguments '--weeks[number of weeks]:count:' '--workspace[workspace id]:workspace id:' '--channel[channel id or name]:channel:' '--format[output format]:format:(text json log)' '--json[json output]'
+                ;;
+              *)
+                _values 'analytics subcommand' digest quiet trends
+                ;;
+            esac
+          fi
           ;;
         publish)
           _arguments '--repo[git repo path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--message[commit message]:message:' '--no-commit[skip git commit]' '--push[push to origin]'

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -77,6 +77,7 @@ func (a *App) printHelp() {
 	b.WriteString("  doctor     Check config, DB, tokens, and desktop coverage.\n")
 	b.WriteString("  report     Show archive activity and share freshness.\n")
 	b.WriteString("  digest     Per-channel activity summary for a window.\n")
+	b.WriteString("  analytics  Grouped analytics subcommands.\n")
 	b.WriteString("  publish    Export a git-backed archive snapshot.\n")
 	b.WriteString("  subscribe  Configure a git-backed archive reader.\n")
 	b.WriteString("  update     Pull and import the latest git snapshot.\n")
@@ -98,6 +99,7 @@ func (a *App) printHelp() {
 	b.WriteString("  slacrawl doctor\n")
 	b.WriteString("  slacrawl report\n")
 	b.WriteString("  slacrawl digest --since 7d\n")
+	b.WriteString("  slacrawl analytics trends --weeks 4\n")
 	b.WriteString("  slacrawl subscribe --db ~/.slacrawl/slacrawl.db https://example.com/private/slacrawl-archive.git\n")
 	b.WriteString("  slacrawl sync --source api --latest-only\n")
 	b.WriteString("  slacrawl import ./my-export.zip --workspace T01234567\n")
@@ -159,6 +161,10 @@ func renderSpecialBlock(w *strings.Builder, title string, value any) bool {
 		return renderReportBlock(w, value)
 	case "Digest":
 		return renderDigestBlock(w, value)
+	case "Analytics Quiet":
+		return renderAnalyticsQuietBlock(w, value)
+	case "Analytics Trends":
+		return renderAnalyticsTrendsBlock(w, value)
 	case "Sync", "Watch":
 		return renderSyncBlock(w, title, value)
 	case "Search":
@@ -912,6 +918,133 @@ func renderDigestBlock(w *strings.Builder, value any) bool {
 			w.WriteByte('\n')
 		}
 	}
+	return true
+}
+
+func renderAnalyticsQuietBlock(w *strings.Builder, value any) bool {
+	quiet, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	writeTitle(w, "ANALYTICS QUIET")
+
+	w.WriteString(colorize(ansiGreen, "● Window"))
+	w.WriteByte('\n')
+	w.WriteString("  since        ")
+	w.WriteString(shortValue(quiet["since"]))
+	w.WriteByte('\n')
+	w.WriteString("  until        ")
+	w.WriteString(shortValue(quiet["until"]))
+	w.WriteByte('\n')
+	if ws := shortValue(quiet["workspace"]); ws != "-" {
+		w.WriteString("  workspace    ")
+		w.WriteString(ws)
+		w.WriteByte('\n')
+	}
+
+	if totals, ok := quiet["totals"].(map[string]any); ok {
+		w.WriteByte('\n')
+		w.WriteString(colorize(ansiCyan, "Totals"))
+		w.WriteByte('\n')
+		writeMetricRow(w, []metric{
+			{"channels", shortValue(totals["channels"]), ansiGreen},
+		})
+	}
+
+	channels, _ := quiet["channels"].([]any)
+	w.WriteByte('\n')
+	w.WriteString(colorize(ansiCyan, "Channels"))
+	w.WriteByte('\n')
+	if len(channels) == 0 {
+		w.WriteString(colorize(ansiDim, "  no quiet channels in window"))
+		w.WriteByte('\n')
+		return true
+	}
+	rows := make([]map[string]any, 0, len(channels))
+	for _, item := range channels {
+		row, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		lastMessage := shortValue(row["last_message"])
+		if lastMessage == "-" {
+			lastMessage = "never"
+		}
+		rows = append(rows, map[string]any{
+			"channel":      shortValue(row["channel_name"]),
+			"kind":         shortValue(row["kind"]),
+			"last_message": lastMessage,
+			"days_silent":  shortValue(row["days_silent"]),
+		})
+	}
+	renderTable(w, rows, 1)
+	return true
+}
+
+func renderAnalyticsTrendsBlock(w *strings.Builder, value any) bool {
+	trends, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	writeTitle(w, "ANALYTICS TRENDS")
+
+	w.WriteString(colorize(ansiGreen, "● Window"))
+	w.WriteByte('\n')
+	w.WriteString("  weeks        ")
+	w.WriteString(shortValue(trends["weeks"]))
+	w.WriteByte('\n')
+	w.WriteString("  since        ")
+	w.WriteString(shortValue(trends["since"]))
+	w.WriteByte('\n')
+	w.WriteString("  until        ")
+	w.WriteString(shortValue(trends["until"]))
+	w.WriteByte('\n')
+	if ws := shortValue(trends["workspace"]); ws != "-" {
+		w.WriteString("  workspace    ")
+		w.WriteString(ws)
+		w.WriteByte('\n')
+	}
+	if ch := shortValue(trends["channel"]); ch != "-" {
+		w.WriteString("  channel      ")
+		w.WriteString(ch)
+		w.WriteByte('\n')
+	}
+
+	rows, _ := trends["rows"].([]any)
+	w.WriteByte('\n')
+	w.WriteString(colorize(ansiCyan, "Weekly counts"))
+	w.WriteByte('\n')
+	if len(rows) == 0 {
+		w.WriteString(colorize(ansiDim, "  no channel activity in window"))
+		w.WriteByte('\n')
+		return true
+	}
+
+	tableRows := make([]map[string]any, 0)
+	for _, item := range rows {
+		row, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		channelName := shortValue(row["channel_name"])
+		if channelName == "-" {
+			channelName = shortValue(row["channel_id"])
+		}
+		weekly, _ := row["weekly"].([]any)
+		for _, weeklyItem := range weekly {
+			week, ok := weeklyItem.(map[string]any)
+			if !ok {
+				continue
+			}
+			tableRows = append(tableRows, map[string]any{
+				"channel":    channelName,
+				"kind":       shortValue(row["kind"]),
+				"week_start": shortValue(week["week_start"]),
+				"messages":   shortValue(week["messages"]),
+			})
+		}
+	}
+	renderTable(w, tableRows, 1)
 	return true
 }
 

--- a/internal/report/quiet.go
+++ b/internal/report/quiet.go
@@ -1,0 +1,137 @@
+package report
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vincentkoc/slacrawl/internal/store"
+)
+
+// QuietOptions controls how a Quiet report is built.
+type QuietOptions struct {
+	Now         time.Time
+	Since       time.Duration
+	WorkspaceID string
+}
+
+// Quiet summarizes channels with no activity in a window.
+type Quiet struct {
+	GeneratedAt time.Time      `json:"generated_at"`
+	Since       time.Time      `json:"since"`
+	Until       time.Time      `json:"until"`
+	Workspace   string         `json:"workspace,omitempty"`
+	Channels    []QuietChannel `json:"channels"`
+	Totals      QuietTotals    `json:"totals"`
+}
+
+// QuietChannel is one channel that has no recent activity.
+type QuietChannel struct {
+	ChannelID   string `json:"channel_id"`
+	ChannelName string `json:"channel_name"`
+	Kind        string `json:"kind,omitempty"`
+	WorkspaceID string `json:"workspace_id"`
+	LastMessage string `json:"last_message,omitempty"`
+	DaysSilent  int    `json:"days_silent"`
+}
+
+// QuietTotals summarizes quiet-channel counts.
+type QuietTotals struct {
+	Channels int `json:"channels"`
+}
+
+// BuildQuiet computes channels with no messages newer than the lookback window.
+func BuildQuiet(ctx context.Context, s *store.Store, opts QuietOptions) (Quiet, error) {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	sinceWindow := opts.Since
+	if sinceWindow < 0 {
+		sinceWindow = -sinceWindow
+	}
+	if sinceWindow == 0 {
+		sinceWindow = 30 * 24 * time.Hour
+	}
+	since := now.Add(-sinceWindow)
+
+	out := Quiet{
+		GeneratedAt: now,
+		Since:       since,
+		Until:       now,
+		Workspace:   opts.WorkspaceID,
+	}
+
+	channels, err := quietChannels(ctx, s.DB(), since, now, opts.WorkspaceID)
+	if err != nil {
+		return Quiet{}, err
+	}
+	out.Channels = channels
+	out.Totals = QuietTotals{Channels: len(channels)}
+	return out, nil
+}
+
+func quietChannels(ctx context.Context, db *sql.DB, since time.Time, now time.Time, workspaceID string) ([]QuietChannel, error) {
+	query := &strings.Builder{}
+	query.WriteString(`
+with latest_messages as (
+	select
+		m.workspace_id,
+		m.channel_id,
+		max(cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer)) as last_ts
+	from messages m
+	where m.ts not like 'draft:%'
+	  and instr(m.ts, '.') > 0
+	group by m.workspace_id, m.channel_id
+)
+select
+	c.workspace_id,
+	c.id as channel_id,
+	coalesce(nullif(c.name, ''), c.id) as channel_name,
+	coalesce(c.kind, '') as kind,
+	lm.last_ts
+from channels c
+left join latest_messages lm on lm.workspace_id = c.workspace_id and lm.channel_id = c.id
+where 1 = 1
+`)
+	args := make([]any, 0, 2)
+	if workspaceID != "" {
+		query.WriteString("  and c.workspace_id = ?\n")
+		args = append(args, workspaceID)
+	}
+	query.WriteString("  and (lm.last_ts is null or lm.last_ts < ?)\n")
+	args = append(args, since.Unix())
+	query.WriteString(`order by
+	case when lm.last_ts is null then 0 else 1 end,
+	lm.last_ts asc,
+	channel_name asc
+`)
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("quiet channels query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	minimumDaysSilent := int(now.Sub(since).Hours() / 24)
+	out := make([]QuietChannel, 0)
+	for rows.Next() {
+		var row QuietChannel
+		var lastEpoch sql.NullInt64
+		if err := rows.Scan(&row.WorkspaceID, &row.ChannelID, &row.ChannelName, &row.Kind, &lastEpoch); err != nil {
+			return nil, fmt.Errorf("quiet channels scan: %w", err)
+		}
+		if lastEpoch.Valid {
+			last := time.Unix(lastEpoch.Int64, 0).UTC()
+			row.LastMessage = last.Format(time.RFC3339)
+			row.DaysSilent = int(now.Sub(last).Hours() / 24)
+		} else {
+			row.DaysSilent = minimumDaysSilent
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}

--- a/internal/report/quiet_test.go
+++ b/internal/report/quiet_test.go
@@ -1,0 +1,51 @@
+package report
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vincentkoc/slacrawl/internal/store"
+)
+
+func TestBuildQuiet(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "quiet.db")
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	defer st.Close()
+
+	ctx := context.Background()
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-2 * 24 * time.Hour)
+	stale := now.Add(-45 * 24 * time.Hour)
+
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T1", Name: "team", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C-quiet", WorkspaceID: "T1", Name: "quiet", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C-recent", WorkspaceID: "T1", Name: "recent", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C-stale", WorkspaceID: "T1", Name: "stale", Kind: "private_channel", RawJSON: "{}", UpdatedAt: now}))
+
+	addMsg(t, ctx, st, "C-recent", tsEpoch(recent, 100), "T1", "U1", "", "new activity")
+	addMsg(t, ctx, st, "C-stale", tsEpoch(stale, 200), "T1", "U1", "", "old activity")
+
+	quiet, err := BuildQuiet(ctx, st, QuietOptions{Now: now})
+	require.NoError(t, err)
+	require.Equal(t, now.Add(-30*24*time.Hour), quiet.Since)
+	require.Equal(t, now, quiet.Until)
+	require.Len(t, quiet.Channels, 2)
+	require.Equal(t, 2, quiet.Totals.Channels)
+
+	require.Equal(t, "C-quiet", quiet.Channels[0].ChannelID)
+	require.Empty(t, quiet.Channels[0].LastMessage)
+	require.Equal(t, 30, quiet.Channels[0].DaysSilent)
+
+	require.Equal(t, "C-stale", quiet.Channels[1].ChannelID)
+	require.Equal(t, stale.Format(time.RFC3339), quiet.Channels[1].LastMessage)
+	require.GreaterOrEqual(t, quiet.Channels[1].DaysSilent, 45)
+
+	for _, row := range quiet.Channels {
+		require.NotEqual(t, "C-recent", row.ChannelID)
+	}
+}

--- a/internal/report/trends.go
+++ b/internal/report/trends.go
@@ -59,11 +59,10 @@ func BuildTrends(ctx context.Context, s *store.Store, opts TrendsOptions) (Trend
 		weeks = 8
 	}
 
-	untilBucket := now.Unix() / secondsPerWeek
-	sinceBucket := untilBucket - int64(weeks) + 1
-	since := time.Unix(sinceBucket*secondsPerWeek, 0).UTC()
+	currentWeekStart := startOfWeekUTC(now)
+	since := currentWeekStart.AddDate(0, 0, -7*(weeks-1))
 
-	rows, err := trendsRows(ctx, s.DB(), sinceBucket, untilBucket, weeks, opts.WorkspaceID, opts.Channel)
+	rows, err := trendsRows(ctx, s.DB(), since, now, weeks, opts.WorkspaceID, opts.Channel)
 	if err != nil {
 		return Trends{}, err
 	}
@@ -86,7 +85,7 @@ type trendKey struct {
 	kind        string
 }
 
-func trendsRows(ctx context.Context, db *sql.DB, sinceBucket int64, untilBucket int64, weeks int, workspaceID string, channel string) ([]TrendsRow, error) {
+func trendsRows(ctx context.Context, db *sql.DB, since time.Time, until time.Time, weeks int, workspaceID string, channel string) ([]TrendsRow, error) {
 	query := &strings.Builder{}
 	query.WriteString(`
 select
@@ -94,16 +93,15 @@ select
 	m.channel_id,
 	coalesce(nullif(c.name, ''), m.channel_id) as channel_name,
 	coalesce(c.kind, '') as kind,
-	cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) / 604800 as week_bucket,
-	count(*) as messages
+	cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) as ts_epoch
 from messages m
 left join channels c on c.id = m.channel_id and c.workspace_id = m.workspace_id
 where m.ts not like 'draft:%'
   and instr(m.ts, '.') > 0
-  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) / 604800 >= ?
-  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) / 604800 <= ?
+  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) >= ?
+  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) <= ?
 `)
-	args := []any{sinceBucket, untilBucket}
+	args := []any{since.Unix(), until.Unix()}
 	if workspaceID != "" {
 		query.WriteString("  and m.workspace_id = ?\n")
 		args = append(args, workspaceID)
@@ -112,9 +110,7 @@ where m.ts not like 'draft:%'
 		query.WriteString("  and (m.channel_id = ? or c.name = ?)\n")
 		args = append(args, channel, channel)
 	}
-	query.WriteString(`group by m.workspace_id, m.channel_id, channel_name, kind, week_bucket
-order by channel_name asc, week_bucket asc
-`)
+	query.WriteString("order by channel_name asc, ts_epoch asc\n")
 
 	rows, err := db.QueryContext(ctx, query.String(), args...)
 	if err != nil {
@@ -124,19 +120,33 @@ order by channel_name asc, week_bucket asc
 
 	countsByChannel := make(map[trendKey]map[int64]int)
 	for rows.Next() {
-		var key trendKey
-		var bucket int64
-		var messages int
-		if err := rows.Scan(&key.workspaceID, &key.channelID, &key.channelName, &key.kind, &bucket, &messages); err != nil {
+		var (
+			key     trendKey
+			tsEpoch int64
+		)
+		if err := rows.Scan(&key.workspaceID, &key.channelID, &key.channelName, &key.kind, &tsEpoch); err != nil {
 			return nil, fmt.Errorf("trends rows scan: %w", err)
 		}
 		if countsByChannel[key] == nil {
 			countsByChannel[key] = make(map[int64]int)
 		}
-		countsByChannel[key][bucket] = messages
+		weekStart := startOfWeekUTC(time.Unix(tsEpoch, 0).UTC())
+		countsByChannel[key][weekStart.Unix()]++
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+
+	if strings.TrimSpace(channel) != "" {
+		matching, err := trendChannels(ctx, db, workspaceID, channel)
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range matching {
+			if countsByChannel[key] == nil {
+				countsByChannel[key] = make(map[int64]int)
+			}
+		}
 	}
 
 	keys := make([]trendKey, 0, len(countsByChannel))
@@ -157,10 +167,10 @@ order by channel_name asc, week_bucket asc
 	for _, key := range keys {
 		weekly := make([]WeeklyCount, 0, weeks)
 		for i := 0; i < weeks; i++ {
-			bucket := sinceBucket + int64(i)
+			weekStart := since.AddDate(0, 0, 7*i)
 			weekly = append(weekly, WeeklyCount{
-				WeekStart: time.Unix(bucket*secondsPerWeek, 0).UTC(),
-				Messages:  countsByChannel[key][bucket],
+				WeekStart: weekStart,
+				Messages:  countsByChannel[key][weekStart.Unix()],
 			})
 		}
 		out = append(out, TrendsRow{
@@ -172,4 +182,49 @@ order by channel_name asc, week_bucket asc
 		})
 	}
 	return out, nil
+}
+
+func trendChannels(ctx context.Context, db *sql.DB, workspaceID string, channel string) ([]trendKey, error) {
+	query := &strings.Builder{}
+	query.WriteString(`
+select
+	workspace_id,
+	id,
+	coalesce(nullif(name, ''), id) as channel_name,
+	coalesce(kind, '') as kind
+from channels
+where (id = ? or name = ?)
+`)
+	args := []any{channel, channel}
+	if workspaceID != "" {
+		query.WriteString("  and workspace_id = ?\n")
+		args = append(args, workspaceID)
+	}
+	query.WriteString("order by channel_name asc, workspace_id asc, id asc\n")
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("trends channels query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []trendKey
+	for rows.Next() {
+		var key trendKey
+		if err := rows.Scan(&key.workspaceID, &key.channelID, &key.channelName, &key.kind); err != nil {
+			return nil, fmt.Errorf("trends channels scan: %w", err)
+		}
+		out = append(out, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func startOfWeekUTC(t time.Time) time.Time {
+	t = t.UTC()
+	dayStart := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	offset := (int(dayStart.Weekday()) + 6) % 7
+	return dayStart.AddDate(0, 0, -offset)
 }

--- a/internal/report/trends.go
+++ b/internal/report/trends.go
@@ -1,0 +1,175 @@
+package report
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vincentkoc/slacrawl/internal/store"
+)
+
+const secondsPerWeek = int64(7 * 24 * 60 * 60)
+
+// TrendsOptions controls how a Trends report is built.
+type TrendsOptions struct {
+	Now         time.Time
+	Weeks       int
+	WorkspaceID string
+	Channel     string
+}
+
+// Trends summarizes week-over-week message volume per channel.
+type Trends struct {
+	GeneratedAt time.Time   `json:"generated_at"`
+	Since       time.Time   `json:"since"`
+	Until       time.Time   `json:"until"`
+	Weeks       int         `json:"weeks"`
+	Workspace   string      `json:"workspace,omitempty"`
+	Channel     string      `json:"channel,omitempty"`
+	Rows        []TrendsRow `json:"rows"`
+}
+
+// TrendsRow is one channel's weekly message trend.
+type TrendsRow struct {
+	WorkspaceID string        `json:"workspace_id"`
+	ChannelID   string        `json:"channel_id"`
+	ChannelName string        `json:"channel_name"`
+	Kind        string        `json:"kind,omitempty"`
+	Weekly      []WeeklyCount `json:"weekly"`
+}
+
+// WeeklyCount is the message count for a specific week bucket.
+type WeeklyCount struct {
+	WeekStart time.Time `json:"week_start"`
+	Messages  int       `json:"messages"`
+}
+
+// BuildTrends computes weekly message counts per channel.
+func BuildTrends(ctx context.Context, s *store.Store, opts TrendsOptions) (Trends, error) {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	weeks := opts.Weeks
+	if weeks <= 0 {
+		weeks = 8
+	}
+
+	untilBucket := now.Unix() / secondsPerWeek
+	sinceBucket := untilBucket - int64(weeks) + 1
+	since := time.Unix(sinceBucket*secondsPerWeek, 0).UTC()
+
+	rows, err := trendsRows(ctx, s.DB(), sinceBucket, untilBucket, weeks, opts.WorkspaceID, opts.Channel)
+	if err != nil {
+		return Trends{}, err
+	}
+
+	return Trends{
+		GeneratedAt: now,
+		Since:       since,
+		Until:       now,
+		Weeks:       weeks,
+		Workspace:   opts.WorkspaceID,
+		Channel:     opts.Channel,
+		Rows:        rows,
+	}, nil
+}
+
+type trendKey struct {
+	workspaceID string
+	channelID   string
+	channelName string
+	kind        string
+}
+
+func trendsRows(ctx context.Context, db *sql.DB, sinceBucket int64, untilBucket int64, weeks int, workspaceID string, channel string) ([]TrendsRow, error) {
+	query := &strings.Builder{}
+	query.WriteString(`
+select
+	m.workspace_id,
+	m.channel_id,
+	coalesce(nullif(c.name, ''), m.channel_id) as channel_name,
+	coalesce(c.kind, '') as kind,
+	cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) / 604800 as week_bucket,
+	count(*) as messages
+from messages m
+left join channels c on c.id = m.channel_id and c.workspace_id = m.workspace_id
+where m.ts not like 'draft:%'
+  and instr(m.ts, '.') > 0
+  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) / 604800 >= ?
+  and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) / 604800 <= ?
+`)
+	args := []any{sinceBucket, untilBucket}
+	if workspaceID != "" {
+		query.WriteString("  and m.workspace_id = ?\n")
+		args = append(args, workspaceID)
+	}
+	if channel != "" {
+		query.WriteString("  and (m.channel_id = ? or c.name = ?)\n")
+		args = append(args, channel, channel)
+	}
+	query.WriteString(`group by m.workspace_id, m.channel_id, channel_name, kind, week_bucket
+order by channel_name asc, week_bucket asc
+`)
+
+	rows, err := db.QueryContext(ctx, query.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("trends rows query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	countsByChannel := make(map[trendKey]map[int64]int)
+	for rows.Next() {
+		var key trendKey
+		var bucket int64
+		var messages int
+		if err := rows.Scan(&key.workspaceID, &key.channelID, &key.channelName, &key.kind, &bucket, &messages); err != nil {
+			return nil, fmt.Errorf("trends rows scan: %w", err)
+		}
+		if countsByChannel[key] == nil {
+			countsByChannel[key] = make(map[int64]int)
+		}
+		countsByChannel[key][bucket] = messages
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	keys := make([]trendKey, 0, len(countsByChannel))
+	for key := range countsByChannel {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].channelName != keys[j].channelName {
+			return keys[i].channelName < keys[j].channelName
+		}
+		if keys[i].workspaceID != keys[j].workspaceID {
+			return keys[i].workspaceID < keys[j].workspaceID
+		}
+		return keys[i].channelID < keys[j].channelID
+	})
+
+	out := make([]TrendsRow, 0, len(keys))
+	for _, key := range keys {
+		weekly := make([]WeeklyCount, 0, weeks)
+		for i := 0; i < weeks; i++ {
+			bucket := sinceBucket + int64(i)
+			weekly = append(weekly, WeeklyCount{
+				WeekStart: time.Unix(bucket*secondsPerWeek, 0).UTC(),
+				Messages:  countsByChannel[key][bucket],
+			})
+		}
+		out = append(out, TrendsRow{
+			WorkspaceID: key.workspaceID,
+			ChannelID:   key.channelID,
+			ChannelName: key.channelName,
+			Kind:        key.kind,
+			Weekly:      weekly,
+		})
+	}
+	return out, nil
+}

--- a/internal/report/trends_test.go
+++ b/internal/report/trends_test.go
@@ -20,30 +20,31 @@ func TestBuildTrends(t *testing.T) {
 
 	ctx := context.Background()
 	now := time.Unix(1776852000, 0).UTC() // 2026-04-22T12:00:00Z
-	nowBucket := now.Unix() / secondsPerWeek
+	currentWeekStart := startOfWeekUTC(now)
 
 	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T1", Name: "team", RawJSON: "{}", UpdatedAt: now}))
 	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C1", WorkspaceID: "T1", Name: "alpha", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
 	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C2", WorkspaceID: "T1", Name: "beta", Kind: "private_channel", RawJSON: "{}", UpdatedAt: now}))
 
-	seed := func(channelID string, bucket int64, count int) {
+	seed := func(channelID string, weekStart time.Time, count int) {
 		for i := 0; i < count; i++ {
-			ts := fmt.Sprintf("%d.%06d", bucket*secondsPerWeek+int64(10+i), i+1)
+			ts := fmt.Sprintf("%d.%06d", weekStart.Add(time.Duration(i+1)*time.Hour).Unix(), i+1)
 			addMsg(t, ctx, st, channelID, ts, "T1", "U1", "", "message")
 		}
 	}
 
-	seed("C1", nowBucket-2, 2)
-	seed("C1", nowBucket-1, 3)
-	seed("C1", nowBucket, 1)
+	seed("C1", currentWeekStart.AddDate(0, 0, -14), 2)
+	seed("C1", currentWeekStart.AddDate(0, 0, -7), 3)
+	seed("C1", currentWeekStart, 1)
 
-	seed("C2", nowBucket-1, 2)
-	seed("C2", nowBucket, 4)
+	seed("C2", currentWeekStart.AddDate(0, 0, -7), 2)
+	seed("C2", currentWeekStart, 4)
 
 	trends, err := BuildTrends(ctx, st, TrendsOptions{Now: now, Weeks: 3})
 	require.NoError(t, err)
 	require.Equal(t, 3, trends.Weeks)
 	require.Len(t, trends.Rows, 2)
+	require.Equal(t, currentWeekStart.AddDate(0, 0, -14), trends.Since)
 
 	require.Equal(t, "alpha", trends.Rows[0].ChannelName)
 	require.Equal(t, "beta", trends.Rows[1].ChannelName)
@@ -60,8 +61,41 @@ func TestBuildTrends(t *testing.T) {
 	require.Equal(t, 2, beta[1].Messages)
 	require.Equal(t, 4, beta[2].Messages)
 
-	for i, bucket := range []int64{nowBucket - 2, nowBucket - 1, nowBucket} {
-		require.Equal(t, time.Unix(bucket*secondsPerWeek, 0).UTC(), alpha[i].WeekStart)
-		require.Equal(t, time.Unix(bucket*secondsPerWeek, 0).UTC(), beta[i].WeekStart)
+	for i, weekStart := range []time.Time{
+		currentWeekStart.AddDate(0, 0, -14),
+		currentWeekStart.AddDate(0, 0, -7),
+		currentWeekStart,
+	} {
+		require.Equal(t, weekStart, alpha[i].WeekStart)
+		require.Equal(t, weekStart, beta[i].WeekStart)
 	}
+}
+
+func TestBuildTrendsIncludesRequestedQuietChannel(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "trends-quiet.db")
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	defer st.Close()
+
+	ctx := context.Background()
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	currentWeekStart := startOfWeekUTC(now)
+
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T1", Name: "team", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C3", WorkspaceID: "T1", Name: "quiet", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+
+	trends, err := BuildTrends(ctx, st, TrendsOptions{
+		Now:         now,
+		Weeks:       2,
+		WorkspaceID: "T1",
+		Channel:     "quiet",
+	})
+	require.NoError(t, err)
+	require.Len(t, trends.Rows, 1)
+	require.Equal(t, "quiet", trends.Rows[0].ChannelName)
+	require.Len(t, trends.Rows[0].Weekly, 2)
+	require.Equal(t, currentWeekStart.AddDate(0, 0, -7), trends.Rows[0].Weekly[0].WeekStart)
+	require.Equal(t, 0, trends.Rows[0].Weekly[0].Messages)
+	require.Equal(t, currentWeekStart, trends.Rows[0].Weekly[1].WeekStart)
+	require.Equal(t, 0, trends.Rows[0].Weekly[1].Messages)
 }

--- a/internal/report/trends_test.go
+++ b/internal/report/trends_test.go
@@ -1,0 +1,67 @@
+package report
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vincentkoc/slacrawl/internal/store"
+)
+
+func TestBuildTrends(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "trends.db")
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	defer st.Close()
+
+	ctx := context.Background()
+	now := time.Unix(1776852000, 0).UTC() // 2026-04-22T12:00:00Z
+	nowBucket := now.Unix() / secondsPerWeek
+
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T1", Name: "team", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C1", WorkspaceID: "T1", Name: "alpha", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C2", WorkspaceID: "T1", Name: "beta", Kind: "private_channel", RawJSON: "{}", UpdatedAt: now}))
+
+	seed := func(channelID string, bucket int64, count int) {
+		for i := 0; i < count; i++ {
+			ts := fmt.Sprintf("%d.%06d", bucket*secondsPerWeek+int64(10+i), i+1)
+			addMsg(t, ctx, st, channelID, ts, "T1", "U1", "", "message")
+		}
+	}
+
+	seed("C1", nowBucket-2, 2)
+	seed("C1", nowBucket-1, 3)
+	seed("C1", nowBucket, 1)
+
+	seed("C2", nowBucket-1, 2)
+	seed("C2", nowBucket, 4)
+
+	trends, err := BuildTrends(ctx, st, TrendsOptions{Now: now, Weeks: 3})
+	require.NoError(t, err)
+	require.Equal(t, 3, trends.Weeks)
+	require.Len(t, trends.Rows, 2)
+
+	require.Equal(t, "alpha", trends.Rows[0].ChannelName)
+	require.Equal(t, "beta", trends.Rows[1].ChannelName)
+
+	alpha := trends.Rows[0].Weekly
+	require.Len(t, alpha, 3)
+	require.Equal(t, 2, alpha[0].Messages)
+	require.Equal(t, 3, alpha[1].Messages)
+	require.Equal(t, 1, alpha[2].Messages)
+
+	beta := trends.Rows[1].Weekly
+	require.Len(t, beta, 3)
+	require.Equal(t, 0, beta[0].Messages)
+	require.Equal(t, 2, beta[1].Messages)
+	require.Equal(t, 4, beta[2].Messages)
+
+	for i, bucket := range []int64{nowBucket - 2, nowBucket - 1, nowBucket} {
+		require.Equal(t, time.Unix(bucket*secondsPerWeek, 0).UTC(), alpha[i].WeekStart)
+		require.Equal(t, time.Unix(bucket*secondsPerWeek, 0).UTC(), beta[i].WeekStart)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces `slacrawl analytics <subcommand>` as a namespace for activity-style queries. This is phase 2 of a planned 4-PR rollout; PR #9 (the standalone `slacrawl digest`) was phase 1. Three subcommands ship here: `analytics digest` (delegates to the existing digest implementation so `slacrawl digest` is unchanged), `analytics quiet`, and `analytics trends`. Further phases add `health`, `response-times`, `threads-stale`, and `activity`.

## Why this matters

- slacrawl already has the store, schema, and FTS needed for activity analytics; `internal/report/digest.go` established the pattern in v0.4.
- Exposing quiet channels and week-over-week trends makes the local archive useful for recurring personal retro / team-health reviews without a separate tool.
- slackdump has no SQL-backed analytics; a small family of subcommands keeps slacrawl differentiated while matching what I ship in pp-slack today.

## Changes

New subcommand group and two analytics commands:

```
slacrawl analytics                              # usage
slacrawl analytics digest [--since 7d] [--workspace X] [--channel C]
slacrawl analytics quiet  [--since 30d] [--workspace X]
slacrawl analytics trends [--weeks 8]  [--workspace X] [--channel C]
```

- `internal/report/quiet.go` (+137): channels whose newest message is older than `--since` (archive candidates). Zero-activity channels listed too.
- `internal/report/trends.go` (+175): week-bucketed message counts per channel, zero-filled across the window.
- `internal/cli/analytics.go` (+120): dispatcher + flag parsing. `analytics digest` routes to the existing `runDigest` path so a single implementation serves both entry points.
- `internal/cli/render.go` (+133): special-block renderers for `Analytics Quiet` and `Analytics Trends` in the text format. JSON format works via the shared struct encoding.
- `internal/cli/completion.go` (+61/-1): analytics subcommand completion for bash/zsh.
- Tests: `quiet_test.go`, `trends_test.go`, `analytics_test.go` cover quiet+stale channels, weekly zero-fill across a sparse 3-week seed, and the CLI dispatcher in both text and JSON formats.
- README and SPEC updated.

No schema changes. No new go.mod deps. No changes to `slacrawl digest` behavior.

## Testing

```
gofmt -l .                       # clean
go vet ./...
go build ./cmd/slacrawl
go test ./...                    # all pass, 3 new test files
```

## Demo

![analytics demo](https://github.com/mvanhorn/slacrawl/releases/download/evidence-pr3-1776897526/pr3_analytics.gif)

Shows the subcommand usage, digest on imported data, quiet (all 3 channels quiet in a 7-day window), trends (zero-filled weekly buckets for channel `general`), and a `diff` confirming `slacrawl digest` and `slacrawl analytics digest` produce identical output.

## Open questions for the maintainer

1. **Namespace**: went with `analytics` per the plan doc. Alternatives: `insights`, `stats`. Happy to rename if you prefer.
2. **`internal/report/` vs `internal/analytics/`**: kept everything in `internal/report/` alongside `digest.go` to match your current organization. If you'd rather carve out an `internal/analytics/` package, one PR to do the split cleanly.
3. **Subsequent phases**: planning to ship `health` + `response-times` as one PR, then `threads-stale` + `activity` as a last PR. Flag if you'd rather see a different slicing or pause here.

This contribution was developed with AI assistance.
