### PR TITLE
feat: add MCP Slack sync source

### DIFF
--- a/.agents/skills/slacrawl/SKILL.md
+++ b/.agents/skills/slacrawl/SKILL.md
@@ -29,10 +29,11 @@ Refresh:
 
 ```bash
 slacrawl sync --source bot --latest-only
+slacrawl sync --source mcp --workspace T01234567
 slacrawl sync --source wiretap
 ```
 
-Use `--full` only for deliberate historical backfills. `bot` = API tokens; `wiretap` = Slack Desktop cache; `all` = API then desktop enrichment.
+Use `--full` only for deliberate historical backfills. `bot` = API tokens; `mcp` = configured HTTP or stdio Slack connector; `wiretap` = Slack Desktop cache; `all` = API then desktop enrichment.
 
 ## Query Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Added `sync --source mcp` for fetching Slack users, channels, messages, and threads through Codex's HTTP connector gateway or the reference Slack MCP server over stdio into the canonical SQLite archive.
+- Updated the minimum Go toolchain to 1.26.4 to pick up standard-library security fixes.
 
 ## 0.6.3 - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.6.4 - Unreleased
 
+### Changes
+
+- Added `sync --source mcp` for fetching Slack users, channels, messages, and threads through Codex's HTTP connector gateway or the reference Slack MCP server over stdio into the canonical SQLite archive.
+
 ## 0.6.3 - 2026-05-25
 
 ### Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 ARG ALPINE_VERSION=3.23
 
 FROM golang:${GO_VERSION}-alpine AS build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/vincentkoc/slacrawl" alt="License"></a>
-  <img src="https://img.shields.io/badge/go-1.26.3%2B-00ADD8" alt="Go 1.26.3+">
+  <img src="https://img.shields.io/badge/go-1.26.4%2B-00ADD8" alt="Go 1.26.4+">
   <img src="https://img.shields.io/badge/storage-SQLite-003B57" alt="SQLite">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey" alt="Platform">
 </p>
@@ -61,7 +61,7 @@ If one of those gaps matters to your workflow, open an issue so it can be tracke
 
 ## Requirements
 
-- Go `1.26.3+`
+- Go `1.26.4+`
 - `node` if you want richer desktop-local IndexedDB blob decoding
 - a Slack bot token for standard API sync
 - an app token if you want to use `tail`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Slack search is convenient until you need your own workflow, your own retention, or your own queries. `slacrawl` is a Go-based CLI that pulls Slack workspace metadata and message history into SQLite so you can inspect it without depending on the Slack UI.
 
-Data stays on your machine. You can run it in API mode, desktop mode, or a hybrid workflow that combines both. That covers one-shot syncs, live tailing over Socket Mode, and local desktop recovery or "wiretap" style inspection from Slack Desktop artifacts already on your machine.
+Data stays on your machine. You can run it in API mode, MCP connector mode, desktop mode, or a hybrid workflow. That covers one-shot syncs, live tailing over Socket Mode, connector-backed fetching, and local desktop recovery or "wiretap" style inspection from Slack Desktop artifacts already on your machine.
 
 ## Included
 
@@ -147,6 +147,7 @@ export SLACK_USER_TOKEN="xoxp-..."
 go run ./cmd/slacrawl init
 go run ./cmd/slacrawl doctor
 go run ./cmd/slacrawl sync --source bot
+go run ./cmd/slacrawl sync --source mcp --workspace T01234567
 go run ./cmd/slacrawl search --workspace T01234567 "incident"
 go run ./cmd/slacrawl analytics trends --weeks 4
 go run ./cmd/slacrawl tail --repair-every 30m
@@ -162,6 +163,7 @@ If you built the binary, replace `go run ./cmd/slacrawl` with `./bin/slacrawl`.
 Treat one `slacrawl` config/database as one Slack visibility boundary. The archive should mean "what this bot/account/profile can see", not a blend of unrelated personal and company backups.
 
 - `--source bot` is an alias for `--source api`; it crawls Slack through configured bot/user tokens
+- `--source mcp` fetches through Codex's HTTP Slack connector or the reference Slack MCP server over stdio and requires a workspace ID for archive ownership
 - `--source wiretap` is an alias for `--source desktop`; it reads the local Slack Desktop cache
 - `--source all` runs API first, then desktop enrichment
 - `[share]` is a backup/restore target for the current DB, not a second Slack source
@@ -173,6 +175,7 @@ Choose the path that matches your setup:
 - use `sync --source bot` for normal token-backed incremental syncs
 - use `sync --source bot --full` only when you want a deliberate full backfill
 - use `sync --source bot --latest-only` when you only want fresh deltas on channels that already have local history
+- use `sync --source mcp --workspace T01234567` when a configured HTTP or stdio MCP connector can read the workspace
 - use `sync --source wiretap` when you want local desktop recovery only
 - use `watch` when you want desktop-local state to refresh into SQLite continuously
 
@@ -184,7 +187,7 @@ Choose the path that matches your setup:
 - `publish` exports the local SQLite archive into a git repo as compressed JSONL shards plus a manifest
 - `subscribe` configures a git-backed reader that can run without Slack credentials
 - `update` pulls and imports the latest git snapshot
-- `sync` performs a one-shot crawl from bot/API, wiretap/desktop, or both
+- `sync` performs a one-shot crawl from bot/API, MCP connector, wiretap/desktop, or both
 - `import` imports a Slack export ZIP or extracted export directory
 - `tail` listens for live events through Socket Mode, including one tail per configured workspace
 - `watch` refreshes desktop-local state on a schedule

--- a/config.example.toml
+++ b/config.example.toml
@@ -37,6 +37,24 @@ token_env = "SLACK_USER_TOKEN"
 enabled = true
 path = ""
 
+[slack.mcp]
+enabled = true
+transport = "http"
+base_url = "https://chatgpt.com/backend-api/wham/apps"
+auth_path = "~/.codex/auth.json"
+token_env = "CODEX_APPS_ACCESS_TOKEN"
+account_id_env = "CODEX_APPS_ACCOUNT_ID"
+protocol_version = "2025-03-26"
+connector_id = ""
+channel_types = "public_channel,private_channel"
+page_size = 100
+search_limit = 20
+max_pages = 250
+# Reference Slack MCP server over stdio:
+# transport = "stdio"
+# command = "npx"
+# args = ["-y", "@modelcontextprotocol/server-slack"]
+
 [sync]
 concurrency = 4
 repair_every = "30m"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,19 @@ token_env = "SLACK_USER_TOKEN"
 enabled = true
 path = ""
 
+[slack.mcp]
+enabled = true
+base_url = "https://chatgpt.com/backend-api/wham/apps"
+auth_path = "~/.codex/auth.json"
+token_env = "CODEX_APPS_ACCESS_TOKEN"
+account_id_env = "CODEX_APPS_ACCOUNT_ID"
+protocol_version = "2025-03-26"
+connector_id = ""
+channel_types = "public_channel,private_channel"
+page_size = 100
+search_limit = 20
+max_pages = 250
+
 [sync]
 concurrency = 4
 repair_every = "30m"
@@ -97,6 +110,7 @@ Behavior:
 One config/database should represent one Slack visibility boundary: the messages visible to one bot/account/profile. Use ingestion sources to decide how that archive is populated:
 
 - `sync --source bot` is an alias for `sync --source api` and uses Slack bot/user tokens
+- `sync --source mcp` fetches from a Slack connector exposed by the configured HTTP JSON-RPC MCP gateway
 - `sync --source wiretap` is an alias for `sync --source desktop` and reads the local Slack Desktop cache
 - `sync --source all` runs token-backed sync first, then desktop enrichment
 - `[share]` backs up or restores the current DB; it is not a second Slack data source
