### PR TITLE
fix: complete Git share snapshot flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Maintenance
 
+- Added Bash and Zsh completion entries for Git-share snapshot tags and historical refs.
 - Added immutable Git-share snapshot tags and non-mutating historical restores with `update --ref`, using CrawlKit for shared Git history mechanics.
 - Moved FTS5 query escaping onto CrawlKit and refreshed Go dependencies.
 - Updated crawlkit through 0.12.2 for shared runtime hardening, SQLite 1.52, and absolute Windows database paths.

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -533,6 +533,8 @@ func TestCompletionBashOutput(t *testing.T) {
 	require.Contains(t, out, "connector")
 	require.Contains(t, out, "purge")
 	require.Contains(t, out, "--older-than")
+	require.Contains(t, out, "--tag")
+	require.Contains(t, out, "--ref")
 }
 
 func TestCompletionZshOutput(t *testing.T) {
@@ -555,6 +557,8 @@ func TestCompletionZshOutput(t *testing.T) {
 	require.Contains(t, out, "connector")
 	require.Contains(t, out, "purge")
 	require.Contains(t, out, "--keep-media")
+	require.Contains(t, out, "--tag[immutable snapshot tag]")
+	require.Contains(t, out, "--ref[historical Git ref to import]")
 }
 
 func TestReportIncludesArchiveAndShareState(t *testing.T) {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -154,13 +154,13 @@ _slacrawl()
             esac
             ;;
         publish)
-            COMPREPLY=( $(compgen -W "--repo --remote --branch --message --no-commit --push --no-media --help -h ${global_flags}" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "--repo --remote --branch --message --tag --no-commit --push --no-media --help -h ${global_flags}" -- "${cur}") )
             ;;
         subscribe)
             COMPREPLY=( $(compgen -W "--repo --db --remote --branch --stale-after --no-auto-update --no-import --no-media --help -h ${global_flags}" -- "${cur}") )
             ;;
         update)
-            COMPREPLY=( $(compgen -W "--repo --remote --branch --no-media --help -h ${global_flags}" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "--repo --remote --branch --ref --no-media --help -h ${global_flags}" -- "${cur}") )
             ;;
         sync)
             COMPREPLY=( $(compgen -W "--source --workspace --channels --since --full --latest-only --concurrency --with-media --help -h ${global_flags}" -- "${cur}") )
@@ -273,13 +273,13 @@ _slacrawl() {
           fi
           ;;
         publish)
-          _arguments '--repo[git repo path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--message[commit message]:message:' '--no-commit[skip git commit]' '--push[push to origin]' '--no-media[omit cached media files]'
+          _arguments '--repo[git repo path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--message[commit message]:message:' '--tag[immutable snapshot tag]:tag:' '--no-commit[skip git commit]' '--push[push to origin]' '--no-media[omit cached media files]'
           ;;
         subscribe)
           _arguments '--repo[local clone path]:path:_files' '--db[database path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--stale-after[auto-refresh age threshold]:duration:' '--no-auto-update[disable read-time auto refresh]' '--no-import[skip initial import]' '--no-media[skip restoring cached media]'
           ;;
         update)
-          _arguments '--repo[local clone path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--no-media[skip restoring cached media]'
+          _arguments '--repo[local clone path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--ref[historical Git ref to import]:ref:' '--no-media[skip restoring cached media]'
           ;;
         sync)
           _arguments '--source[sync source]:source:(api bot desktop wiretap mcp connector all)' '--workspace[workspace id]:workspace id:' '--channels[channel ids]:channels:' '--since[start timestamp]:timestamp:' '--full[run full sync]' '--latest-only[skip first-time historical backfills]' '--concurrency[worker count]:count:' '--with-media[fetch file media after sync]'


### PR DESCRIPTION
## Summary

- expose `publish --tag` in generated Bash and Zsh completions
- expose `update --ref` in generated Bash and Zsh completions
- add regression coverage and changelog entry

Found during post-merge verification of #64.

## Proof

- `go test -count=1 ./internal/cli -run 'TestCompletion(Bash|Zsh)Output'`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go mod verify`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`
- autoreview clean
