### PR TITLE
feat: add auto_join config option to control channel auto-joining

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Choose the path that matches your setup:
 - use `sync --source api` for normal incremental syncs
 - use `sync --source api --full` only when you want a deliberate full backfill
 - use `sync --source api --latest-only` when you only want fresh deltas on channels that already have local history
+- use `sync --source api --auto-join=false` to skip auto-joining public channels and only sync channels the bot is already a member of
 - use `sync --source desktop` when you want local desktop recovery only
 - use `watch` when you want desktop-local state to refresh into SQLite continuously
 
@@ -385,6 +386,10 @@ Desktop config notes:
 - leave `[slack.desktop].path = ""` to auto-detect the macOS Slack path
 - set a custom absolute path if Slack Desktop data lives elsewhere
 - set `[slack.bot]`, `[slack.app]`, or `[slack.user]` `enabled = false` to ignore that token source entirely
+
+Sync config notes:
+
+- set `[sync].auto_join = false` to disable automatic joining of public channels during sync and only mirror channels the bot can already read
 
 ## Typical Workflow
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -158,6 +158,7 @@ Expected flags:
 - `--full`
 - `--latest-only`
 - `--concurrency <n>`
+- `--auto-join=<bool>`
 
 ### `doctor`
 
@@ -271,6 +272,7 @@ Credential model:
 - blank desktop path means auto-detect the supported macOS Slack path
 - optional `[[workspaces]]` entries can override bot/app/user token env vars per workspace
 - workspace token lookup should default to `SLACK_<WORKSPACE_ID>_BOT_TOKEN`, `SLACK_<WORKSPACE_ID>_APP_TOKEN`, and `SLACK_<WORKSPACE_ID>_USER_TOKEN`
+- `[sync].auto_join` defaults to `true` and controls whether API sync attempts to join public channels before retrying history
 
 Share config:
 
@@ -297,7 +299,7 @@ Share config:
    - otherwise reuse the latest stored per-channel timestamp with overlap
 7. fetch users
 8. backfill message history
-9. attempt public-channel join and retry once on `not_in_channel`
+9. when `auto_join` is enabled, attempt public-channel join and retry once on `not_in_channel`
 10. backfill thread replies only when a user token is configured and successfully auths
 11. normalize messages
    - repair malformed UTF-8 before indexing

--- a/config.example.toml
+++ b/config.example.toml
@@ -41,6 +41,7 @@ repair_every = "30m"
 desktop_refresh_every = "5m"
 full_history = true
 # include_dms = true # requires SLACK_USER_TOKEN with im:history, mpim:history, im:read, mpim:read scopes
+# auto_join = true # auto-join public channels during sync (default: true; set false to only sync already-joined channels)
 
 [search]
 default_mode = "fts"

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -318,6 +318,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	full := fs.Bool("full", false, "full sync")
 	latestOnly := fs.Bool("latest-only", false, "skip first-time historical backfills")
 	concurrency := fs.Int("concurrency", cfg.Sync.Concurrency, "worker count")
+	autoJoin := fs.Bool("auto-join", cfg.Sync.AutoJoinResolved(), "auto-join public channels during sync")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -330,6 +331,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 		Full:        *full,
 		LatestOnly:  *latestOnly,
 		Concurrency: *concurrency,
+		AutoJoin:    *autoJoin,
 	}
 	st, err := a.openStore(cfg)
 	if err != nil {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -331,7 +331,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 		Full:        *full,
 		LatestOnly:  *latestOnly,
 		Concurrency: *concurrency,
-		AutoJoin:    *autoJoin,
+		AutoJoin:    boolPtr(*autoJoin),
 	}
 	st, err := a.openStore(cfg)
 	if err != nil {
@@ -740,6 +740,10 @@ func csv(value string) []string {
 		}
 	}
 	return out
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func isValidChannelKind(kind string) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,16 @@ type SyncConfig struct {
 	DesktopRefreshEvery string `toml:"desktop_refresh_every"`
 	FullHistory         bool   `toml:"full_history"`
 	IncludeDMs          *bool  `toml:"include_dms"`
+	AutoJoin            *bool  `toml:"auto_join"`
+}
+
+// AutoJoinResolved returns whether the bot should auto-join public channels
+// it encounters during sync. Defaults to true for backwards compatibility.
+func (s SyncConfig) AutoJoinResolved() bool {
+	if s.AutoJoin == nil {
+		return true
+	}
+	return *s.AutoJoin
 }
 
 type SearchConfig struct {

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -47,7 +47,14 @@ type SyncOptions struct {
 	Full        bool
 	LatestOnly  bool
 	Concurrency int
-	AutoJoin    bool
+	AutoJoin    *bool
+}
+
+func (o SyncOptions) AutoJoinResolved() bool {
+	if o.AutoJoin == nil {
+		return true
+	}
+	return *o.AutoJoin
 }
 
 type Client struct {
@@ -744,7 +751,7 @@ func (c *Client) syncChannels(ctx context.Context, st *store.Store, workspaceID 
 		historyClient: c.bot,
 		sourceName:    SourceBot,
 		sourceRank:    2,
-		allowJoin:     opts.AutoJoin,
+		allowJoin:     opts.AutoJoinResolved(),
 	})
 }
 

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -47,6 +47,7 @@ type SyncOptions struct {
 	Full        bool
 	LatestOnly  bool
 	Concurrency int
+	AutoJoin    bool
 }
 
 type Client struct {
@@ -343,12 +344,12 @@ func (c *Client) fetchChannels(ctx context.Context, workspaceID string) ([]slack
 	}
 }
 
