### PR TITLE
ci: update TruffleHog action

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@v3.95.5
+        uses: trufflesecurity/trufflehog@v3.95.6
         with:
           path: ./
           base: ${{ steps.scan_range.outputs.base }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Updated crawlkit through 0.12.2 for shared runtime hardening, SQLite 1.52, and absolute Windows database paths.
 - Updated the pinned GoReleaser CI action to 7.2.2.
+- Updated the TruffleHog secret-scanning action to 3.95.6.
 
 ## 0.7.2 - 2026-06-10
 


### PR DESCRIPTION
## Summary

- update the TruffleHog secret-scanning action from 3.95.5 to 3.95.6
- record the maintenance update in the changelog

Upstream 3.95.6 includes detector correctness fixes, support for source lines over 64 KiB, and additional default detectors.

## Verification

- `GOWORK=off go test ./...`
- `GOWORK=off make test`
- race tests and `go vet ./...`
- vulnerability scan: no known vulnerabilities
- workflow lint / YAML parse
- GoReleaser snapshot build
- Docker build and version smoke test
- exact built binary: `doctor`, `status`, and `search` JSON smoke tests, private output suppressed
- independent review: no findings

