### PR TITLE
feat: add exclude_channels config option to skip channels during sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Choose the path that matches your setup:
 - use `sync --source api --full` only when you want a deliberate full backfill
 - use `sync --source api --latest-only` when you only want fresh deltas on channels that already have local history
 - use `sync --source api --auto-join=false` to skip auto-joining public channels and only sync channels the bot is already a member of
+- use `sync --exclude-channels general,random` to skip specific channels by name (case-insensitive; merges with `exclude_channels` in config)
 - use `sync --source desktop` when you want local desktop recovery only
 - use `watch` when you want desktop-local state to refresh into SQLite continuously
 
@@ -390,6 +391,7 @@ Desktop config notes:
 Sync config notes:
 
 - set `[sync].auto_join = false` to disable automatic joining of public channels during sync and only mirror channels the bot can already read
+- set `[sync].exclude_channels = ["general", "random"]` to skip specific channels during sync (case-insensitive matching on channel name)
 
 ## Typical Workflow
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -154,6 +154,7 @@ Expected flags:
 - `--source api|desktop|all`
 - `--workspace <id>`
 - `--channels <csv>`
+- `--exclude-channels <csv>`
 - `--since <timestamp>`
 - `--full`
 - `--latest-only`
@@ -273,6 +274,7 @@ Credential model:
 - optional `[[workspaces]]` entries can override bot/app/user token env vars per workspace
 - workspace token lookup should default to `SLACK_<WORKSPACE_ID>_BOT_TOKEN`, `SLACK_<WORKSPACE_ID>_APP_TOKEN`, and `SLACK_<WORKSPACE_ID>_USER_TOKEN`
 - `[sync].auto_join` defaults to `true` and controls whether API sync attempts to join public channels before retrying history
+- `[sync].exclude_channels` is an optional case-insensitive list of channel names to skip during API sync and merges with `--exclude-channels`
 
 Share config:
 
@@ -297,18 +299,19 @@ Share config:
    - `--full` disables incremental cutoffs
    - `--latest-only` skips channels that do not already have a stored cursor
    - otherwise reuse the latest stored per-channel timestamp with overlap
-7. fetch users
-8. backfill message history
-9. when `auto_join` is enabled, attempt public-channel join and retry once on `not_in_channel`
-10. backfill thread replies only when a user token is configured and successfully auths
-11. normalize messages
+7. apply any configured or CLI-provided excluded channel-name filters after channel discovery and allow-list filtering
+8. fetch users
+9. backfill message history
+10. when `auto_join` is enabled, attempt public-channel join and retry once on `not_in_channel`
+11. backfill thread replies only when a user token is configured and successfully auths
+12. normalize messages
    - repair malformed UTF-8 before indexing
    - normalize indexed text with NFKC
    - strip zero-width and non-printable control noise
    - collapse odd whitespace for stable FTS / mention extraction
-12. upsert canonical rows
-13. update FTS rows and mentions
-14. write checkpoints, channel skips, and join attempts
+13. upsert canonical rows
+14. update FTS rows and mentions
+15. write checkpoints, channel skips, and join attempts
 
 ### Git share sync
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -42,6 +42,7 @@ desktop_refresh_every = "5m"
 full_history = true
 # include_dms = true # requires SLACK_USER_TOKEN with im:history, mpim:history, im:read, mpim:read scopes
 # auto_join = true # auto-join public channels during sync (default: true; set false to only sync already-joined channels)
+# exclude_channels = [] # channel names to skip during sync, case-insensitive (default: empty)
 
 [search]
 default_mode = "fts"

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -314,6 +314,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	source := fs.String("source", "api", "api|desktop|all")
 	workspaceID := fs.String("workspace", "", "workspace id")
 	channels := fs.String("channels", "", "comma separated channel ids")
+	excludeChannels := fs.String("exclude-channels", "", "comma separated channel names to skip during sync")
 	since := fs.String("since", "", "oldest slack ts or RFC3339 timestamp")
 	full := fs.Bool("full", false, "full sync")
 	latestOnly := fs.Bool("latest-only", false, "skip first-time historical backfills")
@@ -327,6 +328,10 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 		Source:      syncer.Source(*source),
 		WorkspaceID: coalesce(*workspaceID, cfg.WorkspaceID),
 		Channels:    csv(*channels),
+		ExcludeChannels: mergeStringSlices(
+			cfg.Sync.ExcludeChannels,
+			csv(*excludeChannels),
+		),
 		Since:       *since,
 		Full:        *full,
 		LatestOnly:  *latestOnly,