-func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, oldest string, now time.Time, userRepliesAvailable bool) error {
+func (c *Client) syncChannelMessages(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, oldest string, now time.Time, userRepliesAvailable bool, autoJoin bool) error {
 	return c.syncChannelMessagesWithSource(ctx, st, workspaceID, channel, oldest, now, userRepliesAvailable, channelSyncSource{
 		historyClient: c.bot,
 		sourceName:    SourceBot,
 		sourceRank:    2,
-		allowJoin:     true,
+		allowJoin:     autoJoin,
 	})
 }
 
@@ -743,7 +744,7 @@ func (c *Client) syncChannels(ctx context.Context, st *store.Store, workspaceID 
 		historyClient: c.bot,
 		sourceName:    SourceBot,
 		sourceRank:    2,
-		allowJoin:     true,
+		allowJoin:     opts.AutoJoin,
 	})
 }
 

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -280,7 +280,7 @@ func TestSyncJoinsPublicChannelBeforeRetryingHistory(t *testing.T) {
 	st := mustStore(t)
 	defer st.Close()
 
-	err := client.Sync(context.Background(), st, SyncOptions{})
+	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: true})
 	require.NoError(t, err)
 
 	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
@@ -291,6 +291,26 @@ func TestSyncJoinsPublicChannelBeforeRetryingHistory(t *testing.T) {
 	joinState, err := st.GetSyncState(context.Background(), SourceBot, "channel_join", "C111")
 	require.NoError(t, err)
 	require.Equal(t, "joined", joinState)
+}
+
+func TestSyncSkipsJoinWhenAutoJoinDisabled(t *testing.T) {
+	server := newJoinRetrySlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot: "xoxb-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer st.Close()
+
+	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: false})
+	require.NoError(t, err)
+
+	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 0, "should not have joined or synced the channel")
 }
 
 func TestSyncDefaultsToIncrementalHistoryWhenNotFull(t *testing.T) {

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -280,7 +280,7 @@ func TestSyncJoinsPublicChannelBeforeRetryingHistory(t *testing.T) {
 	st := mustStore(t)
 	defer st.Close()
 
-	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: true})
+	err := client.Sync(context.Background(), st, SyncOptions{})
 	require.NoError(t, err)
 
 	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
@@ -305,12 +305,16 @@ func TestSyncSkipsJoinWhenAutoJoinDisabled(t *testing.T) {
 	st := mustStore(t)
 	defer st.Close()
 
-	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: false})
+	err := client.Sync(context.Background(), st, SyncOptions{AutoJoin: testBoolPtr(false)})
 	require.NoError(t, err)
 
 	rows, err := st.Messages(context.Background(), "", "C111", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 0, "should not have joined or synced the channel")
+}
+
+func testBoolPtr(value bool) *bool {
+	return &value
 }
 
 func TestSyncDefaultsToIncrementalHistoryWhenNotFull(t *testing.T) {

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -26,6 +26,7 @@ type Options struct {
 	Full        bool
 	LatestOnly  bool
 	Concurrency int
+	AutoJoin    bool
 }
 
 type Summary struct {
@@ -50,6 +51,7 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 			Full:        opts.Full,
 			LatestOnly:  opts.LatestOnly,
 			Concurrency: opts.Concurrency,
+			AutoJoin:    opts.AutoJoin,
 		})
 	case SourceDesktop:
 		return syncDesktop(ctx, cfg, st)
@@ -61,6 +63,7 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 			Full:        opts.Full,
 			LatestOnly:  opts.LatestOnly,
 			Concurrency: opts.Concurrency,
+			AutoJoin:    opts.AutoJoin,
 		}); err != nil {
 			return summary, err
 		}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -26,7 +26,7 @@ type Options struct {
 	Full        bool
 	LatestOnly  bool
 	Concurrency int
-	AutoJoin    bool
+	AutoJoin    *bool
 }
 
 type Summary struct {


### PR DESCRIPTION
## Summary
- add `sync.auto_join` config support under `[sync]`
- add a `--auto-join` CLI flag for `slacrawl sync`
- skip `conversations.join` when auto-join is disabled and rely on existing membership instead
- document the new option in README, config example, and SPEC

## Notes
- split out from the closed combined PR #18 so this change can be reviewed independently
- intentionally scoped to `auto_join` only
- companion fix for the pre-existing main test flake: #19

## Testing
- `go build ./cmd/slacrawl`
- `go run ./cmd/slacrawl --help`
- `go run ./cmd/slacrawl completion bash`
- `go test ./...` currently reproduces the same pre-existing analytics flake on `main`; see #19

Closes #14