@@ -120,6 +134,54 @@ db_path = "~/.slacrawl/personal.db"
 remote = "git@github.com:your-user/personal-slacrawl-archive.git"
 repo_path = "~/.slacrawl/personal-share"
 ```
+
+## MCP Connector Source
+
+MCP sync is an additional ingestion source; all reads still use the local slacrawl database. It discovers Slack tools with `tools/list`, calls the connector for users, channels, channel history, and threads, then normalizes the results into the same archive schema used by API and desktop sync.
+
+```bash
+slacrawl sync --source mcp --workspace T01234567
+slacrawl sync --source mcp --workspace T01234567 --channels C01234567 --since 1772574099.659199
+```
+
+The workspace ID is required because connector responses do not reliably carry archive ownership. `connector_id` is optional; when empty, tool discovery matches Slack tools by their names and metadata. Set it when multiple Slack connectors are exposed by one gateway.
+
+The default `transport = "http"` uses Codex's connector gateway:
+
+```toml
+[slack.mcp]
+enabled = true
+transport = "http"
+base_url = "https://chatgpt.com/backend-api/wham/apps"
+auth_path = "~/.codex/auth.json"
+```
+
+HTTP authentication order:
+
+1. The configured `token_env` and optional `account_id_env`.
+2. `CODEX_APPS_ACCESS_TOKEN` or `CODEX_CONNECTORS_TOKEN`.
+3. The configured `auth_path`, using Codex's `tokens.access_token` and optional `tokens.account_id` fields.
+
+`max_pages` bounds each users, channels, channel-history, and thread pagination loop; hitting the bound returns an error instead of silently accepting an incomplete page set. The Codex HTTP connector accepts at most 20 channel or user search results per request. Explicit channel IDs avoid global channel and user enumeration. Normal MCP sync overlaps the latest stored message timestamp per channel by one hour and rechecks persisted thread roots because Slack does not move an old root into channel history when it receives a new reply; `--full` removes the local channel cursor, while `--latest-only` skips channels with no local history. MCP is an explicit source and is not included in `--source all`.
+
+The connector's channel search response may omit privacy metadata. Those channels are stored with kind `mcp_channel` rather than being assumed public; they remain locally searchable but are not treated as public channels by archive export logic.
+
+For the archived MCP reference Slack server, use stdio and export the server's required `SLACK_BOT_TOKEN` and `SLACK_TEAM_ID` variables before running slacrawl:
+
+```toml
+[slack.mcp]
+enabled = true
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-slack"]
+page_size = 100
+search_limit = 100
+max_pages = 250
+```
+
+The subprocess inherits the current environment; secrets are not passed through TOML fields. The reference server exposes public or explicitly configured channels and does not paginate channel history. Therefore each sync imports only the latest `page_size` messages returned by `slack_get_channel_history`; `--since` filters that fetched window locally and `--full` cannot extend the server's history window. Channel and user listing still paginate normally. The npm package is deprecated and its upstream repository is archived, but this adapter supports its published tool contract.
+
+Tool discovery selects either the Codex Slack connector contract or the reference `slack_list_channels`, `slack_get_channel_history`, `slack_get_thread_replies`, and `slack_get_users` contract.
 
 ## Git Archive Sharing
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/slacrawl
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/alecthomas/kong v1.15.0

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -387,7 +387,18 @@ func (a *App) runDoctor(ctx context.Context, configPath string, args []string, f
 			"app_set":      tokens.App != "",
 			"user_set":     tokens.User != "",
 		},
-		"slack_api":         diag,
+		"slack_api": diag,
+		"mcp_source": map[string]any{
+			"enabled":          cfg.Slack.MCP.Enabled,
+			"transport":        cfg.Slack.MCP.Transport,
+			"base_url":         cfg.Slack.MCP.BaseURL,
+			"command":          cfg.Slack.MCP.Command,
+			"connector_id":     cfg.Slack.MCP.ConnectorID,
+			"token_env":        cfg.Slack.MCP.TokenEnv,
+			"token_set":        strings.TrimSpace(os.Getenv(cfg.Slack.MCP.TokenEnv)) != "",
+			"auth_path":        cfg.Slack.MCP.AuthPath,
+			"auth_path_exists": pathExists(cfg.Slack.MCP.AuthPath),
+		},
 		"workspace_api":     workspaceAPI,
 		"thread_coverage":   threadCoverage,
 		"desktop_source":    desktop,
@@ -507,7 +518,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 
 	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
-	source := fs.String("source", "api", "api|bot|desktop|wiretap|all")
+	source := fs.String("source", "api", "api|bot|desktop|wiretap|mcp|connector|all")
 	workspaceID := fs.String("workspace", "", "workspace id")
 	channels := fs.String("channels", "", "comma separated channel ids")
 	excludeChannels := fs.String("exclude-channels", "", "comma separated channel names to skip during sync")
@@ -1591,6 +1602,14 @@ func (a *App) runSyncTargets(ctx context.Context, cfg config.Config, st *store.S
 	if opts.Source == syncer.SourceDesktop {
 		return syncer.Run(ctx, cfg, st, opts)
 	}
+	if opts.Source == syncer.SourceMCP {
+		workspaceID, err := resolveMCPWorkspaceID(targets)
+		if err != nil {
+			return syncer.Summary{}, err
+		}
+		opts.WorkspaceID = workspaceID
+		return syncer.Run(ctx, cfg, st, opts)
+	}
 	if len(targets) == 0 {
 		return syncer.Run(ctx, cfg, st, opts)
 	}
@@ -1606,6 +1625,17 @@ func (a *App) runSyncTargets(ctx context.Context, cfg config.Config, st *store.S
 		last = summary
 	}
 	return last, nil
+}
+
+func resolveMCPWorkspaceID(targets []string) (string, error) {
+	switch len(targets) {
+	case 1:
+		return targets[0], nil
+	case 0:
+		return "", errors.New("workspace ID is required for MCP sync; set workspace_id or pass --workspace")
+	default:
+		return "", errors.New("MCP sync requires one workspace; pass --workspace when multiple workspaces are configured")
+	}
 }
 
 func (a *App) fetchMediaForSync(ctx context.Context, cfg config.Config, st *store.Store, workspaceID string, channels []string) (media.FetchStats, error) {
@@ -2087,6 +2117,12 @@ func archiveProfileFromConfig(cfg config.Config) archiveProfileResponse {
 			Configured: strings.TrimSpace(cfg.Slack.Desktop.Path) != "",
 		},
 		{
+			Name:       "mcp",
+			Label:      "Slack MCP connector visibility",
+			Enabled:    cfg.Slack.MCP.Enabled,
+			Configured: mcpConfigured(cfg.Slack.MCP),
+		},
+		{
 			Name:       "backup",
 			Label:      "Git archive backup/restore",
 			Enabled:    cfg.ShareEnabled(),
@@ -2097,6 +2133,13 @@ func archiveProfileFromConfig(cfg config.Config) archiveProfileResponse {
 		Mode:    archiveMode(sources),
 		Sources: sources,
 	}
+}
+
+func mcpConfigured(cfg config.MCPConfig) bool {
+	if strings.EqualFold(strings.TrimSpace(cfg.Transport), "stdio") {
+		return strings.TrimSpace(cfg.Command) != ""
+	}
+	return strings.TrimSpace(cfg.BaseURL) != ""
 }
 
 func (a *App) buildArchiveProfile(ctx context.Context, cfg config.Config, st *store.Store) (archiveProfileResponse, error) {
@@ -2192,7 +2235,7 @@ func hasAPITokens(cfg config.Config) bool {
 }
 
 func archiveMode(sources []sourceResponse) string {
-	var bot, wiretap, backup, imported bool
+	var bot, mcp, wiretap, backup, imported bool
 	for _, source := range sources {
 		hasData := source.Messages > 0 || source.LastSeenAt != "" || source.SyncEntries > 0
 		switch source.Name {
@@ -2200,6 +2243,8 @@ func archiveMode(sources []sourceResponse) string {
 			bot = hasData
 		case "wiretap":
 			wiretap = hasData
+		case "mcp":
+			mcp = hasData
 		case "backup":
 			backup = hasData
 		case "import":
@@ -2207,10 +2252,12 @@ func archiveMode(sources []sourceResponse) string {
 		}
 	}
 	switch {
-	case bot && wiretap:
+	case boolCount(bot, mcp, wiretap, backup, imported) > 1:
 		return "hybrid"
 	case bot:
 		return "bot"
+	case mcp:
+		return "mcp"
 	case wiretap:
 		return "wiretap"
 	case backup:
@@ -2220,6 +2267,24 @@ func archiveMode(sources []sourceResponse) string {
 	default:
 		return "empty"
 	}
+}
+
+func boolCount(values ...bool) int {
+	count := 0
+	for _, value := range values {
+		if value {
+			count++
+		}
+	}
+	return count
+}
+
+func pathExists(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func shareStateFromConfig(cfg config.Config) shareResponse {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -48,6 +48,18 @@ func TestParseLookback(t *testing.T) {
 	}
 }
 
+func TestResolveMCPWorkspaceID(t *testing.T) {
+	workspaceID, err := resolveMCPWorkspaceID([]string{"T123"})
+	require.NoError(t, err)
+	require.Equal(t, "T123", workspaceID)
+
+	_, err = resolveMCPWorkspaceID(nil)
+	require.ErrorContains(t, err, "workspace ID is required")
+
+	_, err = resolveMCPWorkspaceID([]string{"T1", "T2"})
+	require.ErrorContains(t, err, "pass --workspace")
+}
+
 func TestDigestCommandJSON(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
@@ -118,7 +130,7 @@ func TestInitStatusAndSQL(t *testing.T) {
 	require.Equal(t, float64(0), status["messages"])
 	profile := status["archive_profile"].(map[string]any)
 	require.Equal(t, "empty", profile["mode"])
-	require.Len(t, profile["sources"].([]any), 3)
+	require.Len(t, profile["sources"].([]any), 4)
 
 	stdout.Reset()
 	require.NoError(t, app.Run(ctx, []string{"--config", configPath, "--json", "sql", "select count(*) as messages from messages"}))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type SlackConfig struct {
 	App     TokenConfig   `toml:"app"`
 	User    TokenConfig   `toml:"user"`
 	Desktop DesktopConfig `toml:"desktop"`
+	MCP     MCPConfig     `toml:"mcp"`
 }
 
 type Workspace struct {
@@ -53,6 +54,23 @@ type TokenConfig struct {
 type DesktopConfig struct {
 	Enabled bool   `toml:"enabled"`
 	Path    string `toml:"path"`
+}
+
+type MCPConfig struct {
+	Enabled         bool     `toml:"enabled"`
+	Transport       string   `toml:"transport"`
+	BaseURL         string   `toml:"base_url"`
+	Command         string   `toml:"command"`
+	Args            []string `toml:"args"`
+	AuthPath        string   `toml:"auth_path"`
+	TokenEnv        string   `toml:"token_env"`
+	AccountIDEnv    string   `toml:"account_id_env"`
+	ConnectorID     string   `toml:"connector_id"`
+	ChannelTypes    string   `toml:"channel_types"`
+	PageSize        int      `toml:"page_size"`
+	SearchLimit     int      `toml:"search_limit"`
+	MaxPages        int      `toml:"max_pages"`
+	ProtocolVersion string   `toml:"protocol_version"`
 }
 
 type SyncConfig struct {
@@ -120,6 +138,19 @@ func Default() Config {
 			Desktop: DesktopConfig{
 				Enabled: true,
 				Path:    "",
+			},
+			MCP: MCPConfig{
+				Enabled:         true,
+				Transport:       "http",
+				BaseURL:         "https://chatgpt.com/backend-api/wham/apps",
+				AuthPath:        "~/.codex/auth.json",
+				TokenEnv:        "CODEX_APPS_ACCESS_TOKEN",
+				AccountIDEnv:    "CODEX_APPS_ACCOUNT_ID",
+				ChannelTypes:    "public_channel,private_channel",
+				PageSize:        100,
+				SearchLimit:     20,
+				MaxPages:        250,
+				ProtocolVersion: "2025-03-26",
 			},
 		},
 		Sync: SyncConfig{
@@ -192,6 +223,47 @@ func (c *Config) Normalize() error {
 	if c.Sync.DesktopRefreshEvery == "" {
 		c.Sync.DesktopRefreshEvery = "5m"
 	}
+	defaults := Default().Slack.MCP
+	if c.Slack.MCP.Transport == "" {
+		c.Slack.MCP.Transport = defaults.Transport
+	}
+	c.Slack.MCP.Transport = strings.ToLower(strings.TrimSpace(c.Slack.MCP.Transport))
+	if c.Slack.MCP.Transport != "http" && c.Slack.MCP.Transport != "stdio" {
+		return fmt.Errorf("slack.mcp.transport must be http or stdio, got %q", c.Slack.MCP.Transport)
+	}
+	if c.Slack.MCP.BaseURL == "" {
+		c.Slack.MCP.BaseURL = defaults.BaseURL
+	}
+	if c.Slack.MCP.Transport == "stdio" && strings.TrimSpace(c.Slack.MCP.Command) == "" {
+		return errors.New("slack.mcp.command is required for stdio transport")
+	}
+	if c.Slack.MCP.AuthPath == "" {
+		c.Slack.MCP.AuthPath = defaults.AuthPath
+	}
+	if c.Slack.MCP.TokenEnv == "" {
+		c.Slack.MCP.TokenEnv = defaults.TokenEnv
+	}
+	if c.Slack.MCP.AccountIDEnv == "" {
+		c.Slack.MCP.AccountIDEnv = defaults.AccountIDEnv
+	}
+	if c.Slack.MCP.ChannelTypes == "" {
+		c.Slack.MCP.ChannelTypes = defaults.ChannelTypes
+	}
+	if c.Slack.MCP.PageSize <= 0 {
+		c.Slack.MCP.PageSize = defaults.PageSize
+	}
+	if c.Slack.MCP.SearchLimit <= 0 {
+		c.Slack.MCP.SearchLimit = defaults.SearchLimit
+	}
+	if c.Slack.MCP.Transport == "http" && c.Slack.MCP.SearchLimit > 20 {
+		return errors.New("slack.mcp.search_limit cannot exceed 20")
+	}
+	if c.Slack.MCP.MaxPages < 0 {
+		return errors.New("slack.mcp.max_pages cannot be negative")
+	}
+	if c.Slack.MCP.ProtocolVersion == "" {
+		c.Slack.MCP.ProtocolVersion = defaults.ProtocolVersion
+	}
 	if c.Slack.Desktop.Enabled && strings.TrimSpace(c.Slack.Desktop.Path) == "" {
 		detected, err := DetectDesktopPath()
 		if err != nil {
@@ -200,7 +272,7 @@ func (c *Config) Normalize() error {
 		c.Slack.Desktop.Path = detected
 	}
 
-	paths := []*string{&c.DBPath, &c.CacheDir, &c.LogDir, &c.Slack.Desktop.Path, &c.Share.RepoPath}
+	paths := []*string{&c.DBPath, &c.CacheDir, &c.LogDir, &c.Slack.Desktop.Path, &c.Slack.MCP.AuthPath, &c.Share.RepoPath}
 	for _, candidate := range paths {
 		expanded, err := ExpandPath(*candidate)
 		if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,14 +100,59 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	cfg := Default()
 	cfg.WorkspaceID = "T123"
 	cfg.Share.Remote = "https://example.com/private/slacrawl.git"
+	cfg.Slack.MCP.Enabled = true
+	cfg.Slack.MCP.BaseURL = "https://mcp.example.test"
+	cfg.Slack.MCP.AuthPath = filepath.Join(dir, "auth.json")
 	require.NoError(t, cfg.Save(path))
 
 	loaded, err := Load(path)
 	require.NoError(t, err)
 	require.Equal(t, "T123", loaded.WorkspaceID)
+	require.True(t, loaded.Slack.MCP.Enabled)
+	require.Equal(t, "https://mcp.example.test", loaded.Slack.MCP.BaseURL)
+	require.True(t, filepath.IsAbs(loaded.Slack.MCP.AuthPath))
+	require.Equal(t, 100, loaded.Slack.MCP.PageSize)
+	require.Equal(t, 20, loaded.Slack.MCP.SearchLimit)
 	require.True(t, filepath.IsAbs(loaded.DBPath))
 	require.True(t, filepath.IsAbs(loaded.Share.RepoPath))
 	require.Equal(t, "https://example.com/private/slacrawl.git", loaded.Share.Remote)
+}
+
+func TestSaveAndLoadStdioMCPConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cfg := Default()
+	cfg.Slack.MCP.Transport = "stdio"
+	cfg.Slack.MCP.Command = "npx"
+	cfg.Slack.MCP.Args = []string{"-y", "@modelcontextprotocol/server-slack"}
+	require.NoError(t, cfg.Save(path))
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "stdio", loaded.Slack.MCP.Transport)
+	require.Equal(t, "npx", loaded.Slack.MCP.Command)
+	require.Equal(t, []string{"-y", "@modelcontextprotocol/server-slack"}, loaded.Slack.MCP.Args)
+}
+
+func TestNormalizeRejectsStdioMCPWithoutCommand(t *testing.T) {
+	cfg := Default()
+	cfg.Slack.MCP.Transport = "stdio"
+	cfg.Slack.MCP.Command = ""
+	require.ErrorContains(t, cfg.Normalize(), "command is required")
+}
+
+func TestNormalizeRejectsMCPSearchLimitAboveConnectorMaximum(t *testing.T) {
+	cfg := Default()
+	cfg.Slack.MCP.SearchLimit = 21
+	require.ErrorContains(t, cfg.Normalize(), "cannot exceed 20")
+}
+
+func TestNormalizeAllowsReferenceMCPSearchLimit(t *testing.T) {
+	cfg := Default()
+	cfg.Slack.MCP.Transport = "stdio"
+	cfg.Slack.MCP.Command = "server-slack"
+	cfg.Slack.MCP.SearchLimit = 100
+	require.NoError(t, cfg.Normalize())
 }
 
 func TestDefaultConfigPath(t *testing.T) {

--- a/internal/mcpclient/client.go
+++ b/internal/mcpclient/client.go
@@ -1,0 +1,293 @@
+package mcpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const DefaultProtocolVersion = "2025-03-26"
+
+type ToolMeta struct {
+	ConnectorID   string `json:"connector_id"`
+	ConnectorName string `json:"connector_name"`
+	ResourceURI   string `json:"resource_uri"`
+}
+
+type Tool struct {
+	Name        string          `json:"name"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+	Meta        *ToolMeta       `json:"_meta"`
+}
+
+type Options struct {
+	Endpoint        string
+	AccessToken     string
+	AccountID       string
+	ProtocolVersion string
+	ClientName      string
+	ClientVersion   string
+	HTTPClient      *http.Client
+}
+
+type Client struct {
+	endpoint        string
+	accessToken     string
+	accountID       string
+	protocolVersion string
+	clientName      string
+	clientVersion   string
+	httpClient      *http.Client
+	nextID          atomic.Int64
+}
+
+type Session interface {
+	Initialize(context.Context) error
+	ListTools(context.Context) ([]Tool, error)
+	CallToolText(context.Context, string, map[string]any) (string, error)
+	Close() error
+}
+
+type rpcEnvelope struct {
+	Result *json.RawMessage `json:"result"`
+	Error  *rpcError        `json:"error"`
+}
+
+type rpcError struct {
+	Code    int64           `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+type toolsPage struct {
+	Tools      []Tool `json:"tools"`
+	NextCursor string `json:"nextCursor"`
+}
+
+type toolCallResult struct {
+	IsError bool `json:"isError"`
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+func New(opts Options) (*Client, error) {
+	if strings.TrimSpace(opts.Endpoint) == "" {
+		return nil, errors.New("MCP endpoint is required")
+	}
+	if opts.ProtocolVersion == "" {
+		opts.ProtocolVersion = DefaultProtocolVersion
+	}
+	if opts.ClientName == "" {
+		opts.ClientName = "slacrawl"
+	}
+	if opts.ClientVersion == "" {
+		opts.ClientVersion = "dev"
+	}
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &Client{
+		endpoint:        strings.TrimSpace(opts.Endpoint),
+		accessToken:     strings.TrimSpace(opts.AccessToken),
+		accountID:       strings.TrimSpace(opts.AccountID),
+		protocolVersion: opts.ProtocolVersion,
+		clientName:      opts.ClientName,
+		clientVersion:   opts.ClientVersion,
+		httpClient:      opts.HTTPClient,
+	}, nil
+}
+
+func (c *Client) Close() error { return nil }
+
+func (c *Client) Initialize(ctx context.Context) error {
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := c.call(ctx, "initialize", map[string]any{
+		"protocolVersion": c.protocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    c.clientName,
+			"version": c.clientVersion,
+		},
+	}, &result); err != nil {
+		return err
+	}
+	if strings.TrimSpace(result.ProtocolVersion) == "" {
+		return errors.New("MCP initialize response missing protocolVersion")
+	}
+	return c.notify(ctx, "notifications/initialized", map[string]any{})
+}
+
+func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
+	var tools []Tool
+	cursor := ""
+	seen := map[string]bool{}
+	for {
+		params := map[string]any{}
+		if cursor != "" {
+			params["cursor"] = cursor
+		}
+		var page toolsPage
+		if err := c.call(ctx, "tools/list", params, &page); err != nil {
+			return nil, err
+		}
+		tools = append(tools, page.Tools...)
+		if strings.TrimSpace(page.NextCursor) == "" {
+			return tools, nil
+		}
+		if seen[page.NextCursor] {
+			return nil, fmt.Errorf("MCP tools/list repeated cursor %q", page.NextCursor)
+		}
+		seen[page.NextCursor] = true
+		cursor = page.NextCursor
+	}
+}
+
+func (c *Client) CallToolText(ctx context.Context, name string, arguments map[string]any) (string, error) {
+	var result toolCallResult
+	if err := c.call(ctx, "tools/call", map[string]any{
+		"name":      name,
+		"arguments": stripEmptyArguments(arguments),
+	}, &result); err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, len(result.Content))
+	for _, item := range result.Content {
+		if item.Type != "" && item.Type != "text" {
+			continue
+		}
+		if strings.TrimSpace(item.Text) != "" {
+			parts = append(parts, item.Text)
+		}
+	}
+	text := strings.Join(parts, "\n")
+	if result.IsError {
+		if text == "" {
+			return "", fmt.Errorf("MCP tool %q reported an error", name)
+		}
+		return "", fmt.Errorf("MCP tool %q reported an error: %s", name, text)
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", fmt.Errorf("MCP tool %q returned no text content", name)
+	}
+	return text, nil
+}
+
+func (c *Client) call(ctx context.Context, method string, params any, out any) error {
+	id := c.nextID.Add(1)
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	}
+	if c.accountID != "" {
+		req.Header.Set("ChatGPT-Account-ID", c.accountID)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("call MCP endpoint: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read MCP response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("MCP endpoint returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var envelope rpcEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("decode MCP JSON-RPC response: %w", err)
+	}
+	if envelope.Error != nil {
+		if len(envelope.Error.Data) > 0 {
+			return fmt.Errorf("MCP JSON-RPC error %d: %s (%s)", envelope.Error.Code, envelope.Error.Message, envelope.Error.Data)
+		}
+		return fmt.Errorf("MCP JSON-RPC error %d: %s", envelope.Error.Code, envelope.Error.Message)
+	}
+	if envelope.Result == nil {
+		return errors.New("MCP response missing result")
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(*envelope.Result, out); err != nil {
+		return fmt.Errorf("decode MCP %s result: %w", method, err)
+	}
+	return nil
+}
+
+func (c *Client) notify(ctx context.Context, method string, params any) error {
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	}
+	if c.accountID != "" {
+		req.Header.Set("ChatGPT-Account-ID", c.accountID)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("notify MCP endpoint: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read MCP notification response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("MCP notification returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return nil
+}
+
+func stripEmptyArguments(arguments map[string]any) map[string]any {
+	filtered := make(map[string]any, len(arguments))
+	for key, value := range arguments {
+		if value == nil {
+			continue
+		}
+		if text, ok := value.(string); ok && text == "" {
+			continue
+		}
+		filtered[key] = value
+	}
+	return filtered
+}

--- a/internal/mcpclient/client_test.go
+++ b/internal/mcpclient/client_test.go
@@ -1,0 +1,184 @@
+package mcpclient
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientInitializeListsToolsAndCallsTool(t *testing.T) {
+	listCalls := 0
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		require.Equal(t, "account", r.Header.Get("ChatGPT-Account-ID"))
+		var req struct {
+			Method string           `json:"method"`
+			Params map[string]any   `json:"params"`
+			ID     *json.RawMessage `json:"id"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		methods = append(methods, req.Method)
+		var result any
+		switch req.Method {
+		case "initialize":
+			result = map[string]any{"protocolVersion": DefaultProtocolVersion}
+		case "notifications/initialized":
+			require.Nil(t, req.ID)
+			w.WriteHeader(http.StatusAccepted)
+			return
+		case "tools/list":
+			listCalls++
+			if listCalls == 1 {
+				result = map[string]any{"tools": []map[string]any{{"name": "first"}}, "nextCursor": "next"}
+			} else {
+				require.Equal(t, "next", req.Params["cursor"])
+				result = map[string]any{"tools": []map[string]any{{"name": "second"}}, "nextCursor": ""}
+			}
+		case "tools/call":
+			args := req.Params["arguments"].(map[string]any)
+			require.NotContains(t, args, "empty")
+			result = map[string]any{"isError": false, "content": []map[string]any{{"type": "text", "text": "ok"}}}
+		default:
+			t.Fatalf("unexpected method %q", req.Method)
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": result}))
+	}))
+	defer server.Close()
+
+	client, err := New(Options{Endpoint: server.URL, AccessToken: "token", AccountID: "account"})
+	require.NoError(t, err)
+	require.NoError(t, client.Initialize(context.Background()))
+	tools, err := client.ListTools(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"first", "second"}, []string{tools[0].Name, tools[1].Name})
+	text, err := client.CallToolText(context.Background(), "first", map[string]any{"empty": "", "value": "yes"})
+	require.NoError(t, err)
+	require.Equal(t, "ok", text)
+	require.Equal(t, []string{"initialize", "notifications/initialized", "tools/list", "tools/list", "tools/call"}, methods)
+}
+
+func TestStdioClientInitializeListsToolsAndCallsTool(t *testing.T) {
+	t.Setenv("GO_WANT_MCP_STDIO_HELPER", "1")
+	client, err := NewStdio(context.Background(), StdioOptions{
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestMCPStdioHelperProcess"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, client.Initialize(context.Background()))
+	tools, err := client.ListTools(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"slack_list_channels"}, []string{tools[0].Name})
+	text, err := client.CallToolText(context.Background(), "slack_list_channels", map[string]any{"limit": 1})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true}`, text)
+	require.NoError(t, client.Close())
+}
+
+func TestStdioClientHandlesLargeOutputAndStderr(t *testing.T) {
+	t.Setenv("GO_WANT_MCP_STDIO_HELPER", "1")
+	client, err := NewStdio(context.Background(), StdioOptions{
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestMCPStdioHelperProcess"},
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, client.Close()) }()
+	require.NoError(t, client.Initialize(context.Background()))
+
+	text, err := client.CallToolText(context.Background(), "large", nil)
+	require.NoError(t, err)
+	require.Len(t, text, 128<<10)
+	require.Equal(t, strings.Repeat("x", 128<<10), text)
+}
+
+func TestStdioClientIgnoresLateCanceledResponse(t *testing.T) {
+	t.Setenv("GO_WANT_MCP_STDIO_HELPER", "1")
+	client, err := NewStdio(context.Background(), StdioOptions{
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestMCPStdioHelperProcess"},
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, client.Close()) }()
+	require.NoError(t, client.Initialize(context.Background()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = client.CallToolText(ctx, "slow", nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	time.Sleep(100 * time.Millisecond)
+	text, err := client.CallToolText(context.Background(), "fast", nil)
+	require.NoError(t, err)
+	require.Equal(t, "ok", text)
+}
+
+func TestMCPStdioHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_MCP_STDIO_HELPER") != "1" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 64<<10), 1<<20)
+	encoder := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		require.NoError(t, json.Unmarshal(scanner.Bytes(), &request))
+		if request.Method == "notifications/initialized" {
+			continue
+		}
+		var result any
+		switch request.Method {
+		case "initialize":
+			result = map[string]any{"protocolVersion": DefaultProtocolVersion}
+		case "tools/list":
+			result = map[string]any{"tools": []map[string]any{{"name": "slack_list_channels"}}}
+		case "tools/call":
+			var text string
+			switch request.Params.Name {
+			case "large":
+				_, err := fmt.Fprint(os.Stderr, strings.Repeat("e", 128<<10))
+				require.NoError(t, err)
+				text = strings.Repeat("x", 128<<10)
+			case "slow":
+				time.Sleep(75 * time.Millisecond)
+				text = "late"
+			case "fast":
+				text = "ok"
+			default:
+				text = `{"ok":true}`
+			}
+			result = map[string]any{"content": []map[string]any{{"type": "text", "text": text}}}
+		default:
+			t.Fatalf("unexpected method %q", request.Method)
+		}
+		require.NoError(t, encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": request.ID, "result": result}))
+	}
+	require.NoError(t, scanner.Err())
+}
+
+func TestClientRejectsRepeatedToolCursor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 1, "result": map[string]any{"tools": []any{}, "nextCursor": "same"},
+		}))
+	}))
+	defer server.Close()
+	client, err := New(Options{Endpoint: server.URL})
+	require.NoError(t, err)
+	_, err = client.ListTools(context.Background())
+	require.ErrorContains(t, err, "repeated cursor")
+}

--- a/internal/mcpclient/stdio.go
+++ b/internal/mcpclient/stdio.go
@@ -1,0 +1,278 @@
+package mcpclient
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type StdioOptions struct {
+	Command         string
+	Args            []string
+	ProtocolVersion string
+	ClientName      string
+	ClientVersion   string
+}
+
+type stdioResponse struct {
+	ID     json.RawMessage  `json:"id"`
+	Result *json.RawMessage `json:"result"`
+	Error  *rpcError        `json:"error"`
+}
+
+type stdioResult struct {
+	response stdioResponse
+	err      error
+}
+
+type StdioClient struct {
+	cmd             *exec.Cmd
+	stdin           io.WriteCloser
+	protocolVersion string
+	clientName      string
+	clientVersion   string
+	nextID          atomic.Int64
+	writeMu         sync.Mutex
+	pendingMu       sync.Mutex
+	pending         map[int64]chan stdioResult
+	waitCh          chan error
+	closeOnce       sync.Once
+	waitErr         error
+}
+
+func NewStdio(_ context.Context, opts StdioOptions) (*StdioClient, error) {
+	if strings.TrimSpace(opts.Command) == "" {
+		return nil, errors.New("MCP stdio command is required")
+	}
+	if opts.ProtocolVersion == "" {
+		opts.ProtocolVersion = DefaultProtocolVersion
+	}
+	if opts.ClientName == "" {
+		opts.ClientName = "slacrawl"
+	}
+	if opts.ClientVersion == "" {
+		opts.ClientVersion = "dev"
+	}
+	cmd := exec.Command(opts.Command, opts.Args...)
+	cmd.Env = os.Environ()
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open MCP stdio input: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("open MCP stdio output: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("open MCP stdio error output: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("start MCP stdio command %q: %w", opts.Command, err)
+	}
+	client := &StdioClient{
+		cmd: cmd, stdin: stdin, protocolVersion: opts.ProtocolVersion,
+		clientName: opts.ClientName, clientVersion: opts.ClientVersion,
+		pending: make(map[int64]chan stdioResult), waitCh: make(chan error, 1),
+	}
+	go func() { _, _ = io.Copy(io.Discard, stderr) }()
+	go client.readLoop(stdout)
+	go func() {
+		err := cmd.Wait()
+		processErr := errors.New("MCP stdio process exited")
+		if err != nil {
+			processErr = fmt.Errorf("MCP stdio process exited: %w", err)
+		}
+		client.failPending(processErr)
+		client.waitCh <- err
+	}()
+	return client, nil
+}
+
+func (c *StdioClient) Initialize(ctx context.Context) error {
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := c.call(ctx, "initialize", map[string]any{
+		"protocolVersion": c.protocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": c.clientName, "version": c.clientVersion},
+	}, &result); err != nil {
+		return err
+	}
+	if strings.TrimSpace(result.ProtocolVersion) == "" {
+		return errors.New("MCP initialize response missing protocolVersion")
+	}
+	return c.notify(ctx, "notifications/initialized", map[string]any{})
+}
+
+func (c *StdioClient) ListTools(ctx context.Context) ([]Tool, error) {
+	var tools []Tool
+	cursor := ""
+	seen := map[string]bool{}
+	for {
+		params := map[string]any{}
+		if cursor != "" {
+			params["cursor"] = cursor
+		}
+		var page toolsPage
+		if err := c.call(ctx, "tools/list", params, &page); err != nil {
+			return nil, err
+		}
+		tools = append(tools, page.Tools...)
+		if strings.TrimSpace(page.NextCursor) == "" {
+			return tools, nil
+		}
+		if seen[page.NextCursor] {
+			return nil, fmt.Errorf("MCP tools/list repeated cursor %q", page.NextCursor)
+		}
+		seen[page.NextCursor] = true
+		cursor = page.NextCursor
+	}
+}
+
+func (c *StdioClient) CallToolText(ctx context.Context, name string, arguments map[string]any) (string, error) {
+	var result toolCallResult
+	if err := c.call(ctx, "tools/call", map[string]any{"name": name, "arguments": stripEmptyArguments(arguments)}, &result); err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, len(result.Content))
+	for _, item := range result.Content {
+		if item.Type != "" && item.Type != "text" {
+			continue
+		}
+		if strings.TrimSpace(item.Text) != "" {
+			parts = append(parts, item.Text)
+		}
+	}
+	text := strings.Join(parts, "\n")
+	if result.IsError {
+		if text == "" {
+			return "", fmt.Errorf("MCP tool %q reported an error", name)
+		}
+		return "", fmt.Errorf("MCP tool %q reported an error: %s", name, text)
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", fmt.Errorf("MCP tool %q returned no text content", name)
+	}
+	return text, nil
+}
+
+func (c *StdioClient) call(ctx context.Context, method string, params any, out any) error {
+	id := c.nextID.Add(1)
+	resultCh := make(chan stdioResult, 1)
+	c.pendingMu.Lock()
+	c.pending[id] = resultCh
+	c.pendingMu.Unlock()
+	if err := c.write(ctx, map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params}); err != nil {
+		c.removePending(id)
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		c.removePending(id)
+		return ctx.Err()
+	case result := <-resultCh:
+		if result.err != nil {
+			return result.err
+		}
+		if result.response.Error != nil {
+			return fmt.Errorf("MCP JSON-RPC error %d: %s", result.response.Error.Code, result.response.Error.Message)
+		}
+		if result.response.Result == nil {
+			return errors.New("MCP response missing result")
+		}
+		if out == nil {
+			return nil
+		}
+		if err := json.Unmarshal(*result.response.Result, out); err != nil {
+			return fmt.Errorf("decode MCP %s result: %w", method, err)
+		}
+		return nil
+	}
+}
+
+func (c *StdioClient) notify(ctx context.Context, method string, params any) error {
+	return c.write(ctx, map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
+}
+
+func (c *StdioClient) write(ctx context.Context, value any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if _, err := c.stdin.Write(append(raw, '\n')); err != nil {
+		return fmt.Errorf("write MCP stdio request: %w", err)
+	}
+	return nil
+}
+
+func (c *StdioClient) readLoop(stdout io.Reader) {
+	decoder := json.NewDecoder(bufio.NewReader(stdout))
+	for {
+		var response stdioResponse
+		if err := decoder.Decode(&response); err != nil {
+			c.failPending(fmt.Errorf("decode MCP stdio JSON-RPC response: %w", err))
+			return
+		}
+		var id int64
+		if len(response.ID) == 0 || json.Unmarshal(response.ID, &id) != nil {
+			continue
+		}
+		c.pendingMu.Lock()
+		resultCh := c.pending[id]
+		delete(c.pending, id)
+		c.pendingMu.Unlock()
+		if resultCh != nil {
+			resultCh <- stdioResult{response: response}
+		}
+	}
+}
+
+func (c *StdioClient) removePending(id int64) {
+	c.pendingMu.Lock()
+	delete(c.pending, id)
+	c.pendingMu.Unlock()
+}
+
+func (c *StdioClient) failPending(err error) {
+	c.pendingMu.Lock()
+	pending := c.pending
+	c.pending = make(map[int64]chan stdioResult)
+	c.pendingMu.Unlock()
+	for _, resultCh := range pending {
+		resultCh <- stdioResult{err: err}
+	}
+}
+
+func (c *StdioClient) Close() error {
+	c.closeOnce.Do(func() {
+		_ = c.stdin.Close()
+		select {
+		case c.waitErr = <-c.waitCh:
+		case <-time.After(2 * time.Second):
+			if c.cmd.Process != nil {
+				_ = c.cmd.Process.Kill()
+			}
+			c.waitErr = <-c.waitCh
+		}
+	})
+	return c.waitErr
+}

--- a/internal/slackmcp/adapter_test.go
+++ b/internal/slackmcp/adapter_test.go
@@ -1,0 +1,517 @@
+package slackmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/slacrawl/internal/config"
+	"github.com/openclaw/slacrawl/internal/mcpclient"
+	"github.com/openclaw/slacrawl/internal/store"
+)
+
+const testConnectorID = "asdk_app_test"
+
+func TestSyncStoresMCPConnectorData(t *testing.T) {
+	server := newTestGatewayServer(t)
+	defer server.Close()
+	t.Setenv("CODEX_APPS_ACCESS_TOKEN", "test-token")
+	t.Setenv("CODEX_APPS_ACCOUNT_ID", "acct-123")
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	summary, err := Sync(context.Background(), st, Options{
+		WorkspaceID: "T123",
+		Config: config.MCPConfig{
+			Enabled:         true,
+			BaseURL:         server.URL,
+			AuthPath:        "/unused",
+			TokenEnv:        "CODEX_APPS_ACCESS_TOKEN",
+			AccountIDEnv:    "CODEX_APPS_ACCOUNT_ID",
+			ConnectorID:     testConnectorID,
+			ChannelTypes:    "public_channel,private_channel",
+			PageSize:        100,
+			SearchLimit:     100,
+			MaxPages:        10,
+			ProtocolVersion: "2025-03-26",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.Users)
+	require.Equal(t, 1, summary.Channels)
+	require.Equal(t, 1, summary.Messages)
+	require.Equal(t, 1, summary.Replies)
+
+	rows, err := st.QueryReadOnly(context.Background(), `
+select channel_id, ts, workspace_id, thread_ts, text, source_name, source_rank
+from messages order by ts
+`)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Equal(t, "T123", rows[0]["workspace_id"])
+	require.Equal(t, SourceName, rows[0]["source_name"])
+	require.Equal(t, int64(SourceRank), rows[0]["source_rank"])
+	require.Equal(t, "1772574099.659199", rows[1]["thread_ts"])
+
+	mentions, err := st.QueryReadOnly(context.Background(), `select target_id from message_mentions`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"target_id": "U456"}}, mentions)
+
+	state, err := st.GetSyncState(context.Background(), SourceName, "workspace", "T123")
+	require.NoError(t, err)
+	require.NotEmpty(t, state)
+}
+
+func TestSyncStoresReferenceSlackMCPData(t *testing.T) {
+	server := newReferenceGatewayServer(t)
+	defer server.Close()
+	t.Setenv("CODEX_APPS_ACCESS_TOKEN", "test-token")
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	summary, err := Sync(context.Background(), st, Options{
+		WorkspaceID: "TREF",
+		Config: func() config.MCPConfig {
+			cfg := testMCPConfig(server.URL)
+			cfg.ConnectorID = ""
+			return cfg
+		}(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, summary.Users)
+	require.Equal(t, 1, summary.Channels)
+	require.Equal(t, 1, summary.Messages)
+	require.Equal(t, 1, summary.Replies)
+
+	rows, err := st.QueryReadOnly(context.Background(), `
+select channel_id, ts, thread_ts, user_id, text, source_name
+from messages order by ts
+`)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Equal(t, "CREF", rows[0]["channel_id"])
+	require.Equal(t, "UADA", rows[0]["user_id"])
+	require.Equal(t, "", rows[0]["thread_ts"])
+	require.Equal(t, "1710000000.000001", rows[1]["thread_ts"])
+	require.Equal(t, SourceName, rows[1]["source_name"])
+}
+
+func TestIncrementalSyncReconcilesStoredThreadRoots(t *testing.T) {
+	server, threadCalls := newIncrementalThreadGatewayServer(t)
+	defer server.Close()
+	t.Setenv("CODEX_APPS_ACCESS_TOKEN", "test-token")
+
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+	opts := Options{
+		WorkspaceID: "T123",
+		Channels:    []string{"C123"},
+		Config:      testMCPConfig(server.URL),
+	}
+	require.NoError(t, syncTwice(ctx, st, opts))
+	require.Equal(t, 2, *threadCalls)
+
+	rows, err := st.QueryReadOnly(ctx, `select ts from messages where channel_id = 'C123' and thread_ts = '1710000000.000001' order by ts`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"ts": "1710000001.000002"}, {"ts": "1710000002.000003"}}, rows)
+}
+
+func syncTwice(ctx context.Context, st *store.Store, opts Options) error {
+	if _, err := Sync(ctx, st, opts); err != nil {
+		return err
+	}
+	_, err := Sync(ctx, st, opts)
+	return err
+}
+
+func TestSyncPreservesRicherExistingRecords(t *testing.T) {
+	server := newTestGatewayServer(t)
+	defer server.Close()
+	t.Setenv("CODEX_APPS_ACCESS_TOKEN", "test-token")
+	t.Setenv("CODEX_APPS_ACCOUNT_ID", "acct-123")
+
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+	now := time.Now().UTC()
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T123", Name: "richer", RawJSON: `{"source":"api"}`, UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C123", WorkspaceID: "T123", Name: "richer-channel", Kind: "private_channel", Topic: "keep-topic", IsPrivate: true, RawJSON: `{"source":"api"}`, UpdatedAt: now}))
+	require.NoError(t, st.UpsertUser(ctx, store.User{ID: "U123", WorkspaceID: "T123", Name: "richer-user", RealName: "Keep Name", IsBot: true, RawJSON: `{"source":"api"}`, UpdatedAt: now}))
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID: "C123", TS: "1772574099.659199", WorkspaceID: "T123", UserID: "U123",
+		Text: "richer root", NormalizedText: "richer root", SourceRank: 1, SourceName: "api-user",
+		RawJSON: `{"source":"api"}`, UpdatedAt: now,
+	}, []store.Mention{{Type: "user", TargetID: "UKEEP"}}))
+
+	_, err = Sync(ctx, st, Options{WorkspaceID: "T123", Config: testMCPConfig(server.URL)})
+	require.NoError(t, err)
+
+	rows, err := st.QueryReadOnly(ctx, `select name, kind, topic, is_private from channels where id = 'C123'`)
+	require.NoError(t, err)
+	require.Equal(t, "richer-channel", rows[0]["name"])
+	require.Equal(t, "private_channel", rows[0]["kind"])
+	require.Equal(t, "keep-topic", rows[0]["topic"])
+	require.Equal(t, int64(1), rows[0]["is_private"])
+
+	rows, err = st.QueryReadOnly(ctx, `select name, real_name, is_bot from users where id = 'U123'`)
+	require.NoError(t, err)
+	require.Equal(t, "richer-user", rows[0]["name"])
+	require.Equal(t, "Keep Name", rows[0]["real_name"])
+	require.Equal(t, int64(1), rows[0]["is_bot"])
+
+	rows, err = st.QueryReadOnly(ctx, `select text, source_name, source_rank from messages where channel_id = 'C123' and ts = '1772574099.659199'`)
+	require.NoError(t, err)
+	require.Equal(t, "richer root", rows[0]["text"])
+	require.Equal(t, "api-user", rows[0]["source_name"])
+	require.Equal(t, int64(1), rows[0]["source_rank"])
+	mentions, err := st.QueryReadOnly(ctx, `select target_id from message_mentions where channel_id = 'C123' and ts = '1772574099.659199'`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"target_id": "UKEEP"}}, mentions)
+}
+
+func TestSyncRequiresWorkspaceID(t *testing.T) {
+	_, err := Sync(context.Background(), nil, Options{})
+	require.ErrorContains(t, err, "workspace ID is required")
+}
+
+func TestFilterChannelsByIDAndName(t *testing.T) {
+	channels := []ChannelRecord{{ID: "C1", Name: "alpha"}, {ID: "C2", Name: "beta"}}
+	require.Equal(t, []ChannelRecord{channels[1]}, filterChannels(channels, []string{"#alpha"}))
+	require.Equal(t, []ChannelRecord{channels[0]}, filterChannels(channels, []string{"C2"}))
+}
+
+func TestSyncExplicitChannelAvoidsGlobalEnumeration(t *testing.T) {
+	server := newTargetedGatewayServer(t)
+	defer server.Close()
+	t.Setenv("CODEX_APPS_ACCESS_TOKEN", "test-token")
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	summary, err := Sync(context.Background(), st, Options{
+		WorkspaceID: "T123",
+		Channels:    []string{"C123"},
+		Config: config.MCPConfig{
+			BaseURL:         server.URL,
+			TokenEnv:        "CODEX_APPS_ACCESS_TOKEN",
+			ConnectorID:     testConnectorID,
+			ChannelTypes:    "public_channel,private_channel",
+			PageSize:        100,
+			SearchLimit:     100,
+			MaxPages:        10,
+			ProtocolVersion: "2025-03-26",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.Channels)
+	require.Equal(t, 0, summary.Users)
+	require.Equal(t, 1, summary.Messages)
+
+	rows, err := st.QueryReadOnly(context.Background(), `select kind from channels where id = 'C123'`)
+	require.NoError(t, err)
+	require.Equal(t, "mcp_channel", rows[0]["kind"])
+}
+
+func TestSyncPlanOverlapsAndHonorsLatestOnly(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+	require.NoError(t, st.EnsureWorkspace(ctx, store.Workspace{ID: "T1", Name: "T1", RawJSON: "{}", UpdatedAt: time.Now().UTC()}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C1", WorkspaceID: "T1", Name: "one", Kind: "mcp_channel", RawJSON: "{}", UpdatedAt: time.Now().UTC()}))
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: "1772574099.659199", WorkspaceID: "T1", Text: "existing", NormalizedText: "existing",
+		SourceRank: SourceRank, SourceName: SourceName, RawJSON: "{}", UpdatedAt: time.Now().UTC(),
+	}, nil))
+
+	channels := []ChannelRecord{{ID: "C1"}, {ID: "C2"}}
+	oldest, selected, err := syncPlan(ctx, st, "T1", channels, Options{LatestOnly: true})
+	require.NoError(t, err)
+	require.Equal(t, []ChannelRecord{{ID: "C1"}}, selected)
+	require.Equal(t, "1772570499.659199", oldest["C1"])
+
+	oldest, selected, err = syncPlan(ctx, st, "T1", channels, Options{Full: true})
+	require.NoError(t, err)
+	require.Len(t, selected, 2)
+	require.Empty(t, oldest["C1"])
+
+	oldest, selected, err = syncPlan(ctx, st, "T1", channels, Options{Since: "2026-03-08T12:00:00Z"})
+	require.NoError(t, err)
+	require.Len(t, selected, 2)
+	require.Equal(t, "1772971200.000000", oldest["C1"])
+}
+
+func TestWalkPagesRejectsTruncation(t *testing.T) {
+	calls := 0
+	err := walkPages(2, func(string) (string, error) {
+		calls++
+		return fmt.Sprintf("more-%d", calls), nil
+	})
+	require.ErrorContains(t, err, "max_pages=2")
+	require.Equal(t, 2, calls)
+}
+
+func TestResolveAuthPrefersEnvironment(t *testing.T) {
+	t.Setenv("CODEX_APPS_ACCESS_TOKEN", "env-token")
+	t.Setenv("CODEX_APPS_ACCOUNT_ID", "acct-123")
+	auth, err := resolveAuth(config.MCPConfig{TokenEnv: "CODEX_APPS_ACCESS_TOKEN", AccountIDEnv: "CODEX_APPS_ACCOUNT_ID", AuthPath: "/unused"})
+	require.NoError(t, err)
+	require.Equal(t, "env-token", auth.AccessToken)
+	require.Equal(t, "acct-123", auth.AccountID)
+}
+
+func TestResolveSlackToolset(t *testing.T) {
+	tools := []mcpclient.Tool{
+		{Name: "slack_search_channels", Meta: &mcpclient.ToolMeta{ConnectorID: testConnectorID}},
+		{Name: "slack_search_users", Meta: &mcpclient.ToolMeta{ConnectorID: testConnectorID}},
+		{Name: "slack_read_channel", Meta: &mcpclient.ToolMeta{ConnectorID: testConnectorID}},
+		{Name: "slack_read_thread", Meta: &mcpclient.ToolMeta{ConnectorID: testConnectorID}},
+	}
+	client := Client{connectorID: testConnectorID}
+	filtered, err := filterSlackTools(tools, client.connectorID)
+	require.NoError(t, err)
+	searchChannels, err := matchTool(filtered, []string{"search", "channel"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "slack_search_channels", searchChannels)
+	require.Equal(t, "slack_read_thread", matchToolOptional(filtered, []string{"read", "thread"}, nil))
+}
+
+func testMCPConfig(baseURL string) config.MCPConfig {
+	return config.MCPConfig{
+		Enabled: true, BaseURL: baseURL, AuthPath: "/unused",
+		TokenEnv: "CODEX_APPS_ACCESS_TOKEN", AccountIDEnv: "CODEX_APPS_ACCOUNT_ID",
+		ConnectorID: testConnectorID, ChannelTypes: "public_channel,private_channel",
+		PageSize: 100, SearchLimit: 100, MaxPages: 10, ProtocolVersion: "2025-03-26",
+	}
+}
+
+func TestFilterSlackToolsRejectsUnknownConfiguredConnector(t *testing.T) {
+	tools := []mcpclient.Tool{{Name: "slack_search_channels", Meta: &mcpclient.ToolMeta{ConnectorID: "new-id"}}}
+	_, err := filterSlackTools(tools, "stale-id")
+	require.ErrorContains(t, err, "was not found")
+}
+
+func TestFilterSlackToolsUsesExactConnectorWhenAvailable(t *testing.T) {
+	wanted := mcpclient.Tool{Name: "search_channels", Meta: &mcpclient.ToolMeta{ConnectorID: "wanted", ConnectorName: "Slack"}}
+	other := mcpclient.Tool{Name: "slack_search_channels", Meta: &mcpclient.ToolMeta{ConnectorID: "other", ConnectorName: "Slack"}}
+	filtered, err := filterSlackTools([]mcpclient.Tool{other, wanted}, "wanted")
+	require.NoError(t, err)
+	require.Equal(t, []mcpclient.Tool{wanted}, filtered)
+}
+
+func newTestGatewayServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		require.Equal(t, "acct-123", r.Header.Get("ChatGPT-Account-ID"))
+		var req struct {
+			Method string         `json:"method"`
+			Params map[string]any `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case "initialize":
+			writeRPCResult(t, w, map[string]any{"protocolVersion": "2025-03-26"})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			writeRPCResult(t, w, map[string]any{"tools": []map[string]any{
+				{"name": "slack_search_channels", "_meta": map[string]any{"connector_id": testConnectorID}},
+				{"name": "slack_search_users", "_meta": map[string]any{"connector_id": testConnectorID}},
+				{"name": "slack_read_channel", "_meta": map[string]any{"connector_id": testConnectorID}},
+				{"name": "slack_read_thread", "_meta": map[string]any{"connector_id": testConnectorID}},
+			}, "nextCursor": ""})
+		case "tools/call":
+			name, _ := req.Params["name"].(string)
+			switch name {
+			case "slack_search_channels":
+				writeToolText(t, w, map[string]any{"results": "### Result 1\nName: #codex-feedback\nCreated: 2026-03-08T12:00:00Z\nPurpose: feedback\nTopic: debugging\nPermalink: [open](https://openai.slack.com/archives/C123)\nIs Archived: false", "pagination_info": ""})
+			case "slack_search_users":
+				writeToolText(t, w, map[string]any{"results": "### Result 1\nUser ID: U123\nName: Ada\nTitle: Engineer\nEmail: ada@example.com\nTimezone: UTC\nPermalink: [open](https://openai.slack.com/team/U123)", "pagination_info": ""})
+			case "slack_read_channel":
+				writeToolText(t, w, map[string]any{"messages": "Channel: codex-feedback (C123)\n\n=== Message from Ada (U123) at 2026-03-08T12:00:00Z === \nMessage TS: 1772574099.659199\nroot message <@U456>\nThread: 1 replies (latest: 2026-03-08T12:03:19Z)", "pagination_info": ""})
+			case "slack_read_thread":
+				writeToolText(t, w, map[string]any{"messages": "From: Ada (U123)\nTime: 2026-03-08T12:00:00Z\nMessage TS: 1772574099.659199\nroot message <@U456>\n\n=== THREAD REPLIES\n\n--- Reply 1 ---\nFrom: Grace (U456)\nTime: 2026-03-08T12:03:19Z\nMessage TS: 1772574199.000000\nreply message", "pagination_info": ""})
+			default:
+				t.Fatalf("unexpected tool call %q", name)
+			}
+		default:
+			t.Fatalf("unexpected RPC method %q", req.Method)
+		}
+	}))
+}
+
+func newTargetedGatewayServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string         `json:"method"`
+			Params map[string]any `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		switch req.Method {
+		case "initialize":
+			writeRPCResult(t, w, map[string]any{"protocolVersion": "2025-03-26"})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			writeRPCResult(t, w, map[string]any{"tools": []map[string]any{
+				{"name": "slack_search_channels", "_meta": map[string]any{"connector_id": testConnectorID}},
+				{"name": "slack_search_users", "_meta": map[string]any{"connector_id": testConnectorID}},
+				{"name": "slack_read_channel", "_meta": map[string]any{"connector_id": testConnectorID}},
+			}, "nextCursor": ""})
+		case "tools/call":
+			name, _ := req.Params["name"].(string)
+			require.Equal(t, "slack_read_channel", name, "targeted sync must not enumerate channels or users")
+			writeToolText(t, w, map[string]any{
+				"messages":        "Channel: codex-feedback (C123)\n\n=== Message from Ada (U123) at 2026-03-08T12:00:00Z === \nMessage TS: 1772574099.659199\ntargeted message",
+				"pagination_info": "",
+			})
+		default:
+			t.Fatalf("unexpected RPC method %q", req.Method)
+		}
+	}))
+}
+
+func newReferenceGatewayServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string         `json:"method"`
+			Params map[string]any `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		switch req.Method {
+		case "initialize":
+			writeRPCResult(t, w, map[string]any{"protocolVersion": "2025-03-26"})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			writeRPCResult(t, w, map[string]any{"tools": []map[string]any{
+				{"name": "slack_list_channels"},
+				{"name": "slack_get_channel_history"},
+				{"name": "slack_get_thread_replies"},
+				{"name": "slack_get_users"},
+			}})
+		case "tools/call":
+			name, _ := req.Params["name"].(string)
+			switch name {
+			case "slack_list_channels":
+				writeToolText(t, w, map[string]any{
+					"ok": true,
+					"channels": []map[string]any{{
+						"id": "CREF", "name": "reference", "is_private": false,
+						"topic": map[string]any{"value": "MCP"}, "purpose": map[string]any{"value": "test"},
+					}},
+					"response_metadata": map[string]any{"next_cursor": ""},
+				})
+			case "slack_get_users":
+				writeToolText(t, w, map[string]any{
+					"ok": true,
+					"members": []map[string]any{
+						{"id": "UADA", "name": "ada", "profile": map[string]any{"real_name": "Ada", "display_name": "ada"}},
+						{"id": "UGRACE", "name": "grace", "profile": map[string]any{"real_name": "Grace", "display_name": "grace"}},
+					},
+					"response_metadata": map[string]any{"next_cursor": ""},
+				})
+			case "slack_get_channel_history":
+				writeToolText(t, w, map[string]any{
+					"ok": true,
+					"messages": []map[string]any{{
+						"ts": "1710000000.000001", "user": "UADA", "text": "reference root",
+						"reply_count": 1, "latest_reply": "1710000001.000002",
+					}},
+				})
+			case "slack_get_thread_replies":
+				writeToolText(t, w, map[string]any{
+					"ok": true,
+					"messages": []map[string]any{
+						{"ts": "1710000000.000001", "user": "UADA", "text": "reference root", "reply_count": 1},
+						{"ts": "1710000001.000002", "thread_ts": "1710000000.000001", "user": "UGRACE", "text": "reference reply"},
+					},
+				})
+			default:
+				t.Fatalf("unexpected reference tool call %q", name)
+			}
+		default:
+			t.Fatalf("unexpected RPC method %q", req.Method)
+		}
+	}))
+}
+
+func newIncrementalThreadGatewayServer(t *testing.T) (*httptest.Server, *int) {
+	t.Helper()
+	historyCalls := 0
+	threadCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string         `json:"method"`
+			Params map[string]any `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		switch req.Method {
+		case "initialize":
+			writeRPCResult(t, w, map[string]any{"protocolVersion": "2025-03-26"})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			writeRPCResult(t, w, map[string]any{"tools": []map[string]any{
+				{"name": "slack_search_channels", "_meta": map[string]any{"connector_id": testConnectorID}},
+				{"name": "slack_search_users", "_meta": map[string]any{"connector_id": testConnectorID}},
+				{"name": "slack_read_channel", "_meta": map[string]any{"connector_id": testConnectorID}},
+				{"name": "slack_read_thread", "_meta": map[string]any{"connector_id": testConnectorID}},
+			}})
+		case "tools/call":
+			name, _ := req.Params["name"].(string)
+			switch name {
+			case "slack_read_channel":
+				historyCalls++
+				messages := "Channel: test (C123)\n\n=== Message from Ada (U1) at 2024-03-09T16:00:00Z === \nMessage TS: 1710003600.000010\nnewer root"
+				if historyCalls == 1 {
+					messages = "Channel: test (C123)\n\n=== Message from Ada (U1) at 2024-03-09T15:00:00Z === \nMessage TS: 1710000000.000001\nold root\nThread: 1 replies (latest: 2024-03-09T15:00:01Z)\n\n=== Message from Ada (U1) at 2024-03-09T16:00:00Z === \nMessage TS: 1710003600.000010\nnewer root"
+				}
+				writeToolText(t, w, map[string]any{"messages": messages, "pagination_info": ""})
+			case "slack_read_thread":
+				threadCalls++
+				messages := "From: Ada (U1)\nTime: 2024-03-09T15:00:00Z\nMessage TS: 1710000000.000001\nold root\n\n=== THREAD REPLIES\n\n--- Reply 1 ---\nFrom: Grace (U2)\nTime: 2024-03-09T15:00:01Z\nMessage TS: 1710000001.000002\nfirst reply"
+				if threadCalls > 1 {
+					messages += "\n\n--- Reply 2 ---\nFrom: Linus (U3)\nTime: 2024-03-09T15:00:02Z\nMessage TS: 1710000002.000003\nlate reply"
+				}
+				writeToolText(t, w, map[string]any{"messages": messages, "pagination_info": ""})
+			default:
+				t.Fatalf("unexpected incremental tool call %q", name)
+			}
+		default:
+			t.Fatalf("unexpected RPC method %q", req.Method)
+		}
+	}))
+	return server, &threadCalls
+}
+
+func writeToolText(t *testing.T, w http.ResponseWriter, payload map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+	writeRPCResult(t, w, map[string]any{"isError": false, "content": []map[string]any{{"text": string(raw)}}})
+}
+
+func writeRPCResult(t *testing.T, w http.ResponseWriter, result any) {
+	t.Helper()
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": result}))
+}

--- a/internal/slackmcp/client.go
+++ b/internal/slackmcp/client.go
@@ -1,0 +1,470 @@
+package slackmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/openclaw/slacrawl/internal/config"
+	"github.com/openclaw/slacrawl/internal/mcpclient"
+)
+
+type Client struct {
+	mcp          mcpclient.Session
+	connectorID  string
+	channelTypes string
+	pageSize     int
+	searchLimit  int
+	maxPages     int
+}
+
+type toolset struct {
+	provider       providerKind
+	searchChannels string
+	searchUsers    string
+	readChannel    string
+	readThread     string
+}
+
+type providerKind string
+
+const (
+	providerCodex     providerKind = "codex"
+	providerReference providerKind = "reference"
+)
+
+type searchEnvelope struct {
+	Results        string `json:"results"`
+	PaginationInfo string `json:"pagination_info"`
+}
+
+type messagesEnvelope struct {
+	Messages       string `json:"messages"`
+	PaginationInfo string `json:"pagination_info"`
+}
+
+type page[T any] struct {
+	Items      []T
+	NextCursor string
+}
+
+type channelPage struct {
+	ChannelID   string
+	ChannelName string
+	Messages    []MessageRecord
+	NextCursor  string
+}
+
+type threadPage struct {
+	Parent     *MessageRecord
+	Replies    []MessageRecord
+	NextCursor string
+}
+
+func New(ctx context.Context, cfg config.MCPConfig, httpClient *http.Client) (*Client, error) {
+	var mcp mcpclient.Session
+	var err error
+	switch strings.ToLower(strings.TrimSpace(cfg.Transport)) {
+	case "", "http":
+		auth, authErr := resolveAuth(cfg)
+		if authErr != nil {
+			return nil, authErr
+		}
+		mcp, err = mcpclient.New(mcpclient.Options{
+			Endpoint:        cfg.BaseURL,
+			AccessToken:     auth.AccessToken,
+			AccountID:       auth.AccountID,
+			ProtocolVersion: cfg.ProtocolVersion,
+			ClientName:      "slacrawl",
+			ClientVersion:   "dev",
+			HTTPClient:      httpClient,
+		})
+	case "stdio":
+		mcp, err = mcpclient.NewStdio(ctx, mcpclient.StdioOptions{
+			Command:         cfg.Command,
+			Args:            cfg.Args,
+			ProtocolVersion: cfg.ProtocolVersion,
+			ClientName:      "slacrawl",
+			ClientVersion:   "dev",
+		})
+	default:
+		return nil, fmt.Errorf("unsupported MCP transport %q", cfg.Transport)
+	}
+	if err != nil {
+		return nil, err
+	}
+	client := &Client{
+		mcp:          mcp,
+		connectorID:  strings.TrimSpace(cfg.ConnectorID),
+		channelTypes: cfg.ChannelTypes,
+		pageSize:     cfg.PageSize,
+		searchLimit:  cfg.SearchLimit,
+		maxPages:     cfg.MaxPages,
+	}
+	if err := client.mcp.Initialize(ctx); err != nil {
+		_ = client.mcp.Close()
+		return nil, err
+	}
+	return client, nil
+}
+
+func (c *Client) Close() error { return c.mcp.Close() }
+
+func (c *Client) discover(ctx context.Context) (toolset, error) {
+	tools, err := c.mcp.ListTools(ctx)
+	if err != nil {
+		return toolset{}, err
+	}
+	tools, err = filterSlackTools(tools, c.connectorID)
+	if err != nil {
+		return toolset{}, err
+	}
+	if hasTools(tools, "slack_list_channels", "slack_get_channel_history", "slack_get_users") {
+		return toolset{
+			provider:       providerReference,
+			searchChannels: "slack_list_channels",
+			searchUsers:    "slack_get_users",
+			readChannel:    "slack_get_channel_history",
+			readThread:     toolNameOptional(tools, "slack_get_thread_replies"),
+		}, nil
+	}
+	searchChannels, err := matchTool(tools, []string{"search", "channel"}, nil)
+	if err != nil {
+		return toolset{}, err
+	}
+	searchUsers, err := matchTool(tools, []string{"search", "user"}, []string{"profile"})
+	if err != nil {
+		return toolset{}, err
+	}
+	readChannel, err := matchTool(tools, []string{"read", "channel"}, []string{"search", "thread", "canvas"})
+	if err != nil {
+		return toolset{}, err
+	}
+	return toolset{
+		provider:       providerCodex,
+		searchChannels: searchChannels,
+		searchUsers:    searchUsers,
+		readChannel:    readChannel,
+		readThread:     matchToolOptional(tools, []string{"read", "thread"}, []string{"search", "canvas"}),
+	}, nil
+}
+
+func hasTools(tools []mcpclient.Tool, names ...string) bool {
+	for _, name := range names {
+		if toolNameOptional(tools, name) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func toolNameOptional(tools []mcpclient.Tool, name string) string {
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool.Name
+		}
+	}
+	return ""
+}
+
+func (c *Client) channels(ctx context.Context, tools toolset, query string) ([]ChannelRecord, error) {
+	if tools.provider == providerReference {
+		channels, err := c.referenceChannels(ctx, tools)
+		if err != nil || strings.TrimSpace(query) == "" {
+			return channels, err
+		}
+		query = strings.TrimPrefix(strings.TrimSpace(query), "#")
+		filtered := channels[:0]
+		for _, channel := range channels {
+			if strings.EqualFold(channel.ID, query) || strings.EqualFold(channel.Name, query) {
+				filtered = append(filtered, channel)
+			}
+		}
+		return filtered, nil
+	}
+	return collectPages(c.maxPages, func(cursor string) (page[ChannelRecord], error) {
+		raw, err := c.mcp.CallToolText(ctx, tools.searchChannels, map[string]any{
+			"query":           requiredQuery(query),
+			"cursor":          cursor,
+			"limit":           c.searchLimit,
+			"channel_types":   c.channelTypes,
+			"response_format": "detailed",
+		})
+		if err != nil {
+			return page[ChannelRecord]{}, err
+		}
+		return parseChannels(raw)
+	})
+}
+
+func (c *Client) users(ctx context.Context, tools toolset) ([]UserRecord, error) {
+	if tools.provider == providerReference {
+		return c.referenceUsers(ctx, tools)
+	}
+	return collectPages(c.maxPages, func(cursor string) (page[UserRecord], error) {
+		raw, err := c.mcp.CallToolText(ctx, tools.searchUsers, map[string]any{
+			"query":           requiredQuery(""),
+			"cursor":          cursor,
+			"limit":           c.searchLimit,
+			"response_format": "detailed",
+		})
+		if err != nil {
+			return page[UserRecord]{}, err
+		}
+		return parseUsers(raw)
+	})
+}
+
+func (c *Client) channelMessages(ctx context.Context, tools toolset, channelID, oldest string) (channelPage, error) {
+	if tools.provider == providerReference {
+		return c.referenceChannelMessages(ctx, tools, channelID, oldest)
+	}
+	var result channelPage
+	err := walkPages(c.maxPages, func(cursor string) (string, error) {
+		raw, err := c.mcp.CallToolText(ctx, tools.readChannel, map[string]any{
+			"channel_id":      channelID,
+			"cursor":          cursor,
+			"oldest":          emptyToNil(oldest),
+			"limit":           c.pageSize,
+			"response_format": "detailed",
+		})
+		if err != nil {
+			return "", err
+		}
+		next, err := parseChannelMessages(raw)
+		if err != nil {
+			return "", err
+		}
+		if result.ChannelID == "" {
+			result.ChannelID = next.ChannelID
+			result.ChannelName = next.ChannelName
+		}
+		result.Messages = append(result.Messages, next.Messages...)
+		result.NextCursor = next.NextCursor
+		return next.NextCursor, nil
+	})
+	return result, err
+}
+
+func (c *Client) threadMessages(ctx context.Context, tools toolset, channelID, threadTS string) (threadPage, error) {
+	if tools.readThread == "" {
+		return threadPage{}, errors.New("Slack MCP connector does not provide a read-thread tool")
+	}
+	if tools.provider == providerReference {
+		return c.referenceThreadMessages(ctx, tools, channelID, threadTS)
+	}
+	var result threadPage
+	err := walkPages(c.maxPages, func(cursor string) (string, error) {
+		raw, err := c.mcp.CallToolText(ctx, tools.readThread, map[string]any{
+			"channel_id":      channelID,
+			"message_ts":      threadTS,
+			"cursor":          cursor,
+			"limit":           c.pageSize,
+			"response_format": "detailed",
+		})
+		if err != nil {
+			return "", err
+		}
+		next, err := parseThreadMessages(raw, channelID)
+		if err != nil {
+			return "", err
+		}
+		if result.Parent == nil {
+			result.Parent = next.Parent
+		}
+		result.Replies = append(result.Replies, next.Replies...)
+		result.NextCursor = next.NextCursor
+		return next.NextCursor, nil
+	})
+	return result, err
+}
+
+func collectPages[T any](maxPages int, fetch func(string) (page[T], error)) ([]T, error) {
+	var items []T
+	err := walkPages(maxPages, func(cursor string) (string, error) {
+		result, err := fetch(cursor)
+		if err != nil {
+			return "", err
+		}
+		items = append(items, result.Items...)
+		return result.NextCursor, nil
+	})
+	return items, err
+}
+
+func walkPages(maxPages int, fetch func(string) (string, error)) error {
+	cursor := ""
+	seen := map[string]struct{}{}
+	for pages := 0; ; pages++ {
+		if maxPages > 0 && pages >= maxPages {
+			return fmt.Errorf("MCP pagination exceeded max_pages=%d", maxPages)
+		}
+		next, err := fetch(cursor)
+		if err != nil {
+			return err
+		}
+		next = strings.TrimSpace(next)
+		if next == "" {
+			return nil
+		}
+		if _, ok := seen[next]; ok {
+			return fmt.Errorf("MCP pagination repeated cursor %q", next)
+		}
+		seen[next] = struct{}{}
+		cursor = next
+	}
+}
+
+type authInfo struct {
+	AccessToken string
+	AccountID   string
+}
+
+func resolveAuth(cfg config.MCPConfig) (authInfo, error) {
+	tokenEnv := cfg.TokenEnv
+	if tokenEnv == "" {
+		tokenEnv = "CODEX_APPS_ACCESS_TOKEN"
+	}
+	accountEnv := cfg.AccountIDEnv
+	if accountEnv == "" {
+		accountEnv = "CODEX_APPS_ACCOUNT_ID"
+	}
+	if token := strings.TrimSpace(os.Getenv(tokenEnv)); token != "" {
+		return authInfo{AccessToken: token, AccountID: strings.TrimSpace(os.Getenv(accountEnv))}, nil
+	}
+	if token := strings.TrimSpace(os.Getenv("CODEX_APPS_ACCESS_TOKEN")); token != "" {
+		return authInfo{AccessToken: token, AccountID: strings.TrimSpace(os.Getenv(accountEnv))}, nil
+	}
+	if token := strings.TrimSpace(os.Getenv("CODEX_CONNECTORS_TOKEN")); token != "" {
+		return authInfo{AccessToken: token, AccountID: strings.TrimSpace(os.Getenv(accountEnv))}, nil
+	}
+	if strings.TrimSpace(cfg.AuthPath) == "" {
+		return authInfo{}, fmt.Errorf("MCP token environment variable %s is unset and auth_path is empty", tokenEnv)
+	}
+	raw, err := os.ReadFile(cfg.AuthPath)
+	if err != nil {
+		return authInfo{}, fmt.Errorf("read MCP auth file %s: %w", cfg.AuthPath, err)
+	}
+	var payload struct {
+		Tokens *struct {
+			AccessToken string `json:"access_token"`
+			AccountID   string `json:"account_id"`
+		} `json:"tokens"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return authInfo{}, fmt.Errorf("parse MCP auth file %s: %w", cfg.AuthPath, err)
+	}
+	if payload.Tokens == nil || strings.TrimSpace(payload.Tokens.AccessToken) == "" {
+		return authInfo{}, fmt.Errorf("MCP auth file %s does not contain tokens.access_token", cfg.AuthPath)
+	}
+	return authInfo{AccessToken: strings.TrimSpace(payload.Tokens.AccessToken), AccountID: strings.TrimSpace(payload.Tokens.AccountID)}, nil
+}
+
+func filterSlackTools(tools []mcpclient.Tool, connectorID string) ([]mcpclient.Tool, error) {
+	if connectorID != "" {
+		exact := make([]mcpclient.Tool, 0, len(tools))
+		for _, tool := range tools {
+			if tool.Meta != nil && strings.TrimSpace(tool.Meta.ConnectorID) == connectorID {
+				exact = append(exact, tool)
+			}
+		}
+		if len(exact) > 0 {
+			return exact, nil
+		}
+		return nil, fmt.Errorf("configured Slack MCP connector %q was not found", connectorID)
+	}
+
+	filtered := make([]mcpclient.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if strings.Contains(toolIdentity(tool), "slack") {
+			filtered = append(filtered, tool)
+		}
+	}
+	return filtered, nil
+}
+
+func matchTool(tools []mcpclient.Tool, required, forbidden []string) (string, error) {
+	if name := matchToolOptional(tools, required, forbidden); name != "" {
+		return name, nil
+	}
+	return "", fmt.Errorf("could not resolve Slack MCP tool requiring %q and excluding %q", required, forbidden)
+}
+
+func matchToolOptional(tools []mcpclient.Tool, required, forbidden []string) string {
+	type candidate struct {
+		name  string
+		score int
+	}
+	var candidates []candidate
+	for _, tool := range tools {
+		identity := toolIdentity(tool)
+		if !containsAll(identity, required) || containsAny(identity, forbidden) {
+			continue
+		}
+		score := len(required) * 10
+		if strings.Contains(strings.ToLower(tool.Name), strings.Join(required, "_")) {
+			score += 100
+		}
+		if strings.Contains(identity, "slack") {
+			score++
+		}
+		candidates = append(candidates, candidate{name: tool.Name, score: score})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score == candidates[j].score {
+			return candidates[i].name < candidates[j].name
+		}
+		return candidates[i].score > candidates[j].score
+	})
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0].name
+}
+
+func toolIdentity(tool mcpclient.Tool) string {
+	parts := []string{strings.ToLower(tool.Name), strings.ToLower(tool.Title)}
+	if tool.Meta != nil {
+		parts = append(parts, strings.ToLower(tool.Meta.ConnectorName), strings.ToLower(tool.Meta.ResourceURI))
+	}
+	return strings.Join(parts, " ")
+}
+
+func containsAll(value string, needles []string) bool {
+	for _, needle := range needles {
+		if !strings.Contains(value, needle) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsAny(value string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func requiredQuery(value string) string {
+	if value == "" {
+		// Codex Slack search treats a present whitespace-only query as list-all;
+		// an empty string would be removed by the generic MCP argument filter.
+		return " "
+	}
+	return value
+}
+
+func emptyToNil(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}

--- a/internal/slackmcp/parse.go
+++ b/internal/slackmcp/parse.go
@@ -1,0 +1,407 @@
+package slackmcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type ChannelRecord struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	Topic      string `json:"topic"`
+	Purpose    string `json:"purpose"`
+	Permalink  string `json:"permalink"`
+	IsPrivate  bool   `json:"is_private"`
+	IsArchived bool   `json:"is_archived"`
+}
+
+type UserRecord struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	RealName  string `json:"real_name"`
+	Title     string `json:"title"`
+	Email     string `json:"email"`
+	Timezone  string `json:"timezone"`
+	Permalink string `json:"permalink"`
+	IsBot     bool   `json:"is_bot"`
+}
+
+type MessageRecord struct {
+	ChannelID     string   `json:"channel_id"`
+	ChannelName   string   `json:"channel_name"`
+	TS            string   `json:"ts"`
+	ThreadTS      string   `json:"thread_ts"`
+	AuthorID      string   `json:"author_id"`
+	AuthorName    string   `json:"author_name"`
+	OccurredAt    string   `json:"occurred_at"`
+	Text          string   `json:"text"`
+	ReplyCount    int      `json:"reply_count"`
+	LatestReply   string   `json:"latest_reply"`
+	Reactions     []string `json:"reactions,omitempty"`
+	FileSummaries []string `json:"file_summaries,omitempty"`
+}
+
+type messageMetadata struct {
+	ReplyCount  int
+	LatestReply string
+	Reactions   []string
+	Files       []string
+}
+
+var (
+	identityRE          = regexp.MustCompile(`^(?P<name>.+?) \((?:ID: )?(?:<@)?(?P<id>[A-Z0-9]+)(?:\|[^>]+)?(?:>)?\)\s*$`)
+	linkRE              = regexp.MustCompile(`\((https?://[^)]+)\)`)
+	cursorRE            = regexp.MustCompile("`([^`]+)`")
+	readChannelHeaderRE = regexp.MustCompile(`^Channel: #?(?P<name>.+?) \((?P<id>[A-Z0-9]+)\)$`)
+	threadFooterRE      = regexp.MustCompile(`^(?P<count>\d+) replies \(latest: (?P<latest>.+?)\)$`)
+)
+
+func parseChannels(raw string) (page[ChannelRecord], error) {
+	var envelope searchEnvelope
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		return page[ChannelRecord]{}, fmt.Errorf("decode Slack MCP channel search payload: %w", err)
+	}
+	var channels []ChannelRecord
+	for _, block := range resultBlocks(envelope.Results) {
+		fields := parseFields(block)
+		id := firstNonEmpty(fields["Channel ID"], fields["ID"], permalinkChannelID(fields["Permalink"]))
+		if id == "" {
+			return page[ChannelRecord]{}, errorsf("channel result missing ID", block)
+		}
+		kind, private := channelKind(fields)
+		channels = append(channels, ChannelRecord{
+			ID:         id,
+			Name:       strings.TrimPrefix(fields["Name"], "#"),
+			Kind:       kind,
+			Topic:      fields["Topic"],
+			Purpose:    fields["Purpose"],
+			Permalink:  parseMarkdownLink(fields["Permalink"]),
+			IsPrivate:  private,
+			IsArchived: strings.EqualFold(fields["Is Archived"], "true"),
+		})
+	}
+	return page[ChannelRecord]{Items: channels, NextCursor: extractCursor(envelope.PaginationInfo)}, nil
+}
+
+func parseUsers(raw string) (page[UserRecord], error) {
+	var envelope searchEnvelope
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		return page[UserRecord]{}, fmt.Errorf("decode Slack MCP user search payload: %w", err)
+	}
+	var users []UserRecord
+	for _, block := range resultBlocks(envelope.Results) {
+		fields := parseFields(block)
+		id := firstNonEmpty(fields["User ID"], fields["ID"])
+		if id == "" {
+			return page[UserRecord]{}, errorsf("user result missing ID", block)
+		}
+		users = append(users, UserRecord{
+			ID:        id,
+			Name:      firstNonEmpty(fields["Username"], fields["Name"]),
+			RealName:  firstNonEmpty(fields["Real Name"], fields["Name"]),
+			Title:     fields["Title"],
+			Email:     fields["Email"],
+			Timezone:  fields["Timezone"],
+			Permalink: parseMarkdownLink(fields["Permalink"]),
+		})
+	}
+	return page[UserRecord]{Items: users, NextCursor: extractCursor(envelope.PaginationInfo)}, nil
+}
+
+func parseChannelMessages(raw string) (channelPage, error) {
+	var envelope messagesEnvelope
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		return channelPage{}, fmt.Errorf("decode Slack MCP channel payload: %w", err)
+	}
+	header := firstLine(envelope.Messages)
+	matches := readChannelHeaderRE.FindStringSubmatch(header)
+	if matches == nil {
+		return channelPage{}, fmt.Errorf("parse Slack MCP channel header %q", header)
+	}
+	result := channelPage{
+		ChannelID:   matches[2],
+		ChannelName: matches[1],
+		NextCursor:  extractCursor(envelope.PaginationInfo),
+	}
+	start := strings.Index(envelope.Messages, "=== Message from ")
+	if start < 0 {
+		return result, nil
+	}
+	body := strings.TrimPrefix(envelope.Messages[start:], "=== Message from ")
+	for _, block := range strings.Split(body, "\n\n=== Message from ") {
+		header, remainder, ok := strings.Cut(block, " === \nMessage TS: ")
+		if !ok {
+			continue
+		}
+		ts, messageBody, ok := strings.Cut(remainder, "\n")
+		if !ok {
+			continue
+		}
+		identity, occurredAt, ok := strings.Cut(header, " at ")
+		if !ok {
+			return channelPage{}, fmt.Errorf("parse Slack MCP message time from %q", header)
+		}
+		name, id := parseNameID(identity)
+		text, metadata := splitMessageBodyAndMetadata(messageBody)
+		result.Messages = append(result.Messages, MessageRecord{
+			ChannelID:     result.ChannelID,
+			ChannelName:   result.ChannelName,
+			TS:            strings.TrimSpace(ts),
+			AuthorID:      id,
+			AuthorName:    firstNonEmpty(name, identity),
+			OccurredAt:    occurredAt,
+			Text:          text,
+			ReplyCount:    metadata.ReplyCount,
+			LatestReply:   metadata.LatestReply,
+			Reactions:     metadata.Reactions,
+			FileSummaries: metadata.Files,
+		})
+	}
+	return result, nil
+}
+
+func parseThreadMessages(raw, channelID string) (threadPage, error) {
+	var envelope messagesEnvelope
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		return threadPage{}, fmt.Errorf("decode Slack MCP thread payload: %w", err)
+	}
+	parentPart, repliesPart, ok := strings.Cut(envelope.Messages, "\n\n=== THREAD REPLIES")
+	if !ok {
+		return threadPage{}, fmt.Errorf("Slack MCP thread payload missing replies separator")
+	}
+	parent, err := parseThreadMessage(parentPart, channelID, "")
+	if err != nil {
+		return threadPage{}, err
+	}
+	var replies []MessageRecord
+	repliesBody := repliesPart
+	if _, rest, ok := strings.Cut(repliesPart, "\n\n"); ok {
+		repliesBody = rest
+	}
+	repliesBody = strings.TrimPrefix(repliesBody, "--- Reply ")
+	for _, block := range strings.Split(repliesBody, "\n\n--- Reply ") {
+		_, body, ok := strings.Cut(block, " ---\n")
+		if !ok {
+			continue
+		}
+		reply, err := parseThreadMessage(body, channelID, parent.TS)
+		if err != nil {
+			return threadPage{}, err
+		}
+		replies = append(replies, reply)
+	}
+	return threadPage{Parent: &parent, Replies: replies, NextCursor: extractCursor(envelope.PaginationInfo)}, nil
+}
+
+func parseThreadMessage(raw, channelID, threadTS string) (MessageRecord, error) {
+	lines := strings.Split(raw, "\n")
+	from := fieldValue(lines, "From: ")
+	occurredAt := fieldValue(lines, "Time: ")
+	ts := fieldValue(lines, "Message TS: ")
+	if from == "" || occurredAt == "" || ts == "" {
+		return MessageRecord{}, fmt.Errorf("Slack MCP thread message missing required fields")
+	}
+	name, id := parseNameID(from)
+	text, metadata := splitMessageBodyAndMetadata(collectAfterMessageTS(lines))
+	return MessageRecord{
+		ChannelID:     channelID,
+		TS:            ts,
+		ThreadTS:      threadTS,
+		AuthorID:      id,
+		AuthorName:    firstNonEmpty(name, from),
+		OccurredAt:    occurredAt,
+		Text:          text,
+		ReplyCount:    metadata.ReplyCount,
+		LatestReply:   metadata.LatestReply,
+		Reactions:     metadata.Reactions,
+		FileSummaries: metadata.Files,
+	}, nil
+}
+
+func channelKind(fields map[string]string) (string, bool) {
+	kind := strings.ToLower(firstNonEmpty(fields["Type"], fields["Channel Type"]))
+	private := strings.EqualFold(fields["Is Private"], "true") || strings.Contains(kind, "private")
+	if private {
+		return "private_channel", true
+	}
+	if strings.Contains(kind, "public") || strings.EqualFold(fields["Is Private"], "false") {
+		return "public_channel", false
+	}
+	return "mcp_channel", false
+}
+
+func parseFields(block string) map[string]string {
+	fields := map[string]string{}
+	currentKey := ""
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimRight(line, " \t")
+		if trimmed == "---" {
+			continue
+		}
+		if key, value, ok := splitField(trimmed); ok {
+			currentKey = key
+			fields[key] = value
+			continue
+		}
+		if strings.TrimSpace(trimmed) != "" && currentKey != "" {
+			if fields[currentKey] != "" {
+				fields[currentKey] += "\n"
+			}
+			fields[currentKey] += trimmed
+		}
+	}
+	return fields
+}
+
+func splitField(line string) (string, string, bool) {
+	key, value, ok := strings.Cut(line, ":")
+	if !ok {
+		return "", "", false
+	}
+	for _, ch := range key {
+		if (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != ' ' && ch != '_' {
+			return "", "", false
+		}
+	}
+	return key, strings.TrimSpace(value), true
+}
+
+func resultBlocks(results string) []string {
+	parts := strings.Split(results, "### Result ")
+	blocks := make([]string, 0, len(parts)-1)
+	for _, part := range parts[1:] {
+		if _, body, ok := strings.Cut(part, "\n"); ok {
+			blocks = append(blocks, body)
+		}
+	}
+	return blocks
+}
+
+func parseNameID(value string) (string, string) {
+	matches := identityRE.FindStringSubmatch(strings.TrimSpace(value))
+	if matches == nil {
+		return strings.TrimSpace(value), ""
+	}
+	return matches[1], matches[2]
+}
+
+func parseMarkdownLink(value string) string {
+	matches := linkRE.FindStringSubmatch(value)
+	if matches == nil {
+		return ""
+	}
+	return matches[1]
+}
+
+func permalinkChannelID(value string) string {
+	link := parseMarkdownLink(value)
+	index := strings.Index(link, "/archives/")
+	if index < 0 {
+		return ""
+	}
+	rest := link[index+len("/archives/"):]
+	if id, _, ok := strings.Cut(rest, "/"); ok {
+		return id
+	}
+	return rest
+}
+
+func extractCursor(value string) string {
+	matches := cursorRE.FindStringSubmatch(value)
+	if matches == nil {
+		return ""
+	}
+	return matches[1]
+}
+
+func splitMessageBodyAndMetadata(raw string) (string, messageMetadata) {
+	lines := strings.Split(raw, "\n")
+	metadata := messageMetadata{}
+	for len(lines) > 0 {
+		last := strings.TrimSpace(lines[len(lines)-1])
+		switch {
+		case last == "":
+			lines = lines[:len(lines)-1]
+		case strings.HasPrefix(last, "Files: "):
+			metadata.Files = splitMetadataList(strings.TrimPrefix(last, "Files: "))
+			lines = lines[:len(lines)-1]
+		case strings.HasPrefix(last, "Reactions: "):
+			metadata.Reactions = splitMetadataList(strings.TrimPrefix(last, "Reactions: "))
+			lines = lines[:len(lines)-1]
+		case strings.HasPrefix(last, "Thread: "):
+			matches := threadFooterRE.FindStringSubmatch(strings.TrimPrefix(last, "Thread: "))
+			if matches == nil {
+				return strings.TrimSpace(strings.Join(lines, "\n")), metadata
+			}
+			metadata.ReplyCount, _ = strconv.Atoi(matches[1])
+			metadata.LatestReply = matches[2]
+			lines = lines[:len(lines)-1]
+		default:
+			return strings.TrimSpace(strings.Join(lines, "\n")), metadata
+		}
+	}
+	return "", metadata
+}
+
+func splitMetadataList(value string) []string {
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}
+
+func collectAfterMessageTS(lines []string) string {
+	var result []string
+	capture := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Message TS: ") {
+			capture = true
+			continue
+		}
+		if capture {
+			result = append(result, line)
+		}
+	}
+	return strings.Join(result, "\n")
+}
+
+func fieldValue(lines []string, prefix string) string {
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	return ""
+}
+
+func firstLine(value string) string {
+	if line, _, ok := strings.Cut(value, "\n"); ok {
+		return line
+	}
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func errorsf(message, payload string) error {
+	payload = strings.TrimSpace(payload)
+	if len(payload) > 120 {
+		payload = payload[:120] + "..."
+	}
+	return fmt.Errorf("%s: %s", message, payload)
+}

--- a/internal/slackmcp/reference.go
+++ b/internal/slackmcp/reference.go
@@ -1,0 +1,234 @@
+package slackmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type referenceResponse struct {
+	OK               bool                      `json:"ok"`
+	Error            string                    `json:"error"`
+	Channels         []referenceChannel        `json:"channels"`
+	Members          []referenceUser           `json:"members"`
+	Messages         []referenceMessage        `json:"messages"`
+	ResponseMetadata referenceResponseMetadata `json:"response_metadata"`
+}
+
+type referenceResponseMetadata struct {
+	NextCursor string `json:"next_cursor"`
+}
+
+type referenceChannel struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	IsPrivate  bool   `json:"is_private"`
+	IsArchived bool   `json:"is_archived"`
+	Topic      struct {
+		Value string `json:"value"`
+	} `json:"topic"`
+	Purpose struct {
+		Value string `json:"value"`
+	} `json:"purpose"`
+}
+
+type referenceUser struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	RealName string `json:"real_name"`
+	IsBot    bool   `json:"is_bot"`
+	TZ       string `json:"tz"`
+	Profile  struct {
+		RealName    string `json:"real_name"`
+		DisplayName string `json:"display_name"`
+		Title       string `json:"title"`
+		Email       string `json:"email"`
+	} `json:"profile"`
+}
+
+type referenceMessage struct {
+	TS          string `json:"ts"`
+	ThreadTS    string `json:"thread_ts"`
+	User        string `json:"user"`
+	BotID       string `json:"bot_id"`
+	Username    string `json:"username"`
+	Text        string `json:"text"`
+	ReplyCount  int    `json:"reply_count"`
+	LatestReply string `json:"latest_reply"`
+	Reactions   []struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	} `json:"reactions"`
+	Files []struct {
+		Name     string `json:"name"`
+		Title    string `json:"title"`
+		Mimetype string `json:"mimetype"`
+	} `json:"files"`
+}
+
+func (c *Client) referenceChannels(ctx context.Context, tools toolset) ([]ChannelRecord, error) {
+	return collectPages(c.maxPages, func(cursor string) (page[ChannelRecord], error) {
+		raw, err := c.mcp.CallToolText(ctx, tools.searchChannels, map[string]any{
+			"cursor": cursor,
+			"limit":  min(c.searchLimit, 200),
+		})
+		if err != nil {
+			return page[ChannelRecord]{}, err
+		}
+		var response referenceResponse
+		if err := decodeReferenceResponse(raw, &response); err != nil {
+			return page[ChannelRecord]{}, fmt.Errorf("decode reference Slack channels: %w", err)
+		}
+		channels := make([]ChannelRecord, 0, len(response.Channels))
+		for _, channel := range response.Channels {
+			kind := "public_channel"
+			if channel.IsPrivate {
+				kind = "private_channel"
+			}
+			channels = append(channels, ChannelRecord{
+				ID:         channel.ID,
+				Name:       channel.Name,
+				Kind:       kind,
+				Topic:      channel.Topic.Value,
+				Purpose:    channel.Purpose.Value,
+				IsPrivate:  channel.IsPrivate,
+				IsArchived: channel.IsArchived,
+			})
+		}
+		return page[ChannelRecord]{Items: channels, NextCursor: response.ResponseMetadata.NextCursor}, nil
+	})
+}
+
+func (c *Client) referenceUsers(ctx context.Context, tools toolset) ([]UserRecord, error) {
+	return collectPages(c.maxPages, func(cursor string) (page[UserRecord], error) {
+		raw, err := c.mcp.CallToolText(ctx, tools.searchUsers, map[string]any{
+			"cursor": cursor,
+			"limit":  min(c.searchLimit, 200),
+		})
+		if err != nil {
+			return page[UserRecord]{}, err
+		}
+		var response referenceResponse
+		if err := decodeReferenceResponse(raw, &response); err != nil {
+			return page[UserRecord]{}, fmt.Errorf("decode reference Slack users: %w", err)
+		}
+		users := make([]UserRecord, 0, len(response.Members))
+		for _, user := range response.Members {
+			users = append(users, UserRecord{
+				ID:       user.ID,
+				Name:     firstNonEmpty(user.Profile.DisplayName, user.Name),
+				RealName: firstNonEmpty(user.Profile.RealName, user.RealName),
+				Title:    user.Profile.Title,
+				Email:    user.Profile.Email,
+				Timezone: user.TZ,
+				IsBot:    user.IsBot,
+			})
+		}
+		return page[UserRecord]{Items: users, NextCursor: response.ResponseMetadata.NextCursor}, nil
+	})
+}
+
+func (c *Client) referenceChannelMessages(ctx context.Context, tools toolset, channelID, oldest string) (channelPage, error) {
+	raw, err := c.mcp.CallToolText(ctx, tools.readChannel, map[string]any{
+		"channel_id": channelID,
+		"limit":      c.pageSize,
+	})
+	if err != nil {
+		return channelPage{}, err
+	}
+	var response referenceResponse
+	if err := decodeReferenceResponse(raw, &response); err != nil {
+		return channelPage{}, fmt.Errorf("decode reference Slack channel history: %w", err)
+	}
+	messages := make([]MessageRecord, 0, len(response.Messages))
+	for _, message := range response.Messages {
+		if !timestampAtLeast(message.TS, oldest) {
+			continue
+		}
+		messages = append(messages, referenceMessageRecord(channelID, message))
+	}
+	return channelPage{ChannelID: channelID, Messages: messages}, nil
+}
+
+func (c *Client) referenceThreadMessages(ctx context.Context, tools toolset, channelID, threadTS string) (threadPage, error) {
+	raw, err := c.mcp.CallToolText(ctx, tools.readThread, map[string]any{
+		"channel_id": channelID,
+		"thread_ts":  threadTS,
+	})
+	if err != nil {
+		return threadPage{}, err
+	}
+	var response referenceResponse
+	if err := decodeReferenceResponse(raw, &response); err != nil {
+		return threadPage{}, fmt.Errorf("decode reference Slack thread: %w", err)
+	}
+	result := threadPage{}
+	for i, message := range response.Messages {
+		record := referenceMessageRecord(channelID, message)
+		if message.TS == threadTS || i == 0 && result.Parent == nil {
+			record.ThreadTS = ""
+			copy := record
+			result.Parent = &copy
+			continue
+		}
+		record.ThreadTS = threadTS
+		result.Replies = append(result.Replies, record)
+	}
+	return result, nil
+}
+
+func decodeReferenceResponse(raw string, response *referenceResponse) error {
+	if err := json.Unmarshal([]byte(raw), response); err != nil {
+		return err
+	}
+	if response.Error != "" {
+		return fmt.Errorf("Slack API error: %s", response.Error)
+	}
+	return nil
+}
+
+func referenceMessageRecord(channelID string, message referenceMessage) MessageRecord {
+	authorID := firstNonEmpty(message.User, message.BotID)
+	reactions := make([]string, 0, len(message.Reactions))
+	for _, reaction := range message.Reactions {
+		value := reaction.Name
+		if reaction.Count > 0 {
+			value += ":" + strconv.Itoa(reaction.Count)
+		}
+		reactions = append(reactions, value)
+	}
+	files := make([]string, 0, len(message.Files))
+	for _, file := range message.Files {
+		value := firstNonEmpty(file.Title, file.Name, file.Mimetype)
+		if value != "" {
+			files = append(files, value)
+		}
+	}
+	return MessageRecord{
+		ChannelID:     channelID,
+		TS:            message.TS,
+		ThreadTS:      message.ThreadTS,
+		AuthorID:      authorID,
+		AuthorName:    message.Username,
+		Text:          message.Text,
+		ReplyCount:    message.ReplyCount,
+		LatestReply:   message.LatestReply,
+		Reactions:     reactions,
+		FileSummaries: files,
+	}
+}
+
+func timestampAtLeast(value, oldest string) bool {
+	oldest = strings.TrimSpace(oldest)
+	if oldest == "" {
+		return true
+	}
+	valueNumber, valueErr := strconv.ParseFloat(value, 64)
+	oldestNumber, oldestErr := strconv.ParseFloat(oldest, 64)
+	if valueErr == nil && oldestErr == nil {
+		return valueNumber >= oldestNumber
+	}
+	return value >= oldest
+}

