### PR TITLE
fix(ci): allow auto-assign on PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   assign:


### PR DESCRIPTION
## Summary
- grant `pull-requests: write` to the Auto Assign workflow
- fixes PR auto-assignment failures on fork-authored pull requests

## Root cause
The `issues.addAssignees` endpoint for pull requests requires pull request write permission. The workflow only granted `pull-requests: read`, so `pull_request_target` runs failed with `403 Resource not accessible by integration`.

## Testing
- `go test ./...`
- `go build ./cmd/slacrawl`
