### PR TITLE
fix(ci): upgrade release action to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,6 @@ on:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -37,7 +34,7 @@ jobs:
         run: go test ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/README.md
+++ b/README.md
@@ -88,15 +88,15 @@ Download the package that matches your platform from the [latest release](https:
 Debian/Ubuntu:
 
 ```bash
-curl -LO https://github.com/vincentkoc/slacrawl/releases/latest/download/slacrawl_0.6.0_amd64.deb
-sudo dpkg -i slacrawl_0.6.0_amd64.deb
+curl -LO https://github.com/vincentkoc/slacrawl/releases/latest/download/slacrawl_0.6.1_amd64.deb
+sudo dpkg -i slacrawl_0.6.1_amd64.deb
 ```
 
 RHEL/Fedora:
 
 ```bash
-curl -LO https://github.com/vincentkoc/slacrawl/releases/latest/download/slacrawl-0.6.0-1.x86_64.rpm
-sudo rpm -i slacrawl-0.6.0-1.x86_64.rpm
+curl -LO https://github.com/vincentkoc/slacrawl/releases/latest/download/slacrawl-0.6.1-1.x86_64.rpm
+sudo rpm -i slacrawl-0.6.1-1.x86_64.rpm
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- upgrade the release workflow from `goreleaser/goreleaser-action@v6` to `@v7`
- remove the temporary Node 24 force flag, since v7 is the real action-side fix
- update README package examples for the validation patch release `v0.6.1`

## Root cause
The previous workflow-level Node 24 opt-in changed the warning but did not remove the root cause: the v6 action still targets Node 20. A release workflow re-run also showed that re-publishing an already published tag fails on duplicate assets, so this needs validation through a fresh patch release tag.

## Testing
- `go test ./...`
- `go build ./cmd/slacrawl`
