### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Install deadcode
+        run: go install golang.org/x/tools/cmd/deadcode@v0.45.0
+
+      - name: Deadcode
+        run: '"$(go env GOPATH)/bin/deadcode" -test ./...'
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,13 @@ jobs:
         run: go install golang.org/x/tools/cmd/deadcode@v0.45.0
 
       - name: Deadcode
-        run: '"$(go env GOPATH)/bin/deadcode" -test ./...'
+        run: |
+          output_file=$(mktemp)
+          "$(go env GOPATH)/bin/deadcode" -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
   test:
     runs-on: ubuntu-latest

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1822,10 +1822,6 @@ func stripKnownFlags(args []string, strip map[string]bool) []string {
 	return out
 }
 
-func WithTimeout(parent context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(parent, 30*time.Second)
-}
-
 func (a *App) runPublish(ctx context.Context, configPath string, args []string, format OutputFormat) error {
 	cfg, err := loadConfig(configPath)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -490,16 +490,6 @@ func DetectDesktopPath() (string, error) {
 	return "", nil
 }
 
-func ValidateTokenShape(value string, prefix string) error {
-	if value == "" {
-		return errors.New("token missing")
-	}
-	if !strings.HasPrefix(value, prefix) {
-		return fmt.Errorf("token must start with %s", prefix)
-	}
-	return nil
-}
-
 func Redact(value string) string {
 	if value == "" {
 		return ""

--- a/internal/search/normalize.go
+++ b/internal/search/normalize.go
@@ -81,10 +81,6 @@ func NormalizeMessage(msg slack.Message) string {
 	return joinNormalizedParts(parts)
 }
 
-func NormalizeRawPayloadText(value any) string {
-	return strings.Join(normalizeRawPayloadParts(value), " ")
-}
-
 func normalizeRawPayloadParts(value any) []string {
 	parts := make([]string, 0)
 	appendRawVisibleText(&parts, value, "")
@@ -728,16 +724,6 @@ func display(label string, fallback string) string {
 		return label
 	}
 	return fallback
-}
-
-func filterEmpty(parts []string) []string {
-	filtered := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if strings.TrimSpace(part) != "" {
-			filtered = append(filtered, strings.TrimSpace(part))
-		}
-	}
-	return filtered
 }
 
 func sanitizeText(raw string) string {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1087,13 +1087,6 @@ func (s *Store) DeleteSyncState(ctx context.Context, source, entityType, entityI
 	})
 }
 
-func (s *Store) DeleteSyncStateByType(ctx context.Context, source, entityType string) error {
-	return s.q.DeleteSyncStateByType(ctx, storedb.DeleteSyncStateByTypeParams{
-		SourceName: source,
-		EntityType: entityType,
-	})
-}
-
 func (s *Store) DeleteSyncStateByTypePrefix(ctx context.Context, source, entityType, entityIDPrefix string) error {
 	return s.q.DeleteSyncStateByTypePrefix(ctx, storedb.DeleteSyncStateByTypePrefixParams{
 		SourceName:   source,
@@ -2099,35 +2092,11 @@ func stringifyDBValue(value any) any {
 	}
 }
 
-func DebugJSON(value any) string {
-	data, _ := json.MarshalIndent(value, "", "  ")
-	return string(data)
-}
-
-func ParseTime(value string) string {
-	if value == "" {
-		return ""
-	}
-	if parsed, err := time.Parse(time.RFC3339, value); err == nil {
-		return parsed.Format(time.RFC3339)
-	}
-	return value
-}
-
 func RequireLimit(limit int) int {
 	if limit <= 0 {
 		return 50
 	}
 	return limit
-}
-
-func PrettyStatus(status Status) string {
-	last := "never"
-	if !status.LastSyncAt.IsZero() {
-		last = status.LastSyncAt.Format(time.RFC3339)
-	}
-	return fmt.Sprintf("workspaces=%d channels=%d users=%d messages=%d last_sync=%s thread_state=%s",
-		status.Workspaces, status.Channels, status.Users, status.Messages, last, status.ThreadState)
 }
 
 func readSchemaVersion(db *sql.DB) (int, error) {


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove the eight unreachable helpers reported on current `main`
- fail the lint job whenever deadcode emits findings

## How it works

The lint job installs the pinned `deadcode` binary, then analyzes all packages with `-test`. The tool writes unreachable-function findings to stdout but exits successfully, so the workflow captures stdout in a temporary file and explicitly fails when that file is non-empty. Tool crashes, package-load failures, or install failures still fail normally through GitHub Actions' `bash -e` behavior.

Including `-test` adds test executables as reachability roots. Helpers used only by tests remain live; reported public helpers also identify possible test-coverage gaps.

## Validation
- `git diff --check origin/main...HEAD`
- exact gate command on PR head: clean, zero findings
- negative control against pre-PR `main`: eight findings, gate rejected as expected
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go build ./cmd/slacrawl`
- `autoreview --mode branch --base origin/main --no-web-search --thinking high`: clean
