### PR TITLE
fix: detect linux slack desktop path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.7.2 - Unreleased
 
+### Changes
+
+- Added automatic Slack Desktop cache discovery on Linux using `XDG_CONFIG_HOME` or `~/.config`. Thanks @TurboTheTurtle.
+
 ## 0.7.1 - 2026-06-08
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -427,16 +427,22 @@ The starter config lives in [`config.example.toml`](./config.example.toml). By d
 - `SLACK_APP_TOKEN`
 - `SLACK_USER_TOKEN`
 
-Desktop discovery is enabled by default and uses:
+Desktop discovery is enabled by default and checks the supported Slack Desktop
+locations for your platform:
 
 ```text
+# macOS
 ~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack
+
+# Linux
+${XDG_CONFIG_HOME}/Slack
+~/.config/Slack
 ```
 
 Desktop config notes:
 
 - set `[slack.desktop].enabled = false` to disable desktop ingestion
-- leave `[slack.desktop].path = ""` to auto-detect the macOS Slack path
+- leave `[slack.desktop].path = ""` to auto-detect the macOS or Linux Slack path
 - set a custom absolute path if Slack Desktop data lives elsewhere
 - set `[slack.bot]`, `[slack.app]`, or `[slack.user]` `enabled = false` to ignore that token source entirely
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Data stays on your machine. You can run it in API mode, MCP connector mode, desk
 - channel threads
 - local FTS search
 - read-only SQL access
-- macOS Slack Desktop discovery
+- macOS and Linux Slack Desktop discovery
 - optional Slack file media caching
 
 ## Not Yet Included
@@ -68,7 +68,7 @@ If one of those gaps matters to your workflow, open an issue so it can be tracke
 - a configured Slack MCP connector if you want MCP-backed sync
 - an app token if you want to use `tail`
 - an optional user token for fuller historical thread coverage
-- macOS Slack Desktop only if you want desktop-local discovery
+- Slack Desktop on macOS or Linux only if you want desktop-local discovery
 
 ## Install
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -25,7 +25,7 @@ V1 scope:
 - current workspace user snapshot
 - FTS5 search
 - raw SQL access
-- desktop-local Slack discovery on macOS
+- desktop-local Slack discovery on macOS and Linux
 
 Out of scope for V1:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -46,7 +46,7 @@ Out of scope for V1:
 - source precedence: user-token API, then bot-token API and slack-export imports, then desktop-local cache
 - files: metadata only in DB for V1
 - future file-blob backup must store Git-share media as gzip-compressed files, import those files back into raw local cache layout, and keep legacy raw-media import compatibility
-- desktop-local source: macOS Slack Desktop container path only
+- desktop-local source: supported Slack Desktop cache paths on macOS and Linux
 
 ## Local Environment Contract
 
@@ -54,8 +54,10 @@ An agent should assume:
 
 - shell: `zsh`
 - Go `1.25+` is installed
-- macOS desktop-local Slack data may exist under:
+- desktop-local Slack data may exist under:
   - `~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack`
+  - `${XDG_CONFIG_HOME}/Slack`
+  - `~/.config/Slack`
 
 ## Slack Data Model Notes
 
@@ -271,7 +273,7 @@ Credential model:
 - optional user token: `xoxp-`
 - each token source can be enabled or disabled independently
 - desktop source can be enabled or disabled independently
-- blank desktop path means auto-detect the supported macOS Slack path
+- blank desktop path means auto-detect the supported macOS or Linux Slack path
 - optional `[[workspaces]]` entries can override bot/app/user token env vars per workspace
 - workspace token lookup should default to `SLACK_<WORKSPACE_ID>_BOT_TOKEN`, `SLACK_<WORKSPACE_ID>_APP_TOKEN`, and `SLACK_<WORKSPACE_ID>_USER_TOKEN`
 - `[sync].auto_join` defaults to `true` and controls whether API sync attempts to join public channels before retrying history

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,7 +283,7 @@ path = ""
 Behavior:
 
 - `enabled = true` turns on desktop sync support
-- `path = ""` auto-detects the supported macOS Slack container path
+- `path = ""` auto-detects the supported macOS or Linux Slack Desktop path
 - `path = "/custom/path"` overrides detection
 
 To disable desktop ingestion completely:

--- a/docs/desktop-mode.md
+++ b/docs/desktop-mode.md
@@ -38,7 +38,7 @@ with backward compatibility for older raw media entries.
 
 ## Path Detection
 
-On macOS, leave the desktop path blank to auto-detect:
+Leave the desktop path blank to auto-detect a supported Slack Desktop install:
 
 ```toml
 [slack.desktop]
@@ -46,10 +46,15 @@ enabled = true
 path = ""
 ```
 
-The supported default target is:
+The supported default targets are:
 
 ```text
+# macOS
 ~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack
+
+# Linux
+${XDG_CONFIG_HOME}/Slack
+~/.config/Slack
 ```
 
 If your Slack Desktop data lives elsewhere, set the path explicitly.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -499,7 +499,7 @@ func desktopPathCandidates() []string {
 	case "darwin":
 		return []string{macOSContainerDesktopPath, macOSDirectDesktopPath}
 	case "linux":
-		if xdgConfigHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdgConfigHome != "" {
+		if xdgConfigHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); filepath.IsAbs(xdgConfigHome) {
 			return []string{filepath.Join(xdgConfigHome, "Slack"), linuxHomeDesktopPathTemplate}
 		}
 		return []string{linuxHomeDesktopPathTemplate}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,16 +5,20 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	crawlconfig "github.com/openclaw/crawlkit/config"
 )
 
 const (
-	defaultDirName     = ".slacrawl"
-	defaultDesktopPath = "~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack"
-	directDesktopPath  = "~/Library/Application Support/Slack"
+	defaultDirName               = ".slacrawl"
+	macOSContainerDesktopPath    = "~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack"
+	macOSDirectDesktopPath       = "~/Library/Application Support/Slack"
+	linuxHomeDesktopPathTemplate = "~/.config/Slack"
 )
