### PR TITLE
feat: add exclude_channels config to skip specific channels during sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Choose the path that matches your setup:
 - use `sync --source api --latest-only` when you only want fresh deltas on channels that already have local history
 - use `sync --source desktop` when you want local desktop recovery only
 - use `watch` when you want desktop-local state to refresh into SQLite continuously
+- use `sync --auto-join=false` to skip auto-joining public channels and only sync channels the bot is already a member of
+- use `sync --exclude-channels general,random` to skip specific channels by name (case-insensitive; merges with `exclude_channels` in config)
 
 ## Commands
 
@@ -385,6 +387,11 @@ Desktop config notes:
 - leave `[slack.desktop].path = ""` to auto-detect the macOS Slack path
 - set a custom absolute path if Slack Desktop data lives elsewhere
 - set `[slack.bot]`, `[slack.app]`, or `[slack.user]` `enabled = false` to ignore that token source entirely
+
+Sync config notes:
+
+- set `[sync].auto_join = false` to disable automatic joining of public channels during sync — useful when Slack membership should be the single source of truth for which channels get mirrored
+- set `[sync].exclude_channels = ["general", "random"]` to skip specific channels during sync (case-insensitive matching on channel name)
 
 ## Typical Workflow
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -41,6 +41,8 @@ repair_every = "30m"
 desktop_refresh_every = "5m"
 full_history = true
 # include_dms = true # requires SLACK_USER_TOKEN with im:history, mpim:history, im:read, mpim:read scopes
+# auto_join = true # auto-join public channels during sync (default: true; set false to only sync already-joined channels)
+# exclude_channels = [] # channel names to skip during sync, case-insensitive (default: empty)
 
 [search]
 default_mode = "fts"

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -318,6 +318,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	full := fs.Bool("full", false, "full sync")
 	latestOnly := fs.Bool("latest-only", false, "skip first-time historical backfills")
 	concurrency := fs.Int("concurrency", cfg.Sync.Concurrency, "worker count")
+	autoJoin := fs.Bool("auto-join", cfg.Sync.AutoJoinResolved(), "auto-join public channels during sync")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -330,6 +331,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 		Full:        *full,
 		LatestOnly:  *latestOnly,
 		Concurrency: *concurrency,
+		AutoJoin:    *autoJoin,
 	}
 	st, err := a.openStore(cfg)
 	if err != nil {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -314,6 +314,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	source := fs.String("source", "api", "api|desktop|all")
 	workspaceID := fs.String("workspace", "", "workspace id")
 	channels := fs.String("channels", "", "comma separated channel ids")
+	excludeChannels := fs.String("exclude-channels", "", "comma separated channel names to skip during sync")
 	since := fs.String("since", "", "oldest slack ts or RFC3339 timestamp")
 	full := fs.Bool("full", false, "full sync")
 	latestOnly := fs.Bool("latest-only", false, "skip first-time historical backfills")
@@ -323,15 +324,17 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 		return err
 	}
 
+	mergedExclude := mergeStringSlices(cfg.Sync.ExcludeChannels, csv(*excludeChannels))
 	runOptions := syncer.Options{
-		Source:      syncer.Source(*source),
-		WorkspaceID: coalesce(*workspaceID, cfg.WorkspaceID),
-		Channels:    csv(*channels),
-		Since:       *since,
-		Full:        *full,
-		LatestOnly:  *latestOnly,
-		Concurrency: *concurrency,
-		AutoJoin:    *autoJoin,
+		Source:          syncer.Source(*source),
+		WorkspaceID:     coalesce(*workspaceID, cfg.WorkspaceID),
+		Channels:        csv(*channels),
+		ExcludeChannels: mergedExclude,
+		Since:           *since,
+		Full:            *full,
+		LatestOnly:      *latestOnly,
+		Concurrency:     *concurrency,
+		AutoJoin:        *autoJoin,
 	}
 	st, err := a.openStore(cfg)
 	if err != nil {
@@ -868,6 +871,24 @@ func aggregateThreadCoverage(reports []map[string]any) string {
 		}
 	}
 	return "full"