@@ -737,6 +742,26 @@ func csv(value string) []string {
 		part = strings.TrimSpace(part)
 		if part != "" {
 			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func mergeStringSlices(values ...[]string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, list := range values {
+		for _, value := range list {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			key := strings.ToLower(strings.TrimPrefix(value, "#"))
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, value)
 		}
 	}
 	return out

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -46,6 +46,14 @@ func TestParseLookback(t *testing.T) {
 	}
 }
 
+func TestMergeStringSlicesDedupesCaseInsensitive(t *testing.T) {
+	got := mergeStringSlices(
+		[]string{"general", " Ops-Alerts "},
+		[]string{"#GENERAL", "random", "ops-alerts", ""},
+	)
+	require.Equal(t, []string{"general", "Ops-Alerts", "random"}, got)
+}
+
 func TestDigestCommandJSON(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,12 +55,13 @@ type DesktopConfig struct {
 }
 
 type SyncConfig struct {
-	Concurrency         int    `toml:"concurrency"`
-	RepairEvery         string `toml:"repair_every"`
-	DesktopRefreshEvery string `toml:"desktop_refresh_every"`
-	FullHistory         bool   `toml:"full_history"`
-	IncludeDMs          *bool  `toml:"include_dms"`
-	AutoJoin            *bool  `toml:"auto_join"`
+	Concurrency         int      `toml:"concurrency"`
+	RepairEvery         string   `toml:"repair_every"`
+	DesktopRefreshEvery string   `toml:"desktop_refresh_every"`
+	FullHistory         bool     `toml:"full_history"`
+	IncludeDMs          *bool    `toml:"include_dms"`
+	AutoJoin            *bool    `toml:"auto_join"`
+	ExcludeChannels     []string `toml:"exclude_channels"`
 }
 
 // AutoJoinResolved returns whether the bot should auto-join public channels

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"math"
 	"net/http"
 	"sort"
@@ -41,13 +42,14 @@ type Diagnostics struct {
 }
 
 type SyncOptions struct {
-	WorkspaceID string
-	Channels    []string
-	Since       string
-	Full        bool
-	LatestOnly  bool
-	Concurrency int
-	AutoJoin    *bool
+	WorkspaceID     string
+	Channels        []string
+	ExcludeChannels []string
+	Since           string
+	Full            bool
+	LatestOnly      bool
+	Concurrency     int
+	AutoJoin        *bool
 }
 
 func (o SyncOptions) AutoJoinResolved() bool {
@@ -189,6 +191,7 @@ func (c *Client) Sync(ctx context.Context, st *store.Store, opts SyncOptions) er
 		}
 		selectedChannels = append(selectedChannels, channel)
 	}
+	selectedChannels = filterExcludedChannels(selectedChannels, opts.ExcludeChannels)
 	if err := c.syncChannels(ctx, st, workspaceID, selectedChannels, opts, now, userRepliesAvailable); err != nil {
 		return err
 	}
@@ -259,6 +262,36 @@ func (c *Client) Sync(ctx context.Context, st *store.Store, opts SyncOptions) er
 		return err
 	}
 	return st.SetSyncState(ctx, SourceBot, "workspace", workspaceID, now.Format(time.RFC3339))
