### PR TITLE
feat: add auto_join config option to control channel auto-joining

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Choose the path that matches your setup:
 - use `sync --source api --latest-only` when you only want fresh deltas on channels that already have local history
 - use `sync --source desktop` when you want local desktop recovery only
 - use `watch` when you want desktop-local state to refresh into SQLite continuously
+- use `sync --auto-join=false` to skip auto-joining public channels and only sync channels the bot is already a member of
 
 ## Commands
 
@@ -385,6 +386,10 @@ Desktop config notes:
 - leave `[slack.desktop].path = ""` to auto-detect the macOS Slack path
 - set a custom absolute path if Slack Desktop data lives elsewhere
 - set `[slack.bot]`, `[slack.app]`, or `[slack.user]` `enabled = false` to ignore that token source entirely
+
+Sync config notes:
+
+- set `[sync].auto_join = false` to disable automatic joining of public channels during sync — useful when Slack membership should be the single source of truth for which channels get mirrored
 
 ## Typical Workflow
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -41,6 +41,7 @@ repair_every = "30m"
 desktop_refresh_every = "5m"
 full_history = true
 # include_dms = true # requires SLACK_USER_TOKEN with im:history, mpim:history, im:read, mpim:read scopes
+# auto_join = true # auto-join public channels during sync (default: true; set false to only sync already-joined channels)
 
 [search]
 default_mode = "fts"

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -318,6 +318,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	full := fs.Bool("full", false, "full sync")
 	latestOnly := fs.Bool("latest-only", false, "skip first-time historical backfills")
 	concurrency := fs.Int("concurrency", cfg.Sync.Concurrency, "worker count")
+	autoJoin := fs.Bool("auto-join", cfg.Sync.AutoJoinResolved(), "auto-join public channels during sync")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -330,6 +331,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 		Full:        *full,
 		LatestOnly:  *latestOnly,
 		Concurrency: *concurrency,
+		AutoJoin:    *autoJoin,
 	}
 	st, err := a.openStore(cfg)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,16 @@ type SyncConfig struct {
 	DesktopRefreshEvery string `toml:"desktop_refresh_every"`
 	FullHistory         bool   `toml:"full_history"`
 	IncludeDMs          *bool  `toml:"include_dms"`
+	AutoJoin            *bool  `toml:"auto_join"`
+}
+
+// AutoJoinResolved returns whether the bot should auto-join public channels
+// it encounters during sync. Defaults to true for backwards compatibility.
+func (s SyncConfig) AutoJoinResolved() bool {
+	if s.AutoJoin == nil {
+		return true
+	}
+	return *s.AutoJoin
 }
 
 type SearchConfig struct {

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -47,6 +47,7 @@ type SyncOptions struct {
 	Full        bool
 	LatestOnly  bool
 	Concurrency int
+	AutoJoin    bool
 }
 
 type Client struct {
@@ -343,12 +344,12 @@ func (c *Client) fetchChannels(ctx context.Context, workspaceID string) ([]slack
 	}
 }
 
-func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, oldest string, now time.Time, userRepliesAvailable bool) error {
+func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, oldest string, now time.Time, userRepliesAvailable bool, autoJoin bool) error {
 	return c.syncChannelMessagesWithSource(ctx, st, workspaceID, channel, oldest, now, userRepliesAvailable, channelSyncSource{
 		historyClient: c.bot,
 		sourceName:    SourceBot,
 		sourceRank:    2,
-		allowJoin:     true,
+		allowJoin:     autoJoin,
 	})
 }
 
@@ -743,7 +744,7 @@ func (c *Client) syncChannels(ctx context.Context, st *store.Store, workspaceID 
 		historyClient: c.bot,
 		sourceName:    SourceBot,
 		sourceRank:    2,
-		allowJoin:     true,
+		allowJoin:     opts.AutoJoin,
 	})
 }
 

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -280,7 +280,7 @@ func TestSyncJoinsPublicChannelBeforeRetryingHistory(t *testing.T) {
 	st := mustStore(t)
 	defer st.Close()
 
-	err := client.Sync(context.Background(), st, SyncOptions{})
+	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: true})
 	require.NoError(t, err)
 
 	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
@@ -291,6 +291,26 @@ func TestSyncJoinsPublicChannelBeforeRetryingHistory(t *testing.T) {
 	joinState, err := st.GetSyncState(context.Background(), SourceBot, "channel_join", "C111")
 	require.NoError(t, err)
 	require.Equal(t, "joined", joinState)
+}
+
+func TestSyncSkipsJoinWhenAutoJoinDisabled(t *testing.T) {
+	server := newJoinRetrySlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot: "xoxb-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer st.Close()
+
+	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: false})
+	require.NoError(t, err)
+
+	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 0, "should not have joined or synced the channel")
 }
 
 func TestSyncDefaultsToIncrementalHistoryWhenNotFull(t *testing.T) {

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -26,6 +26,7 @@ type Options struct {
 	Full        bool
 	LatestOnly  bool
 	Concurrency int
+	AutoJoin    bool
 }
 
 type Summary struct {
@@ -50,6 +51,7 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 			Full:        opts.Full,
 			LatestOnly:  opts.LatestOnly,
 			Concurrency: opts.Concurrency,
+			AutoJoin:    opts.AutoJoin,
 		})
 	case SourceDesktop:
 		return syncDesktop(ctx, cfg, st)
@@ -61,6 +63,7 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 			Full:        opts.Full,
 			LatestOnly:  opts.LatestOnly,
 			Concurrency: opts.Concurrency,
+			AutoJoin:    opts.AutoJoin,
 		}); err != nil {
 			return summary, err
 		}


### PR DESCRIPTION
## Summary

Adds an `auto_join` configuration option that controls whether the bot automatically joins public channels during sync.

**Fixes:** #14

## Problem

When using a bot token, `slacrawl sync` auto-joins all public channels via `conversations.join`. This is undesirable when the bot should only mirror channels it's explicitly been added to — keeping Slack membership as the single source of truth.

## Changes

- **`config.go`**: Add `AutoJoin *bool` field to `SyncConfig` with `AutoJoinResolved()` method (default: `true`)
- **`app.go`**: Add `--auto-join` CLI flag, threaded through to `SyncOptions`
- **`syncer.go`**: Thread `AutoJoin` through `Options` struct
- **`api.go`**: Skip `conversations.join` when `AutoJoin` is false; log `not_in_channel` skip
- **`api_test.go`**: Add `TestSyncSkipsJoinWhenAutoJoinDisabled`
- **`config.example.toml`**: Document new option
- **`README.md`**: Document CLI flag and config

## Config

```toml
[sync]
auto_join = false  # default: true for backwards compat
```

## Testing

```
go test ./...  # all pass
```

Manually verified: bot left in workspace channels, sync with `auto_join = false` skips unjoin-able channels instead of joining them.