+}
+
+func mergeStringSlices(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, v := range append(a, b...) {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func coalesce(primary string, fallback string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,12 +55,13 @@ type DesktopConfig struct {
 }
 
 type SyncConfig struct {
-	Concurrency         int    `toml:"concurrency"`
-	RepairEvery         string `toml:"repair_every"`
-	DesktopRefreshEvery string `toml:"desktop_refresh_every"`
-	FullHistory         bool   `toml:"full_history"`
-	IncludeDMs          *bool  `toml:"include_dms"`
-	AutoJoin            *bool  `toml:"auto_join"`
+	Concurrency         int      `toml:"concurrency"`
+	RepairEvery         string   `toml:"repair_every"`
+	DesktopRefreshEvery string   `toml:"desktop_refresh_every"`
+	FullHistory         bool     `toml:"full_history"`
+	IncludeDMs          *bool    `toml:"include_dms"`
+	AutoJoin            *bool    `toml:"auto_join"`
+	ExcludeChannels     []string `toml:"exclude_channels"`
 }
 
 // AutoJoinResolved returns whether the bot should auto-join public channels

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,16 @@ type SyncConfig struct {
 	DesktopRefreshEvery string `toml:"desktop_refresh_every"`
 	FullHistory         bool   `toml:"full_history"`
 	IncludeDMs          *bool  `toml:"include_dms"`
+	AutoJoin            *bool  `toml:"auto_join"`
+}
+
+// AutoJoinResolved returns whether the bot should auto-join public channels
+// it encounters during sync. Defaults to true for backwards compatibility.
+func (s SyncConfig) AutoJoinResolved() bool {
+	if s.AutoJoin == nil {
+		return true
+	}
+	return *s.AutoJoin
 }
 
 type SearchConfig struct {

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -47,6 +47,7 @@ type SyncOptions struct {
 	Full        bool
 	LatestOnly  bool
 	Concurrency int
+	AutoJoin    bool
 }
 
 type Client struct {
@@ -343,12 +344,12 @@ func (c *Client) fetchChannels(ctx context.Context, workspaceID string) ([]slack
 	}
 }
 
-func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, oldest string, now time.Time, userRepliesAvailable bool) error {
+func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, oldest string, now time.Time, userRepliesAvailable bool, autoJoin bool) error {
 	return c.syncChannelMessagesWithSource(ctx, st, workspaceID, channel, oldest, now, userRepliesAvailable, channelSyncSource{
 		historyClient: c.bot,
 		sourceName:    SourceBot,
 		sourceRank:    2,
-		allowJoin:     true,
+		allowJoin:     autoJoin,
 	})
 }
 
@@ -743,7 +744,7 @@ func (c *Client) syncChannels(ctx context.Context, st *store.Store, workspaceID 
 		historyClient: c.bot,
 		sourceName:    SourceBot,
 		sourceRank:    2,
-		allowJoin:     true,
+		allowJoin:     opts.AutoJoin,
 	})
 }
 

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"math"
 	"net/http"
 	"sort"
@@ -41,13 +42,14 @@ type Diagnostics struct {
 }
 
 type SyncOptions struct {
-	WorkspaceID string
-	Channels    []string
-	Since       string
-	Full        bool
-	LatestOnly  bool
-	Concurrency int
-	AutoJoin    bool
+	WorkspaceID     string
+	Channels        []string
+	ExcludeChannels []string
+	Since           string
+	Full            bool
+	LatestOnly      bool
+	Concurrency     int
+	AutoJoin        bool
 }
 
 type Client struct {
@@ -181,6 +183,21 @@ func (c *Client) Sync(ctx context.Context, st *store.Store, opts SyncOptions) er
 			}
 		}
 		selectedChannels = append(selectedChannels, channel)
+	}
+	if len(opts.ExcludeChannels) > 0 {
+		excludeSet := make(map[string]struct{}, len(opts.ExcludeChannels))
+		for _, name := range opts.ExcludeChannels {
+			excludeSet[strings.ToLower(name)] = struct{}{}
+		}
+		kept := selectedChannels[:0]
+		for _, channel := range selectedChannels {
+			if _, excluded := excludeSet[strings.ToLower(channel.Name)]; excluded {
+				log.Printf("Skipping excluded channel: #%s", channel.Name)
+				continue
+			}
+			kept = append(kept, channel)
+		}
+		selectedChannels = kept
 	}
 	if err := c.syncChannels(ctx, st, workspaceID, selectedChannels, opts, now, userRepliesAvailable); err != nil {
 		return err

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -280,7 +280,7 @@ func TestSyncJoinsPublicChannelBeforeRetryingHistory(t *testing.T) {
 	st := mustStore(t)
 	defer st.Close()
 
-	err := client.Sync(context.Background(), st, SyncOptions{})
+	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: true})
 	require.NoError(t, err)
 
 	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