+
+var runtimeGOOS = runtime.GOOS
 
 type Config struct {
 	Version     int          `toml:"version"`
@@ -477,7 +481,7 @@ func sanitizeEnvSegment(value string) string {
 }
 
 func DetectDesktopPath() (string, error) {
-	candidates := []string{defaultDesktopPath, directDesktopPath}
+	candidates := desktopPathCandidates()
 	for _, candidate := range candidates {
 		expanded, err := ExpandPath(candidate)
 		if err != nil {
@@ -488,6 +492,20 @@ func DetectDesktopPath() (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func desktopPathCandidates() []string {
+	switch runtimeGOOS {
+	case "darwin":
+		return []string{macOSContainerDesktopPath, macOSDirectDesktopPath}
+	case "linux":
+		if xdgConfigHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdgConfigHome != "" {
+			return []string{filepath.Join(xdgConfigHome, "Slack"), linuxHomeDesktopPathTemplate}
+		}
+		return []string{linuxHomeDesktopPathTemplate}
+	default:
+		return nil
+	}
 }
 
 func Redact(value string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -200,6 +200,19 @@ func TestNormalizeAutoDetectsLinuxDesktopPathFromHomeConfig(t *testing.T) {
 	require.Equal(t, filepath.Join(home, ".config", "Slack"), cfg.Slack.Desktop.Path)
 }
 
+func TestNormalizeIgnoresRelativeXDGConfigHome(t *testing.T) {
+	withRuntimeGOOS(t, "linux")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", ".xdg-config")
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "Slack"), 0o750))
+
+	cfg := Default()
+	cfg.Slack.Desktop.Path = ""
+	require.NoError(t, cfg.Normalize())
+	require.Equal(t, filepath.Join(home, ".config", "Slack"), cfg.Slack.Desktop.Path)
+}
+
 func TestNormalizeLeavesDesktopPathEmptyWhenNoInstallFound(t *testing.T) {
 	withRuntimeGOOS(t, "linux")
 	t.Setenv("HOME", t.TempDir())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -162,6 +162,7 @@ func TestDefaultConfigPath(t *testing.T) {
 }
 
 func TestNormalizeAutoDetectsDesktopPath(t *testing.T) {
+	withRuntimeGOOS(t, "darwin")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	require.NoError(t, os.MkdirAll(filepath.Join(home, "Library", "Application Support", "Slack"), 0o750))
@@ -172,7 +173,35 @@ func TestNormalizeAutoDetectsDesktopPath(t *testing.T) {
 	require.Equal(t, filepath.Join(home, "Library", "Application Support", "Slack"), cfg.Slack.Desktop.Path)
 }
 
+func TestNormalizeAutoDetectsLinuxDesktopPathFromXDGConfigHome(t *testing.T) {
+	withRuntimeGOOS(t, "linux")
+	home := t.TempDir()
+	xdgConfigHome := filepath.Join(home, ".xdg-config")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	require.NoError(t, os.MkdirAll(filepath.Join(xdgConfigHome, "Slack"), 0o750))
+
+	cfg := Default()
+	cfg.Slack.Desktop.Path = ""
+	require.NoError(t, cfg.Normalize())
+	require.Equal(t, filepath.Join(xdgConfigHome, "Slack"), cfg.Slack.Desktop.Path)
+}
+
+func TestNormalizeAutoDetectsLinuxDesktopPathFromHomeConfig(t *testing.T) {
+	withRuntimeGOOS(t, "linux")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".missing-xdg-config"))
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "Slack"), 0o750))
+
+	cfg := Default()
+	cfg.Slack.Desktop.Path = ""
+	require.NoError(t, cfg.Normalize())
+	require.Equal(t, filepath.Join(home, ".config", "Slack"), cfg.Slack.Desktop.Path)
+}
+
 func TestNormalizeLeavesDesktopPathEmptyWhenNoInstallFound(t *testing.T) {
+	withRuntimeGOOS(t, "linux")
 	t.Setenv("HOME", t.TempDir())
 
 	cfg := Default()
@@ -223,4 +252,13 @@ func mustHome(t *testing.T) string {
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 	return home
+}
+
+func withRuntimeGOOS(t *testing.T, goos string) {
+	t.Helper()
+	old := runtimeGOOS
+	runtimeGOOS = goos
+	t.Cleanup(func() {
+		runtimeGOOS = old
+	})
 }


### PR DESCRIPTION
## Summary
- Detect the Linux Slack Desktop config path during automatic workspace discovery.
- Update README discovery docs so macOS and Linux Desktop users are both covered.
- Preserve explicit config/env paths ahead of auto-detection.

## Review follow-up
- Addressed the README wording that still described macOS-only auto-discovery.
- Added real Linux VM runtime proof for blank-path desktop discovery. The runtime proof executes a Linux/arm64 `slacrawl` binary from PR head `32380613661882cd9201731da9c00d11d29c1bdd` inside an Ubuntu Lima VM and verifies `doctor --json` reports the resolved desktop source path.

## Validation
- `gofmt -w internal/config/config.go internal/config/config_test.go`
- `git diff --check`
- `go test ./internal/config -run 'TestNormalizeAutoDetectsLinuxDesktopPath' -v`
- `go test ./...`

## Linux runtime proof

Environment:

```text
prHead=32380613661882cd9201731da9c00d11d29c1bdd
binary.file=ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked
kernel=Linux 6.17.0-29-generic aarch64 GNU/Linux
os=Ubuntu 25.10 questing
config.desktop.path.raw=[slack.desktop] enabled = true path = ""
```

Command shape used in the Linux VM:

```text
HOME="$case/home" XDG_CONFIG_HOME="$case/home/.xdg-config" slacrawl --config "$proof/base-config.toml" doctor --json
HOME="$case/home" XDG_CONFIG_HOME="$case/home/.missing-xdg" slacrawl --config "$proof/base-config.toml" doctor --json
```

Observed output from `doctor --json` for the XDG case:

```text
xdg.expected=/tmp/slacrawl-pr53-runtime-proof/xdg-case/home/.xdg-config/Slack
xdg.desktop.path=/tmp/slacrawl-pr53-runtime-proof/xdg-case/home/.xdg-config/Slack
xdg.desktop.available=true
xdg.tokens.bot_set=false
```

Observed output from `doctor --json` for the HOME fallback case:

```text
homeconfig.expected=/tmp/slacrawl-pr53-runtime-proof/home-config-case/home/.config/Slack
homeconfig.desktop.path=/tmp/slacrawl-pr53-runtime-proof/home-config-case/home/.config/Slack
homeconfig.desktop.available=true
homeconfig.tokens.bot_set=false
```

The test config kept `[slack.desktop].path = ""`; both resolved paths came from Linux runtime auto-detection, not explicit config. API tokens were disabled/unset for the proof, so the output only validates local desktop-source discovery.
