### PR TITLE
fix(ci): run release actions on Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- opt the Release workflow into Node 24 for JavaScript actions
- removes the release annotation about `goreleaser/goreleaser-action@v6` still running on Node 20

## Root cause
The v0.6.0 release completed successfully, but GitHub emitted a deprecation warning because the GoReleaser action still ran under Node 20. GitHub recommends opting workflows into Node 24 now before the runner default changes.

## Testing
- `go test ./...`
- `go build ./cmd/slacrawl`
