### PR TITLE
ci: update GoReleaser action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           cache: true
 
       - name: Snapshot release build
-        uses: goreleaser/goreleaser-action@v7.2.1
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Maintenance
 
 - Updated crawlkit through 0.12.2 for shared runtime hardening, SQLite 1.52, and absolute Windows database paths.
+- Updated the pinned GoReleaser CI action to 7.2.2.
 
 ## 0.7.2 - 2026-06-10
 


### PR DESCRIPTION
## Summary

- update the exact GoReleaser CI action pin from 7.2.1 to 7.2.2
- record the maintenance update in the changelog

Upstream 7.2.2 fixes selection of the newest published release for nightly resolution. Slacrawl uses the stable v2 selector; this keeps the exact CI action pin current without changing release behavior.

## Verification

- `GOWORK=off go test ./...`
- `GOWORK=off make test`
- race tests and `go vet ./...`
- vulnerability scan: no known vulnerabilities
- workflow lint / YAML parse
- GoReleaser snapshot build
- Docker build, version, and help smoke tests
- exact built binary: `doctor`, `status`, and `search` JSON smoke tests, private output suppressed
- independent review: no findings