+}
+
+func filterExcludedChannels(channels []slack.Channel, excludeNames []string) []slack.Channel {
+	if len(channels) == 0 || len(excludeNames) == 0 {
+		return channels
+	}
+	excludeSet := make(map[string]struct{}, len(excludeNames))
+	for _, name := range excludeNames {
+		if key := normalizeChannelName(name); key != "" {
+			excludeSet[key] = struct{}{}
+		}
+	}
+	if len(excludeSet) == 0 {
+		return channels
+	}
+	kept := channels[:0]
+	for _, channel := range channels {
+		if _, excluded := excludeSet[normalizeChannelName(channel.Name)]; excluded {
+			log.Printf("Skipping excluded channel: #%s", channel.Name)
+			continue
+		}
+		kept = append(kept, channel)
+	}
+	return kept
+}
+
+func normalizeChannelName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.TrimPrefix(name, "#")
+	return strings.ToLower(name)
 }
 
 func (c *Client) Tail(ctx context.Context, st *store.Store, workspaceID string, repairEvery time.Duration) error {

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -897,3 +897,64 @@ func TestChannelSyncPlanLatestOnlySkipsUnsyncedChannels(t *testing.T) {
 	require.Contains(t, oldestByChannel, "C123")
 	require.NotContains(t, oldestByChannel, "C999")
 }
+
+func TestSyncSkipsExcludedChannels(t *testing.T) {
+	server := newExcludeChannelSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot: "xoxb-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer st.Close()
+
+	err := client.Sync(context.Background(), st, SyncOptions{ExcludeChannels: []string{" ops-alerts ", "#GENERAL"}})
+	require.NoError(t, err)
+
+	// ops-alerts and general are excluded; only #news should be synced
+	opsRows, err := st.Messages(context.Background(), "", "C111", "", 10)
+	require.NoError(t, err)
+	require.Len(t, opsRows, 0, "ops-alerts should be excluded")
+
+	generalRows, err := st.Messages(context.Background(), "", "C222", "", 10)
+	require.NoError(t, err)
+	require.Len(t, generalRows, 0, "general should be excluded (case-insensitive)")
+
+	newsRows, err := st.Messages(context.Background(), "", "C333", "", 10)
+	require.NoError(t, err)
+	require.Len(t, newsRows, 1, "news should be synced")
+	require.Equal(t, "news message", newsRows[0].Text)
+}
+
+func newExcludeChannelSlackServer(t *testing.T) *mockSlackServer {
+	t.Helper()
+	mock := &mockSlackServer{counts: map[string]int{}, lastOld: map[string]string{}}
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			_, _ = w.Write([]byte(`{"ok":true,"team":"Test Team","team_id":"T123","user":"bot","user_id":"Ubot","bot_id":"B123"}`))
+		case "/conversations.list":
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[
+				{"id":"C111","name":"ops-alerts","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":false,"topic":{"value":""},"purpose":{"value":""}},
+				{"id":"C222","name":"general","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":true,"topic":{"value":""},"purpose":{"value":""}},
+				{"id":"C333","name":"news","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":false,"topic":{"value":""},"purpose":{"value":""}}
+			],"response_metadata":{"next_cursor":""}}`))
+		case "/conversations.history":
+			values := mustFormValues(r)
+			switch values.Get("channel") {
+			case "C333":
+				_, _ = w.Write([]byte(`{"ok":true,"messages":[{"type":"message","user":"U123","text":"news message","ts":"1710000000.000100"}],"response_metadata":{"next_cursor":""}}`))
+			default:
+				_, _ = w.Write([]byte(`{"ok":true,"messages":[],"response_metadata":{"next_cursor":""}}`))
+			}
+		case "/users.list":
+			_, _ = w.Write([]byte(`{"ok":true,"members":[],"response_metadata":{"next_cursor":""}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return mock
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -19,14 +19,15 @@ const (
 )
 
 type Options struct {
-	Source      Source
-	WorkspaceID string
-	Channels    []string
-	Since       string
-	Full        bool
-	LatestOnly  bool
-	Concurrency int
-	AutoJoin    *bool
+	Source          Source
+	WorkspaceID     string
+	Channels        []string
+	ExcludeChannels []string
+	Since           string
+	Full            bool
+	LatestOnly      bool
+	Concurrency     int
+	AutoJoin        *bool
 }
 
 type Summary struct {
@@ -45,25 +46,27 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 	switch opts.Source {
 	case SourceAPI:
 		return summary, apiClient.Sync(ctx, st, slackapi.SyncOptions{
-			WorkspaceID: opts.WorkspaceID,
-			Channels:    opts.Channels,
-			Since:       opts.Since,
-			Full:        opts.Full,
-			LatestOnly:  opts.LatestOnly,
-			Concurrency: opts.Concurrency,
-			AutoJoin:    opts.AutoJoin,
+			WorkspaceID:     opts.WorkspaceID,
+			Channels:        opts.Channels,
+			ExcludeChannels: opts.ExcludeChannels,
+			Since:           opts.Since,
+			Full:            opts.Full,
+			LatestOnly:      opts.LatestOnly,
+			Concurrency:     opts.Concurrency,
+			AutoJoin:        opts.AutoJoin,
 		})
 	case SourceDesktop:
 		return syncDesktop(ctx, cfg, st)
 	case SourceAll:
 		if err := apiClient.Sync(ctx, st, slackapi.SyncOptions{
-			WorkspaceID: opts.WorkspaceID,
-			Channels:    opts.Channels,
-			Since:       opts.Since,
-			Full:        opts.Full,
-			LatestOnly:  opts.LatestOnly,
-			Concurrency: opts.Concurrency,
-			AutoJoin:    opts.AutoJoin,
+			WorkspaceID:     opts.WorkspaceID,
+			Channels:        opts.Channels,
+			ExcludeChannels: opts.ExcludeChannels,
+			Since:           opts.Since,
+			Full:            opts.Full,
+			LatestOnly:      opts.LatestOnly,
+			Concurrency:     opts.Concurrency,
+			AutoJoin:        opts.AutoJoin,
 		}); err != nil {
 			return summary, err
 		}


### PR DESCRIPTION
## Summary
- add `sync.exclude_channels` config support under `[sync]`
- add a `--exclude-channels` CLI flag for `slacrawl sync`
- merge CLI and config exclusions case-insensitively before channel sync
- skip excluded channels while leaving membership behavior unchanged
- document the new option in README, config example, and SPEC

## Notes
- split out from the closed combined PR #18 so this change can be reviewed independently
- intentionally scoped to `exclude_channels` only
- companion fix for the pre-existing main test flake: #19

## Testing
- `go build ./cmd/slacrawl`
- `go run ./cmd/slacrawl --help`
- `go run ./cmd/slacrawl completion bash`
- `go test ./...` currently reproduces the same pre-existing analytics flake on `main`; see #19

Closes #15
