### PR TITLE
fix(cli): align digest format and help flags

### DIFF
--- a/internal/cli/analytics_test.go
+++ b/internal/cli/analytics_test.go
@@ -51,6 +51,11 @@ func TestAnalyticsDigestCommand(t *testing.T) {
 	require.Equal(t, digest["top_n"], analyticsDigest["top_n"])
 	require.Equal(t, digest["totals"], analyticsDigest["totals"])
 	require.Equal(t, digest["channels"], analyticsDigest["channels"])
+
+	stdout.Reset()
+	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "analytics", "digest", "--since", "7d", "--workspace", "T1", "--format", "json"}))
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &analyticsDigest))
+	require.Equal(t, digest["totals"], analyticsDigest["totals"])
 }
 
 func TestAnalyticsQuietCommand(t *testing.T) {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -103,7 +103,7 @@ func (a *App) Run(ctx context.Context, args []string) error {
 	case "update":
 		return a.runUpdate(ctx, *configPath, rest[1:], outputFormat)
 	case "status":
-		return a.runStatus(ctx, *configPath, outputFormat)
+		return a.runStatus(ctx, *configPath, rest[1:], outputFormat)
 	case "sync":
 		return a.runSync(ctx, *configPath, rest[1:], outputFormat)
 	case "import":
@@ -282,7 +282,15 @@ func (a *App) runDoctor(ctx context.Context, configPath string, format OutputFor
 	return a.writeOutput("Doctor", report, format, true)
 }
 
-func (a *App) runStatus(ctx context.Context, configPath string, format OutputFormat) error {
+func (a *App) runStatus(ctx context.Context, configPath string, args []string, format OutputFormat) error {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
 	cfg, err := loadConfig(configPath)
 	if err != nil {
 		return err
@@ -629,12 +637,18 @@ func (a *App) runDigest(ctx context.Context, configPath string, args []string, f
 	workspaceID := fs.String("workspace", "", "workspace id")
 	channel := fs.String("channel", "", "channel id or name")
 	topN := fs.Int("top-n", 1, "number of top posters and mentions per channel")
+	formatFlag := fs.String("format", string(format), "output format: text|json|log")
+	jsonOut := fs.Bool("json", false, "json output")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	lookback, err := parseLookback(*since)
 	if err != nil {
 		return fmt.Errorf("parse --since: %w", err)
+	}
+	outputFormat, err := resolveOutputFormat(*formatFlag, *jsonOut)
+	if err != nil {
+		return err
 	}
 	st, err := a.openReadableStore(ctx, cfg)
 	if err != nil {
@@ -650,7 +664,7 @@ func (a *App) runDigest(ctx context.Context, configPath string, args []string, f
 	if err != nil {
 		return err
 	}
-	return a.writeOutput("Digest", digest, format, true)
+	return a.writeOutput("Digest", digest, outputFormat, true)
 }
 
 // parseLookback accepts Go durations (72h) plus the shorthand Nd for N days.

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -54,6 +54,17 @@ func TestMergeStringSlicesDedupesCaseInsensitive(t *testing.T) {
 	require.Equal(t, []string{"general", "Ops-Alerts", "random"}, got)
 }
 
+func TestStatusHelpDoesNotReadStore(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "missing.toml")
+
+	var stdout bytes.Buffer
+	app := &App{Stdout: &stdout, Stderr: &stdout}
+	require.NoError(t, app.Run(context.Background(), []string{"--config", configPath, "status", "--help"}))
+	require.Contains(t, stdout.String(), "Usage of status:")
+	require.NotContains(t, stdout.String(), "STATUS")
+}
+
 func TestDigestCommandJSON(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
@@ -457,6 +468,8 @@ func TestCompletionBashOutput(t *testing.T) {
 	require.Contains(t, out, "completion")
 	require.Contains(t, out, "report")
 	require.Contains(t, out, "--format")
+	require.Contains(t, out, "--exclude-channels")
+	require.Contains(t, out, "--auto-join")
 	require.Contains(t, out, "--kind")
 }
 
@@ -474,6 +487,8 @@ func TestCompletionZshOutput(t *testing.T) {
 	require.Contains(t, out, "_values 'shell' bash zsh")
 	require.Contains(t, out, "report")
 	require.Contains(t, out, "--no-color")
+	require.Contains(t, out, "--exclude-channels")
+	require.Contains(t, out, "--auto-join")
 	require.Contains(t, out, "public_channel")
 }
 

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -42,12 +42,12 @@ var (
 		"init":       {"--workspace", "--db", "--help", "-h"},
 		"doctor":     {"--help", "-h"},
 		"report":     {"--help", "-h"},
-		"digest":     {"--since", "--workspace", "--channel", "--top-n", "--help", "-h"},
+		"digest":     {"--since", "--workspace", "--channel", "--top-n", "--format", "--json", "--help", "-h"},
 		"analytics":  {"digest", "quiet", "trends", "--help", "-h"},
 		"publish":    {"--repo", "--remote", "--branch", "--message", "--no-commit", "--push", "--help", "-h"},
 		"subscribe":  {"--repo", "--db", "--remote", "--branch", "--stale-after", "--no-auto-update", "--no-import", "--help", "-h"},
 		"update":     {"--repo", "--remote", "--branch", "--help", "-h"},
-		"sync":       {"--source", "--workspace", "--channels", "--since", "--full", "--latest-only", "--concurrency", "--help", "-h"},
+		"sync":       {"--source", "--workspace", "--channels", "--exclude-channels", "--since", "--full", "--latest-only", "--concurrency", "--auto-join", "--help", "-h"},
 		"import":     {"--workspace", "--dry-run", "--force", "--format", "--help", "-h"},
 		"tail":       {"--workspace", "--repair-every", "--help", "-h"},
 		"watch":      {"--desktop-every", "--help", "-h"},
@@ -146,7 +146,7 @@ _slacrawl()
             COMPREPLY=( $(compgen -W "--help -h ${global_flags}" -- "${cur}") )
             ;;
         digest)
-            COMPREPLY=( $(compgen -W "--since --workspace --channel --top-n --help -h ${global_flags}" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "--since --workspace --channel --top-n --format --json --help -h ${global_flags}" -- "${cur}") )
             ;;
         analytics)
             local analytics_subcommand=""
@@ -160,7 +160,7 @@ _slacrawl()
             done
             case "${analytics_subcommand}" in
                 digest)
-                    COMPREPLY=( $(compgen -W "--since --workspace --channel --top-n --help -h ${global_flags}" -- "${cur}") )
+                    COMPREPLY=( $(compgen -W "--since --workspace --channel --top-n --format --json --help -h ${global_flags}" -- "${cur}") )
                     ;;
                 quiet)
                     COMPREPLY=( $(compgen -W "--since --workspace --format --json --help -h ${global_flags}" -- "${cur}") )
@@ -183,7 +183,7 @@ _slacrawl()
             COMPREPLY=( $(compgen -W "--repo --remote --branch --help -h ${global_flags}" -- "${cur}") )
             ;;
         sync)
-            COMPREPLY=( $(compgen -W "--source --workspace --channels --since --full --latest-only --concurrency --help -h ${global_flags}" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "--source --workspace --channels --exclude-channels --since --full --latest-only --concurrency --auto-join --help -h ${global_flags}" -- "${cur}") )
             ;;
         import)
             COMPREPLY=( $(compgen -W "--workspace --dry-run --force --format --help -h ${global_flags}" -- "${cur}") )
@@ -260,7 +260,7 @@ _slacrawl() {
           _arguments '--help[show help]'
           ;;
         digest)
-          _arguments '--since[lookback window]:duration:' '--workspace[workspace id]:workspace id:' '--channel[channel id or name]:channel:' '--top-n[top posters and mentions per channel]:count:'
+          _arguments '--since[lookback window]:duration:' '--workspace[workspace id]:workspace id:' '--channel[channel id or name]:channel:' '--top-n[top posters and mentions per channel]:count:' '--format[output format]:format:(text json log)' '--json[json output]'
           ;;
         analytics)
           if (( CURRENT == 3 )); then
@@ -268,7 +268,7 @@ _slacrawl() {
           else
             case $words[3] in
               digest)
-                _arguments '--since[lookback window]:duration:' '--workspace[workspace id]:workspace id:' '--channel[channel id or name]:channel:' '--top-n[top posters and mentions per channel]:count:'
+                _arguments '--since[lookback window]:duration:' '--workspace[workspace id]:workspace id:' '--channel[channel id or name]:channel:' '--top-n[top posters and mentions per channel]:count:' '--format[output format]:format:(text json log)' '--json[json output]'
                 ;;
               quiet)
                 _arguments '--since[lookback window]:duration:' '--workspace[workspace id]:workspace id:' '--format[output format]:format:(text json log)' '--json[json output]'
