### PR TITLE
fix(desktop): detect non-App Store Slack path and tolerate cross-work…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Search now treats normal CLI input as safe text instead of raw FTS syntax, with phrase, term, and substring fallback plus `--raw-fts` for advanced queries.
 - Wiretap desktop import now includes cached Slack DM and MPIM messages from IndexedDB redux state.
+- Desktop ingest now detects direct-download Slack installs and skips desktop-only cross-workspace collisions from IndexedDB snapshots. Thanks @caocuong2404.
 
 ## 0.6.2 - 2026-05-18
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 const (
 	defaultDirName     = ".slacrawl"
 	defaultDesktopPath = "~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack"
+	directDesktopPath  = "~/Library/Application Support/Slack"
 )
 
 type Config struct {
@@ -404,7 +405,7 @@ func sanitizeEnvSegment(value string) string {
 }
 
 func DetectDesktopPath() (string, error) {
-	candidates := []string{defaultDesktopPath}
+	candidates := []string{defaultDesktopPath, directDesktopPath}
 	for _, candidate := range candidates {
 		expanded, err := ExpandPath(candidate)
 		if err != nil {
@@ -414,7 +415,7 @@ func DetectDesktopPath() (string, error) {
 			return expanded, nil
 		}
 	}
-	return ExpandPath(defaultDesktopPath)
+	return "", nil
 }
 
 func ValidateTokenShape(value string, prefix string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,10 +117,23 @@ func TestDefaultConfigPath(t *testing.T) {
 }
 
 func TestNormalizeAutoDetectsDesktopPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "Library", "Application Support", "Slack"), 0o750))
+
 	cfg := Default()
 	cfg.Slack.Desktop.Path = ""
 	require.NoError(t, cfg.Normalize())
-	require.True(t, filepath.IsAbs(cfg.Slack.Desktop.Path))
+	require.Equal(t, filepath.Join(home, "Library", "Application Support", "Slack"), cfg.Slack.Desktop.Path)
+}
+
+func TestNormalizeLeavesDesktopPathEmptyWhenNoInstallFound(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := Default()
+	cfg.Slack.Desktop.Path = ""
+	require.NoError(t, cfg.Normalize())
+	require.Empty(t, cfg.Slack.Desktop.Path)
 }
 
 func TestNormalizeSetsDefaultWorkspaceFromWorkspaceList(t *testing.T) {

--- a/internal/slackdesktop/desktop_test.go
+++ b/internal/slackdesktop/desktop_test.go
@@ -382,6 +382,26 @@ func TestIngestReduxStatesSkipsDuplicateDesktopMessages(t *testing.T) {
 	}}, now))
 }
 
+func TestIngestReduxStatesSkipsDuplicateDesktopChannels(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, ingestReduxStates(ctx, st, []ReduxDecodedState{{
+		WorkspaceID: "T2",
+		UserID:      "U2",
+		Channels: []ReduxChannel{{
+			ID:            "C1",
+			Name:          "general",
+			IsChannel:     true,
+			ContextTeamID: "T2",
+		}},
+	}}, now))
+}
+
 func TestNormalizeReduxMessageIncludesBlocksAndAttachments(t *testing.T) {
 	normalized := normalizeReduxMessage(ReduxMessage{
 		Channel: "C111",

--- a/internal/slackdesktop/redux.go
+++ b/internal/slackdesktop/redux.go
@@ -180,6 +180,9 @@ func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecod
 				RawJSON:     store.MarshalRaw(member),
 				UpdatedAt:   now,
 			}); err != nil {
+				if strings.Contains(err.Error(), "already belongs to workspace") {
+					continue
+				}
 				return err
 			}
 		}
@@ -203,6 +206,9 @@ func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecod
 				RawJSON:     store.MarshalRaw(channel),
 				UpdatedAt:   now,
 			}); err != nil {
+				if strings.Contains(err.Error(), "already belongs to workspace") {
+					continue
+				}
 				return err
 			}
 			allowedChannels[channel.ID] = struct{}{}
@@ -237,6 +243,9 @@ func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecod
 				RawJSON:        store.MarshalRaw(message),
 				UpdatedAt:      now,
 			}, reduxMentions(message.Text)); err != nil {
+				if strings.Contains(err.Error(), "already belongs to workspace") {
+					continue
+				}
 				return err
 			}
 		}

--- a/internal/slackdesktop/redux.go
+++ b/internal/slackdesktop/redux.go
@@ -180,9 +180,6 @@ func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecod
 				RawJSON:     store.MarshalRaw(member),
 				UpdatedAt:   now,
 			}); err != nil {
-				if strings.Contains(err.Error(), "already belongs to workspace") {
-					continue
-				}
 				return err
 			}
 		}
@@ -206,7 +203,7 @@ func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecod
 				RawJSON:     store.MarshalRaw(channel),
 				UpdatedAt:   now,
 			}); err != nil {
-				if strings.Contains(err.Error(), "already belongs to workspace") {
+				if store.IsWorkspaceCollision(err, "channel") {
 					continue
 				}
 				return err
@@ -243,9 +240,6 @@ func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecod
 				RawJSON:        store.MarshalRaw(message),
 				UpdatedAt:      now,
 			}, reduxMentions(message.Text)); err != nil {
-				if strings.Contains(err.Error(), "already belongs to workspace") {
-					continue
-				}
 				return err
 			}
 		}


### PR DESCRIPTION
…space entities

DetectDesktopPath only checked the Mac App Store container path. Add the direct-download path (~/Library/Application Support/Slack) as a fallback candidate, and return empty when neither exists instead of returning a non-existent path.

Skip workspace collision errors during Redux ingestion for users, channels, and messages that legitimately appear across multiple workspaces (e.g. USLACKBOT).