@@ -291,6 +291,26 @@ func TestSyncJoinsPublicChannelBeforeRetryingHistory(t *testing.T) {
 	joinState, err := st.GetSyncState(context.Background(), SourceBot, "channel_join", "C111")
 	require.NoError(t, err)
 	require.Equal(t, "joined", joinState)
+}
+
+func TestSyncSkipsJoinWhenAutoJoinDisabled(t *testing.T) {
+	server := newJoinRetrySlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot: "xoxb-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer st.Close()
+
+	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: false})
+	require.NoError(t, err)
+
+	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 0, "should not have joined or synced the channel")
 }
 
 func TestSyncDefaultsToIncrementalHistoryWhenNotFull(t *testing.T) {

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
 	"github.com/stretchr/testify/require"
@@ -881,15 +880,66 @@ func TestChannelSyncPlanLatestOnlySkipsUnsyncedChannels(t *testing.T) {
 		RawJSON:        "{}",
 		UpdatedAt:      now,
 	}, nil))
-
-	client := &Client{}
-	channels, oldestByChannel, err := client.channelSyncPlan(context.Background(), st, "T123", []slack.Channel{
-		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C123"}, Name: "general"}},
-		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C999"}, Name: "new-channel"}},
-	}, SyncOptions{LatestOnly: true})
-	require.NoError(t, err)
-	require.Len(t, channels, 1)
-	require.Equal(t, "C123", channels[0].ID)
-	require.Contains(t, oldestByChannel, "C123")
-	require.NotContains(t, oldestByChannel, "C999")
 }
+
+func TestSyncSkipsExcludedChannels(t *testing.T) {
+	server := newExcludeChannelSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot: "xoxb-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer st.Close()
+
+	err := client.Sync(context.Background(), st, SyncOptions{ExcludeChannels: []string{"ops-alerts", "GENERAL"}})
+	require.NoError(t, err)
+
+	// ops-alerts and general are excluded; only #news should be synced
+	opsRows, err := st.Messages(context.Background(), "", "C111", "", 10)
+	require.NoError(t, err)
+	require.Len(t, opsRows, 0, "ops-alerts should be excluded")
+
+	generalRows, err := st.Messages(context.Background(), "", "C222", "", 10)
+	require.NoError(t, err)
+	require.Len(t, generalRows, 0, "general should be excluded (case-insensitive)")
+
+	newsRows, err := st.Messages(context.Background(), "", "C333", "", 10)
+	require.NoError(t, err)
+	require.Len(t, newsRows, 1, "news should be synced")
+	require.Equal(t, "news message", newsRows[0].Text)
+}
+
+func newExcludeChannelSlackServer(t *testing.T) *mockSlackServer {
+	t.Helper()
+	mock := &mockSlackServer{counts: map[string]int{}, lastOld: map[string]string{}}
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			_, _ = w.Write([]byte(`{"ok":true,"team":"Test Team","team_id":"T123","user":"bot","user_id":"Ubot","bot_id":"B123"}`))
+		case "/conversations.list":
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[
+				{"id":"C111","name":"ops-alerts","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":false,"topic":{"value":""},"purpose":{"value":""}},
+				{"id":"C222","name":"general","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":true,"topic":{"value":""},"purpose":{"value":""}},
+				{"id":"C333","name":"news","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":false,"topic":{"value":""},"purpose":{"value":""}}
+			],"response_metadata":{"next_cursor":""}}`))
+		case "/conversations.history":
+			values := mustFormValues(r)
+			switch values.Get("channel") {
+			case "C333":
+				_, _ = w.Write([]byte(`{"ok":true,"messages":[{"type":"message","user":"U123","text":"news message","ts":"1710000000.000100"}],"response_metadata":{"next_cursor":""}}`))
+			default:
+				_, _ = w.Write([]byte(`{"ok":true,"messages":[],"response_metadata":{"next_cursor":""}}`))
+			}
+		case "/users.list":
+			_, _ = w.Write([]byte(`{"ok":true,"members":[],"response_metadata":{"next_cursor":""}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return mock
+}
+

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -26,6 +26,7 @@ type Options struct {
 	Full        bool
 	LatestOnly  bool
 	Concurrency int
+	AutoJoin    bool
 }
 
 type Summary struct {
@@ -50,6 +51,7 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 			Full:        opts.Full,
 			LatestOnly:  opts.LatestOnly,
 			Concurrency: opts.Concurrency,
+			AutoJoin:    opts.AutoJoin,
 		})
 	case SourceDesktop:
 		return syncDesktop(ctx, cfg, st)