@@ -292,7 +292,7 @@ _slacrawl() {
           _arguments '--repo[local clone path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:'
           ;;
         sync)
-          _arguments '--source[sync source]:source:(api desktop all)' '--workspace[workspace id]:workspace id:' '--channels[channel ids]:channels:' '--since[start timestamp]:timestamp:' '--full[run full sync]' '--latest-only[skip first-time historical backfills]' '--concurrency[worker count]:count:'
+          _arguments '--source[sync source]:source:(api desktop all)' '--workspace[workspace id]:workspace id:' '--channels[channel ids]:channels:' '--exclude-channels[channel names]:channels:' '--since[start timestamp]:timestamp:' '--full[run full sync]' '--latest-only[skip first-time historical backfills]' '--concurrency[worker count]:count:' '--auto-join[auto-join public channels]:bool:(true false)'
           ;;
         import)
           _arguments '--workspace[workspace id]:workspace id:' '--dry-run[walk and count without writing]' '--force[overwrite existing slack-export rows at the same rank]' '--format[output format]:format:(text json log)'


### PR DESCRIPTION
## Summary
- let `digest` and `analytics digest` accept local `--format` and `--json` flags
- make `status --help` print usage without opening the configured store
- update bash/zsh completions for the newly added sync flags and digest output flags

## Root cause
Live local smoke testing showed `analytics digest --format json` failed even though the analytics sibling commands accept local output flags. The `status` dispatch also ignored subcommand args, so `status --help` read and printed the live archive instead of help.

## Testing
- `go test ./internal/cli -run 'TestAnalyticsDigestCommand|TestStatusHelpDoesNotReadStore|TestCompletion' -count=3`
- `go test ./...`
- `go build ./cmd/slacrawl`