--- a/internal/slackmcp/sync.go
+++ b/internal/slackmcp/sync.go
@@ -1,0 +1,370 @@
+package slackmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/slack-go/slack"
+
+	"github.com/openclaw/slacrawl/internal/config"
+	"github.com/openclaw/slacrawl/internal/search"
+	"github.com/openclaw/slacrawl/internal/store"
+)
+
+const (
+	SourceName = "mcp"
+	SourceRank = 4
+)
+
+var channelIDRE = regexp.MustCompile(`^[CDG][A-Z0-9]+$`)
+
+type Options struct {
+	WorkspaceID     string
+	Channels        []string
+	ExcludeChannels []string
+	Since           string
+	Full            bool
+	LatestOnly      bool
+	Logger          *slog.Logger
+	HTTPClient      *http.Client
+	Config          config.MCPConfig
+}
+
+type Summary struct {
+	WorkspaceID string `json:"workspace_id,omitempty"`
+	Channels    int    `json:"channels"`
+	Users       int    `json:"users"`
+	Messages    int    `json:"messages"`
+	Replies     int    `json:"replies"`
+}
+
+func Sync(ctx context.Context, st *store.Store, opts Options) (Summary, error) {
+	workspaceID := strings.TrimSpace(opts.WorkspaceID)
+	if workspaceID == "" {
+		return Summary{}, errors.New("workspace ID is required for MCP sync because the connector does not report one")
+	}
+	client, err := New(ctx, opts.Config, opts.HTTPClient)
+	if err != nil {
+		return Summary{}, err
+	}
+	defer func() { _ = client.Close() }()
+	tools, err := client.discover(ctx)
+	if err != nil {
+		return Summary{}, err
+	}
+	now := time.Now().UTC()
+	if err := st.EnsureWorkspace(ctx, store.Workspace{
+		ID:        workspaceID,
+		Name:      workspaceID,
+		RawJSON:   store.MarshalRaw(map[string]any{"source": SourceName}),
+		UpdatedAt: now,
+	}); err != nil {
+		return Summary{}, err
+	}
+
+	channels, err := resolveChannels(ctx, client, tools, opts.Channels)
+	if err != nil {
+		return Summary{}, err
+	}
+	channels = filterChannels(channels, opts.ExcludeChannels)
+	userCount := 0
+	if len(opts.Channels) == 0 {
+		users, err := client.users(ctx, tools)
+		if err != nil {
+			return Summary{}, err
+		}
+		for _, user := range users {
+			if err := st.EnsureUser(ctx, toStoreUser(workspaceID, user, now)); err != nil {
+				return Summary{}, err
+			}
+		}
+		userCount = len(users)
+	}
+
+	oldestByChannel, selected, err := syncPlan(ctx, st, workspaceID, channels, opts)
+	if err != nil {
+		return Summary{}, err
+	}
+	summary := Summary{WorkspaceID: workspaceID, Users: userCount}
+	for _, channel := range selected {
+		channelResult, err := client.channelMessages(ctx, tools, channel.ID, oldestByChannel[channel.ID])
+		if err != nil {
+			return summary, fmt.Errorf("read MCP channel %s: %w", channel.ID, err)
+		}
+		if channel.Name == "" {
+			channel.Name = channelResult.ChannelName
+		}
+		if channel.Kind == "" {
+			channel.Kind = "mcp_channel"
+		}
+		if err := st.EnsureChannel(ctx, toStoreChannel(workspaceID, channel, now)); err != nil {
+			return summary, err
+		}
+		summary.Channels++
+
+		threadRoots := map[string]struct{}{}
+		for _, message := range channelResult.Messages {
+			if err := upsertMessage(ctx, st, workspaceID, message, now); err != nil {
+				return summary, err
+			}
+			summary.Messages++
+			if message.ReplyCount > 0 {
+				threadRoots[message.TS] = struct{}{}
+			}
+		}
+		if tools.readThread == "" {
+			continue
+		}
+		storedRoots, err := st.ChannelThreadRoots(ctx, workspaceID, channel.ID)
+		if err != nil {
+			return summary, err
+		}
+		for _, root := range storedRoots {
+			threadRoots[root.TS] = struct{}{}
+		}
+		orderedRoots := make([]string, 0, len(threadRoots))
+		for threadTS := range threadRoots {
+			orderedRoots = append(orderedRoots, threadTS)
+		}
+		sort.Strings(orderedRoots)
+		for _, threadTS := range orderedRoots {
+			replies, err := syncThread(ctx, st, client, tools, workspaceID, channel.ID, threadTS, now)
+			if err != nil {
+				return summary, err
+			}
+			summary.Replies += replies
+		}
+	}
+	if err := st.SetSyncState(ctx, SourceName, "workspace", workspaceID, now.Format(time.RFC3339)); err != nil {
+		return summary, err
+	}
+	return summary, nil
+}
+
+func syncThread(ctx context.Context, st *store.Store, client *Client, tools toolset, workspaceID, channelID, threadTS string, now time.Time) (int, error) {
+	thread, err := client.threadMessages(ctx, tools, channelID, threadTS)
+	if err != nil {
+		return 0, fmt.Errorf("read MCP thread %s/%s: %w", channelID, threadTS, err)
+	}
+	if thread.Parent != nil {
+		thread.Parent.ReplyCount = max(thread.Parent.ReplyCount, len(thread.Replies))
+		thread.Parent.LatestReply = latestReplyTS(thread.Parent.LatestReply, thread.Replies)
+		if err := upsertMessage(ctx, st, workspaceID, *thread.Parent, now); err != nil {
+			return 0, err
+		}
+	}
+	for _, reply := range thread.Replies {
+		if err := upsertMessage(ctx, st, workspaceID, reply, now); err != nil {
+			return 0, err
+		}
+	}
+	return len(thread.Replies), nil
+}
+
+func resolveChannels(ctx context.Context, client *Client, tools toolset, selectors []string) ([]ChannelRecord, error) {
+	if len(selectors) == 0 {
+		return client.channels(ctx, tools, "")
+	}
+	seen := map[string]struct{}{}
+	var channels []ChannelRecord
+	for _, selector := range selectors {
+		selector = strings.TrimSpace(strings.TrimPrefix(selector, "#"))
+		if selector == "" {
+			continue
+		}
+		if channelIDRE.MatchString(selector) {
+			if _, ok := seen[selector]; !ok {
+				seen[selector] = struct{}{}
+				channels = append(channels, ChannelRecord{ID: selector})
+			}
+			continue
+		}
+		matches, err := client.channels(ctx, tools, selector)
+		if err != nil {
+			return nil, err
+		}
+		found := false
+		for _, channel := range matches {
+			if !strings.EqualFold(channel.Name, selector) && !strings.EqualFold(channel.ID, selector) {
+				continue
+			}
+			found = true
+			if _, ok := seen[channel.ID]; !ok {
+				seen[channel.ID] = struct{}{}
+				channels = append(channels, channel)
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("MCP channel %q not found", selector)
+		}
+	}
+	return channels, nil
+}
+
+func filterChannels(channels []ChannelRecord, excluded []string) []ChannelRecord {
+	if len(excluded) == 0 {
+		return channels
+	}
+	set := make(map[string]struct{}, len(excluded))
+	for _, value := range excluded {
+		set[strings.ToLower(strings.TrimPrefix(strings.TrimSpace(value), "#"))] = struct{}{}
+	}
+	filtered := make([]ChannelRecord, 0, len(channels))
+	for _, channel := range channels {
+		if _, ok := set[strings.ToLower(channel.ID)]; ok {
+			continue
+		}
+		if _, ok := set[strings.ToLower(channel.Name)]; ok {
+			continue
+		}
+		filtered = append(filtered, channel)
+	}
+	return filtered
+}
+
+func syncPlan(ctx context.Context, st *store.Store, workspaceID string, channels []ChannelRecord, opts Options) (map[string]string, []ChannelRecord, error) {
+	oldest := make(map[string]string, len(channels))
+	if opts.Since != "" {
+		since := normalizeTimestamp(opts.Since)
+		for _, channel := range channels {
+			oldest[channel.ID] = since
+		}
+		return oldest, channels, nil
+	}
+	if opts.Full {
+		return oldest, channels, nil
+	}
+	cursors, err := st.ChannelSyncCursors(ctx, workspaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	latest := make(map[string]string, len(cursors))
+	for _, cursor := range cursors {
+		latest[cursor.ID] = cursor.LatestTS
+	}
+	selected := make([]ChannelRecord, 0, len(channels))
+	for _, channel := range channels {
+		cursor := latest[channel.ID]
+		if opts.LatestOnly && cursor == "" {
+			continue
+		}
+		selected = append(selected, channel)
+		oldest[channel.ID] = overlapTimestamp(cursor, time.Hour)
+	}
+	return oldest, selected, nil
+}
+
+func toStoreChannel(workspaceID string, channel ChannelRecord, now time.Time) store.Channel {
+	return store.Channel{
+		ID:          channel.ID,
+		WorkspaceID: workspaceID,
+		Name:        channel.Name,
+		Kind:        channel.Kind,
+		Topic:       channel.Topic,
+		Purpose:     channel.Purpose,
+		IsPrivate:   channel.IsPrivate,
+		IsArchived:  channel.IsArchived,
+		RawJSON:     store.MarshalRaw(channel),
+		UpdatedAt:   now,
+	}
+}
+
+func toStoreUser(workspaceID string, user UserRecord, now time.Time) store.User {
+	return store.User{
+		ID:          user.ID,
+		WorkspaceID: workspaceID,
+		Name:        user.Name,
+		RealName:    user.RealName,
+		DisplayName: user.Name,
+		Title:       user.Title,
+		IsBot:       user.IsBot,
+		RawJSON:     store.MarshalRaw(user),
+		UpdatedAt:   now,
+	}
+}
+
+func upsertMessage(ctx context.Context, st *store.Store, workspaceID string, message MessageRecord, now time.Time) error {
+	threadTS := message.ThreadTS
+	if threadTS == message.TS {
+		threadTS = ""
+	}
+	slackMessage := slack.Message{Msg: slack.Msg{
+		Channel:         message.ChannelID,
+		Timestamp:       message.TS,
+		ThreadTimestamp: threadTS,
+		User:            message.AuthorID,
+		Text:            message.Text,
+		ReplyCount:      message.ReplyCount,
+		LatestReply:     normalizeTimestamp(message.LatestReply),
+	}}
+	mentions := search.ExtractMentions(message.Text)
+	storedMentions := make([]store.Mention, 0, len(mentions))
+	for _, mention := range mentions {
+		storedMentions = append(storedMentions, store.Mention{
+			Type:        mention.Type,
+			TargetID:    mention.TargetID,
+			DisplayText: mention.DisplayText,
+		})
+	}
+	_, err := st.UpsertMessageByPriority(ctx, store.Message{
+		ChannelID:      message.ChannelID,
+		TS:             message.TS,
+		WorkspaceID:    workspaceID,
+		UserID:         message.AuthorID,
+		ThreadTS:       threadTS,
+		Text:           message.Text,
+		NormalizedText: search.NormalizeMessage(slackMessage),
+		ReplyCount:     message.ReplyCount,
+		LatestReply:    normalizeTimestamp(message.LatestReply),
+		SourceRank:     SourceRank,
+		SourceName:     SourceName,
+		RawJSON:        store.MarshalRaw(message),
+		UpdatedAt:      now,
+		Files:          nil,
+	}, storedMentions)
+	return err
+}
+
+func latestReplyTS(current string, replies []MessageRecord) string {
+	latest := normalizeTimestamp(current)
+	for _, reply := range replies {
+		if reply.TS > latest {
+			latest = reply.TS
+		}
+	}
+	return latest
+}
+
+func normalizeTimestamp(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if _, err := strconv.ParseFloat(value, 64); err == nil {
+		return value
+	}
+	if parsed, err := time.Parse(time.RFC3339, value); err == nil {
+		return fmt.Sprintf("%d.%06d", parsed.Unix(), parsed.Nanosecond()/1000)
+	}
+	return value
+}
+
+func overlapTimestamp(value string, overlap time.Duration) string {
+	if value == "" {
+		return ""
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return value
+	}
+	return strconv.FormatFloat(math.Max(parsed-overlap.Seconds(), 0), 'f', 6, 64)
+}

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -78,6 +78,32 @@ on conflict(channel_id, ts) do update set
   updated_at=excluded.updated_at
 where messages.workspace_id = excluded.workspace_id;
 
+-- name: UpsertMessageByPriority :execrows
+insert into messages (
+  channel_id, ts, workspace_id, user_id, subtype, client_msg_id, thread_ts, parent_user_id,
+  text, normalized_text, reply_count, latest_reply, edited_ts, deleted_ts, source_rank,
+  source_name, raw_json, updated_at
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(channel_id, ts) do update set
+  workspace_id=excluded.workspace_id,
+  user_id=excluded.user_id,
+  subtype=excluded.subtype,
+  client_msg_id=excluded.client_msg_id,
+  thread_ts=excluded.thread_ts,
+  parent_user_id=excluded.parent_user_id,
+  text=excluded.text,
+  normalized_text=excluded.normalized_text,
+  reply_count=excluded.reply_count,
+  latest_reply=excluded.latest_reply,
+  edited_ts=excluded.edited_ts,
+  deleted_ts=excluded.deleted_ts,
+  source_rank=excluded.source_rank,
+  source_name=excluded.source_name,
+  raw_json=excluded.raw_json,
+  updated_at=excluded.updated_at
+where messages.workspace_id = excluded.workspace_id
+  and excluded.source_rank <= messages.source_rank;
+
 -- name: GetMessageWorkspace :one
 select workspace_id from messages where channel_id = ? and ts = ?;
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -461,6 +461,11 @@ type ChannelSyncCursor struct {
 	LatestTS string
 }
 
+type ThreadRoot struct {
+	ChannelID string
+	TS        string
+}
+
 type SyncStateRow struct {
 	SourceName string `json:"source_name"`
 	EntityType string `json:"entity_type"`
@@ -559,6 +564,17 @@ func (s *Store) UpsertWorkspace(ctx context.Context, workspace Workspace) error 
 	})
 }
 
+// EnsureWorkspace inserts sparse provider metadata without replacing richer data
+// already collected by another source.
+func (s *Store) EnsureWorkspace(ctx context.Context, workspace Workspace) error {
+	_, err := s.db.ExecContext(ctx, `
+insert into workspaces (id, name, domain, enterprise_id, raw_json, updated_at)
+values (?, ?, ?, ?, ?, ?)
+on conflict(id) do nothing
+`, workspace.ID, workspace.Name, dbText(workspace.Domain), dbText(workspace.EnterpriseID), workspace.RawJSON, formatDBTime(workspace.UpdatedAt))
+	return err
+}
+
 func (s *Store) UpsertChannel(ctx context.Context, channel Channel) error {
 	rows, err := s.q.UpsertChannel(ctx, storedb.UpsertChannelParams{
 		ID:          channel.ID,
@@ -601,6 +617,31 @@ func (s *Store) UpsertChannel(ctx context.Context, channel Channel) error {
 			return err
 		}
 		return fmt.Errorf("channel %q upsert affected no rows", channel.ID)
+	}
+	return nil
+}
+
+// EnsureChannel inserts lower-fidelity provider metadata without replacing an
+// existing channel collected by a richer source.
+func (s *Store) EnsureChannel(ctx context.Context, channel Channel) error {
+	result, err := s.db.ExecContext(ctx, `
+insert into channels (id, workspace_id, name, kind, topic, purpose, is_private, is_archived, is_shared, is_general, raw_json, updated_at)
+values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(id) do nothing
+`, channel.ID, channel.WorkspaceID, channel.Name, channel.Kind, dbText(channel.Topic), dbText(channel.Purpose), boolInt(channel.IsPrivate), boolInt(channel.IsArchived), boolInt(channel.IsShared), boolInt(channel.IsGeneral), channel.RawJSON, formatDBTime(channel.UpdatedAt))
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil || rows > 0 {
+		return err
+	}
+	existing, err := s.getChannelWorkspaceKind(ctx, channel.ID)
+	if err != nil {
+		return err
+	}
+	if existing.WorkspaceID != channel.WorkspaceID {
+		return &WorkspaceCollisionError{Entity: "channel", ID: channel.ID, ExistingWorkspaceID: existing.WorkspaceID, WorkspaceID: channel.WorkspaceID}
 	}
 	return nil
 }
@@ -659,57 +700,95 @@ func (s *Store) UpsertUser(ctx context.Context, user User) error {
 	return nil
 }
 
+// EnsureUser inserts lower-fidelity provider metadata without replacing an
+// existing user collected by a richer source.
+func (s *Store) EnsureUser(ctx context.Context, user User) error {
+	result, err := s.db.ExecContext(ctx, `
+insert into users (id, workspace_id, name, real_name, display_name, title, is_bot, is_deleted, raw_json, updated_at)
+values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(id) do nothing
+`, user.ID, user.WorkspaceID, user.Name, dbText(user.RealName), dbText(user.DisplayName), dbText(user.Title), boolInt(user.IsBot), boolInt(user.IsDeleted), user.RawJSON, formatDBTime(user.UpdatedAt))
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil || rows > 0 {
+		return err
+	}
+	existingWorkspaceID, err := s.q.GetUserWorkspace(ctx, user.ID)
+	if err != nil {
+		return err
+	}
+	if existingWorkspaceID != user.WorkspaceID {
+		return &WorkspaceCollisionError{Entity: "user", ID: user.ID, ExistingWorkspaceID: existingWorkspaceID, WorkspaceID: user.WorkspaceID}
+	}
+	return nil
+}
+
 func (s *Store) UpsertMessage(ctx context.Context, message Message, mentions []Mention) error {
+	_, err := s.upsertMessage(ctx, message, mentions, false)
+	return err
+}
+
+// UpsertMessageByPriority atomically skips updates from a lower-priority source.
+func (s *Store) UpsertMessageByPriority(ctx context.Context, message Message, mentions []Mention) (bool, error) {
+	return s.upsertMessage(ctx, message, mentions, true)
+}
+
+func (s *Store) upsertMessage(ctx context.Context, message Message, mentions []Mention, preserveHigherPriority bool) (bool, error) {
 	key := messageKey(message.ChannelID, message.TS)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = tx.Rollback() }()
 	qtx := s.q.WithTx(tx)
 
-	rows, err := qtx.UpsertMessage(ctx, storedb.UpsertMessageParams{
-		ChannelID:      message.ChannelID,
-		Ts:             message.TS,
-		WorkspaceID:    message.WorkspaceID,
-		UserID:         dbText(message.UserID),
-		Subtype:        dbText(message.Subtype),
-		ClientMsgID:    dbText(message.ClientMsgID),
-		ThreadTs:       dbText(message.ThreadTS),
-		ParentUserID:   dbText(message.ParentUserID),
-		Text:           message.Text,
-		NormalizedText: message.NormalizedText,
-		ReplyCount:     int64(message.ReplyCount),
-		LatestReply:    dbText(message.LatestReply),
-		EditedTs:       dbText(message.EditedTS),
-		DeletedTs:      dbText(message.DeletedTS),
-		SourceRank:     int64(message.SourceRank),
-		SourceName:     message.SourceName,
-		RawJson:        message.RawJSON,
-		UpdatedAt:      formatDBTime(message.UpdatedAt),
-	})
+	var rows int64
+	if preserveHigherPriority {
+		rows, err = qtx.UpsertMessageByPriority(ctx, storedb.UpsertMessageByPriorityParams{
+			ChannelID: message.ChannelID, Ts: message.TS, WorkspaceID: message.WorkspaceID,
+			UserID: dbText(message.UserID), Subtype: dbText(message.Subtype), ClientMsgID: dbText(message.ClientMsgID),
+			ThreadTs: dbText(message.ThreadTS), ParentUserID: dbText(message.ParentUserID), Text: message.Text,
+			NormalizedText: message.NormalizedText, ReplyCount: int64(message.ReplyCount), LatestReply: dbText(message.LatestReply),
+			EditedTs: dbText(message.EditedTS), DeletedTs: dbText(message.DeletedTS), SourceRank: int64(message.SourceRank),
+			SourceName: message.SourceName, RawJson: message.RawJSON, UpdatedAt: formatDBTime(message.UpdatedAt),
+		})
+	} else {
+		rows, err = qtx.UpsertMessage(ctx, storedb.UpsertMessageParams{
+			ChannelID: message.ChannelID, Ts: message.TS, WorkspaceID: message.WorkspaceID,
+			UserID: dbText(message.UserID), Subtype: dbText(message.Subtype), ClientMsgID: dbText(message.ClientMsgID),
+			ThreadTs: dbText(message.ThreadTS), ParentUserID: dbText(message.ParentUserID), Text: message.Text,
+			NormalizedText: message.NormalizedText, ReplyCount: int64(message.ReplyCount), LatestReply: dbText(message.LatestReply),
+			EditedTs: dbText(message.EditedTS), DeletedTs: dbText(message.DeletedTS), SourceRank: int64(message.SourceRank),
+			SourceName: message.SourceName, RawJson: message.RawJSON, UpdatedAt: formatDBTime(message.UpdatedAt),
+		})
+	}
 	if err != nil {
-		return err
+		return false, err
 	}
 	if rows == 0 {
 		if err := rejectMessageWorkspaceCollision(ctx, qtx, message); err != nil {
-			return err
+			return false, err
 		}
-		return fmt.Errorf("message %q upsert affected no rows", key)
+		if preserveHigherPriority {
+			return false, nil
+		}
+		return false, fmt.Errorf("message %q upsert affected no rows", key)
 	}
 
 	if err := replaceMessageMentions(ctx, qtx, message.ChannelID, message.TS, mentions); err != nil {
-		return err
+		return false, err
 	}
 
 	filesForSearch := message.Files
 	if message.Files != nil {
 		existingMedia, err := existingFileMedia(ctx, qtx, message.ChannelID, message.TS)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if err := qtx.DeleteMessageFiles(ctx, storedb.DeleteMessageFilesParams{ChannelID: message.ChannelID, Ts: message.TS}); err != nil {
-			return err
+			return false, err
 		}
 		for i, file := range message.Files {
 			if file.WorkspaceID == "" {
@@ -737,24 +816,24 @@ func (s *Store) UpsertMessage(ctx context.Context, message Message, mentions []M
 			}
 			message.Files[i] = file
 			if err := qtx.InsertMessageFile(ctx, insertMessageFileParams(file)); err != nil {
-				return err
+				return false, err
 			}
 		}
 		filesForSearch = message.Files
 	} else {
 		filesForSearch, err = existingFilesForSearch(ctx, tx, message.ChannelID, message.TS)
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	if err := qtx.DeleteMessageFTS(ctx, key); err != nil {
-		return err
+		return false, err
 	}
 	searchMessage := message
 	searchMessage.Files = filesForSearch
 	if err := qtx.InsertMessageFTS(ctx, storedb.InsertMessageFTSParams{MessageKey: key, Content: messageSearchContent(searchMessage)}); err != nil {
-		return err
+		return false, err
 	}
 
 	if err := qtx.InsertMessageEvent(ctx, storedb.InsertMessageEventParams{
@@ -765,10 +844,13 @@ func (s *Store) UpsertMessage(ctx context.Context, message Message, mentions []M
 		PayloadJson: message.RawJSON,
 		CreatedAt:   formatDBTime(message.UpdatedAt),
 	}); err != nil {
-		return err
+		return false, err
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *Store) MarkMessageDeleted(ctx context.Context, message Message, mentions []Mention) error {
@@ -1814,6 +1896,39 @@ func (s *Store) ChannelSyncCursors(ctx context.Context, workspaceID string) ([]C
 		out = append(out, ChannelSyncCursor{ID: row.ID, LatestTS: row.LatestTs})
 	}
 	return out, nil
+}
+
+func (s *Store) ChannelThreadRoots(ctx context.Context, workspaceID, channelID string) ([]ThreadRoot, error) {
+	rows, err := s.db.QueryContext(ctx, `
+select m.channel_id, m.ts
+from messages m
+where m.workspace_id = ?
+  and m.channel_id = ?
+  and coalesce(m.thread_ts, '') = ''
+  and (
+    m.reply_count > 0
+    or exists (
+      select 1 from messages r
+      where r.workspace_id = m.workspace_id
+        and r.channel_id = m.channel_id
+        and r.thread_ts = m.ts
+    )
+  )
+order by m.ts
+`, workspaceID, channelID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var roots []ThreadRoot
+	for rows.Next() {
+		var root ThreadRoot
+		if err := rows.Scan(&root.ChannelID, &root.TS); err != nil {
+			return nil, err
+		}
+		roots = append(roots, root)
+	}
+	return roots, rows.Err()
 }
 
 func (s *Store) RenameChannel(ctx context.Context, channelID string, name string) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -160,6 +160,36 @@ func TestUpsertMessagePreservesSourcePrecedenceAndRefreshesSearch(t *testing.T) 
 	require.Empty(t, matches)
 }
 
+func TestUpsertMessageByPrioritySkipsLowerPriorityContent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	require.NoError(t, s.UpsertMessage(ctx, Message{
+		ChannelID: "C1", TS: "123.45", WorkspaceID: "T1", Text: "richer",
+		NormalizedText: "richer", SourceRank: 1, SourceName: "api-user", RawJSON: `{"source":"api"}`, UpdatedAt: now,
+	}, []Mention{{Type: "user", TargetID: "U1"}}))
+
+	written, err := s.UpsertMessageByPriority(ctx, Message{
+		ChannelID: "C1", TS: "123.45", WorkspaceID: "T1", Text: "lower priority",
+		NormalizedText: "lower priority", SourceRank: 4, SourceName: "mcp", RawJSON: `{"source":"mcp"}`, UpdatedAt: now.Add(time.Second),
+	}, []Mention{{Type: "user", TargetID: "U2"}})
+	require.NoError(t, err)
+	require.False(t, written)
+
+	rows, err := s.QueryReadOnly(ctx, `select text, source_name, source_rank from messages where channel_id = 'C1' and ts = '123.45'`)
+	require.NoError(t, err)
+	require.Equal(t, "richer", rows[0]["text"])
+	require.Equal(t, "api-user", rows[0]["source_name"])
+	require.Equal(t, int64(1), rows[0]["source_rank"])
+	mentions, err := s.QueryReadOnly(ctx, `select target_id from message_mentions where channel_id = 'C1' and ts = '123.45'`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"target_id": "U1"}}, mentions)
+}
+
 func TestQueryReadOnlyRejectsWritableCTE(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	s, err := Open(dbPath)

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -1471,6 +1471,81 @@ func (q *Queries) UpsertMessage(ctx context.Context, arg UpsertMessageParams) (i
 	return result.RowsAffected()
 }
 
+const upsertMessageByPriority = `-- name: UpsertMessageByPriority :execrows
+insert into messages (
+  channel_id, ts, workspace_id, user_id, subtype, client_msg_id, thread_ts, parent_user_id,
+  text, normalized_text, reply_count, latest_reply, edited_ts, deleted_ts, source_rank,
+  source_name, raw_json, updated_at
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(channel_id, ts) do update set
+  workspace_id=excluded.workspace_id,
+  user_id=excluded.user_id,
+  subtype=excluded.subtype,
+  client_msg_id=excluded.client_msg_id,
+  thread_ts=excluded.thread_ts,
+  parent_user_id=excluded.parent_user_id,
+  text=excluded.text,
+  normalized_text=excluded.normalized_text,
+  reply_count=excluded.reply_count,
+  latest_reply=excluded.latest_reply,
+  edited_ts=excluded.edited_ts,
+  deleted_ts=excluded.deleted_ts,
+  source_rank=excluded.source_rank,
+  source_name=excluded.source_name,
+  raw_json=excluded.raw_json,
+  updated_at=excluded.updated_at
+where messages.workspace_id = excluded.workspace_id
+  and excluded.source_rank <= messages.source_rank
+`
+
+type UpsertMessageByPriorityParams struct {
+	ChannelID      string         `json:"channel_id"`
+	Ts             string         `json:"ts"`
+	WorkspaceID    string         `json:"workspace_id"`
+	UserID         sql.NullString `json:"user_id"`
+	Subtype        sql.NullString `json:"subtype"`
+	ClientMsgID    sql.NullString `json:"client_msg_id"`
+	ThreadTs       sql.NullString `json:"thread_ts"`
+	ParentUserID   sql.NullString `json:"parent_user_id"`
+	Text           string         `json:"text"`
+	NormalizedText string         `json:"normalized_text"`
+	ReplyCount     int64          `json:"reply_count"`
+	LatestReply    sql.NullString `json:"latest_reply"`
+	EditedTs       sql.NullString `json:"edited_ts"`
+	DeletedTs      sql.NullString `json:"deleted_ts"`
+	SourceRank     int64          `json:"source_rank"`
+	SourceName     string         `json:"source_name"`
+	RawJson        string         `json:"raw_json"`
+	UpdatedAt      string         `json:"updated_at"`
+}
+
+func (q *Queries) UpsertMessageByPriority(ctx context.Context, arg UpsertMessageByPriorityParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, upsertMessageByPriority,
+		arg.ChannelID,
+		arg.Ts,
+		arg.WorkspaceID,
+		arg.UserID,
+		arg.Subtype,
+		arg.ClientMsgID,
+		arg.ThreadTs,
+		arg.ParentUserID,
+		arg.Text,
+		arg.NormalizedText,
+		arg.ReplyCount,
+		arg.LatestReply,
+		arg.EditedTs,
+		arg.DeletedTs,
+		arg.SourceRank,
+		arg.SourceName,
+		arg.RawJson,
+		arg.UpdatedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const upsertMessageMention = `-- name: UpsertMessageMention :exec
 insert into message_mentions (channel_id, ts, mention_type, target_id, display_text)
 values (?, ?, ?, ?, ?)

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openclaw/slacrawl/internal/config"
 	"github.com/openclaw/slacrawl/internal/slackapi"
 	"github.com/openclaw/slacrawl/internal/slackdesktop"
+	"github.com/openclaw/slacrawl/internal/slackmcp"
 	"github.com/openclaw/slacrawl/internal/store"
 )
 
@@ -18,6 +19,7 @@ type Source string
 const (
 	SourceAPI     Source = "api"
 	SourceDesktop Source = "desktop"
+	SourceMCP     Source = "mcp"
 	SourceAll     Source = "all"
 )
 
@@ -27,10 +29,12 @@ func ParseSource(value string) (Source, error) {
 		return SourceAPI, nil
 	case string(SourceDesktop), "wiretap":
 		return SourceDesktop, nil
+	case string(SourceMCP), "connector":
+		return SourceMCP, nil
 	case string(SourceAll), "hybrid":
 		return SourceAll, nil
 	default:
-		return "", fmt.Errorf("unsupported source %q: use api, bot, desktop, wiretap, or all", value)
+		return "", fmt.Errorf("unsupported source %q: use api, bot, desktop, wiretap, mcp, connector, or all", value)
 	}
 }
 
@@ -49,6 +53,7 @@ type Options struct {
 
 type Summary struct {
 	Desktop slackdesktop.Source `json:"desktop"`
+	MCP     *slackmcp.Summary   `json:"mcp,omitempty"`
 }
 
 func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) (Summary, error) {
@@ -74,6 +79,22 @@ func RunWithTokens(ctx context.Context, cfg config.Config, st *store.Store, opts
 		})
 	case SourceDesktop:
 		return syncDesktop(ctx, cfg, st)
+	case SourceMCP:
+		if !cfg.Slack.MCP.Enabled {
+			return summary, errors.New("slack MCP source is disabled in config")
+		}
+		mcpSummary, err := slackmcp.Sync(ctx, st, slackmcp.Options{
+			WorkspaceID:     opts.WorkspaceID,
+			Channels:        opts.Channels,
+			ExcludeChannels: opts.ExcludeChannels,
+			Since:           opts.Since,
+			Full:            opts.Full,
+			LatestOnly:      opts.LatestOnly,
+			Logger:          opts.Logger,
+			Config:          cfg.Slack.MCP,
+		})
+		summary.MCP = &mcpSummary
+		return summary, err
 	case SourceAll:
 		if err := apiClient.Sync(ctx, st, slackapi.SyncOptions{
 			WorkspaceID:     opts.WorkspaceID,

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -8,13 +8,15 @@ import (
 
 func TestParseSourceAliases(t *testing.T) {
 	cases := map[string]Source{
-		"":        SourceAPI,
-		"api":     SourceAPI,
-		"bot":     SourceAPI,
-		"desktop": SourceDesktop,
-		"wiretap": SourceDesktop,
-		"all":     SourceAll,
-		"hybrid":  SourceAll,
+		"":          SourceAPI,
+		"api":       SourceAPI,
+		"bot":       SourceAPI,
+		"desktop":   SourceDesktop,
+		"wiretap":   SourceDesktop,
+		"mcp":       SourceMCP,
+		"connector": SourceMCP,
+		"all":       SourceAll,
+		"hybrid":    SourceAll,
 	}
 	for input, want := range cases {
 		got, err := ParseSource(input)


### PR DESCRIPTION
## Summary

- add generic MCP Slack ingestion over Codex HTTP JSON-RPC and stdio transports
- support Codex connector and reference Slack MCP tool contracts
- preserve higher-quality existing archive rows and reconcile persisted threads incrementally
- document configuration, authentication, limits, and source behavior

## Validation

- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go build ./cmd/slacrawl`
- structured autoreview with accepted findings fixed and regression-tested
- live OpenAI Slack connector E2E against `#codex-feedback`: 5 roots, 5 replies, 10 unique stored messages across repeated syncs
- live unfiltered connector probe confirmed workspace search pagination behavior
