### PR TITLE
test: fix analytics trends current-week flake

### DIFF
--- a/internal/cli/analytics_test.go
+++ b/internal/cli/analytics_test.go
@@ -121,7 +121,11 @@ func TestAnalyticsTrendsCommand(t *testing.T) {
 
 	seed := func(channelID string, weekStart time.Time, count int) {
 		for i := 0; i < count; i++ {
-			ts := fmt.Sprintf("%d.%06d", weekStart.Add(time.Duration(i+1)*time.Hour).Unix(), i+1)
+			seedTime := weekStart.Add(time.Duration(i+1) * time.Hour)
+			if weekStart.Equal(currentWeekStart) {
+				seedTime = now
+			}
+			ts := fmt.Sprintf("%d.%06d", seedTime.Unix(), i+1)
 			require.NoError(t, st.UpsertMessage(ctx, store.Message{
 				ChannelID:      channelID,
 				TS:             ts,


### PR DESCRIPTION
## Summary
- fix a flake in `TestAnalyticsTrendsCommand`
- keep current-week seeded messages at the test's current timestamp so they are never in the future
- leave production analytics behavior unchanged

## Root cause
`TestAnalyticsTrendsCommand` seeded current-week messages at `weekStart + 1h` and `+2h`, while the analytics query only includes messages with timestamps `<= time.Now()`. Early Monday UTC, one of those seeded messages can still be in the future, so the test fails even though the code is behaving correctly.

## Testing
- `go test ./internal/cli -run TestAnalyticsTrendsCommand -count=20`
- `go test ./...`