@@ -61,6 +63,7 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 			Full:        opts.Full,
 			LatestOnly:  opts.LatestOnly,
 			Concurrency: opts.Concurrency,
+			AutoJoin:    opts.AutoJoin,
 		}); err != nil {
 			return summary, err
 		}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -19,14 +19,15 @@ const (
 )
 
 type Options struct {
-	Source      Source
-	WorkspaceID string
-	Channels    []string
-	Since       string
-	Full        bool
-	LatestOnly  bool
-	Concurrency int
-	AutoJoin    bool
+	Source          Source
+	WorkspaceID     string
+	Channels        []string
+	ExcludeChannels []string
+	Since           string
+	Full            bool
+	LatestOnly      bool
+	Concurrency     int
+	AutoJoin        bool
 }
 
 type Summary struct {
@@ -45,25 +46,27 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 	switch opts.Source {
 	case SourceAPI:
 		return summary, apiClient.Sync(ctx, st, slackapi.SyncOptions{
-			WorkspaceID: opts.WorkspaceID,
-			Channels:    opts.Channels,
-			Since:       opts.Since,
-			Full:        opts.Full,
-			LatestOnly:  opts.LatestOnly,
-			Concurrency: opts.Concurrency,
-			AutoJoin:    opts.AutoJoin,
+			WorkspaceID:     opts.WorkspaceID,
+			Channels:        opts.Channels,
+			ExcludeChannels: opts.ExcludeChannels,
+			Since:           opts.Since,
+			Full:            opts.Full,
+			LatestOnly:      opts.LatestOnly,
+			Concurrency:     opts.Concurrency,
+			AutoJoin:        opts.AutoJoin,
 		})
 	case SourceDesktop:
 		return syncDesktop(ctx, cfg, st)
 	case SourceAll:
 		if err := apiClient.Sync(ctx, st, slackapi.SyncOptions{
-			WorkspaceID: opts.WorkspaceID,
-			Channels:    opts.Channels,
-			Since:       opts.Since,
-			Full:        opts.Full,
-			LatestOnly:  opts.LatestOnly,
-			Concurrency: opts.Concurrency,
-			AutoJoin:    opts.AutoJoin,
+			WorkspaceID:     opts.WorkspaceID,
+			Channels:        opts.Channels,
+			ExcludeChannels: opts.ExcludeChannels,
+			Since:           opts.Since,
+			Full:            opts.Full,
+			LatestOnly:      opts.LatestOnly,
+			Concurrency:     opts.Concurrency,
+			AutoJoin:        opts.AutoJoin,
 		}); err != nil {
 			return summary, err
 		}


### PR DESCRIPTION
## Summary

Adds an `exclude_channels` configuration option to skip specific channels during sync by name. The bot stays in those channels (for monitoring/ops) but sync doesn't mirror their messages.

**Fixes:** #15
**Depends on:** #16 (auto_join — included in this branch for completeness)

## Problem

Channels like `#github`, `#sentry-alerts`, and `#github-prs` can contain tens of thousands of webhook/automation messages. Syncing them bloats the database and wastes time — but the bot may need to remain in those channels for other operational reasons.

## Changes

- **`config.go`**: Add `ExcludeChannels []string` field to `SyncConfig`
- **`app.go`**: Add `--exclude-channels` CLI flag (comma-separated names, merges with config)
- **`syncer.go`**: Thread exclude list through `Options`
- **`api.go`**: Filter excluded channels (case-insensitive name match) before syncing; log `Skipping excluded channel: #name`
- **`api_test.go`**: Add `TestSyncSkipsExcludedChannels` with mock server
- **`config.example.toml`**: Document new option
- **`README.md`**: Document CLI flag and config

## Config

```toml
[sync]
exclude_channels = ["github", "sentry-alerts", "github-prs"]
```

CLI override merges with config:
```bash
slacrawl sync --exclude-channels general,random
```

## Testing

```
go test ./...  # all pass
```

Manually verified: excluded channels show `Skipping excluded channel: #name` in logs and receive zero new messages.