### PR TITLE
fix(config): normalize relative runtime paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Fixed multi-workspace desktop/API sync scoping, fail-closed workspace authentication, workspace-qualified purges, and explicit watch workspace selection. Thanks @zm2231.
 - Prevented unchanged desktop refreshes from duplicating message events and added preview-first retained-history compaction with `purge --keep-message-events`. Thanks @barbieri.
+- Normalized relative runtime paths to absolute paths so commands can open databases created with `init --db <relative-path>`.
+
+### Maintenance
+
+- Hardened release workflows, MCP stdio environment forwarding, command completion, and canonical Homebrew tap targeting.
+- Updated CrawlKit to 0.13.1, slack-go to 0.27.0, and `golang.org/x/net` to 0.55.0.
+- Corrected Linux package examples to use version-matched GitHub Release assets.
 
 ## 0.7.3 - 2026-06-19
 
@@ -19,7 +26,7 @@
 - Retry concurrent Git snapshot branch-and-tag pushes after rebasing and retargeting the unpublished tag.
 - Added immutable Git-share snapshot tags and non-mutating historical restores with `update --ref`, using CrawlKit for shared Git history mechanics.
 - Moved FTS5 query escaping onto CrawlKit and refreshed Go dependencies.
-- Updated crawlkit through 0.12.2 for shared runtime hardening, SQLite 1.52, and absolute Windows database paths.
+- Updated crawlkit through 0.13.0 for shared runtime hardening, SQLite 1.52, and absolute Windows database paths.
 - Updated the pinned GoReleaser CI action to 7.2.2.
 - Updated the TruffleHog secret-scanning action to 3.95.6.
 - Updated GitHub Actions checkout steps to v7.

--- a/README.md
+++ b/README.md
@@ -87,19 +87,22 @@ brew install slacrawl
 <summary>Linux packages from GitHub Releases</summary>
 
 Download the package that matches your platform from the [latest release](https://github.com/openclaw/slacrawl/releases/latest).
+Set `version` to the release you want to install (shown for `0.7.3`).
 
 Debian/Ubuntu:
 
 ```bash
-curl -LO https://github.com/openclaw/slacrawl/releases/latest/download/slacrawl_0.7.2_amd64.deb
-sudo dpkg -i slacrawl_0.7.2_amd64.deb
+version=0.7.3
+curl -LO "https://github.com/openclaw/slacrawl/releases/download/v${version}/slacrawl_${version}_amd64.deb"
+sudo dpkg -i "slacrawl_${version}_amd64.deb"
 ```
 
 RHEL/Fedora:
 
 ```bash
-curl -LO https://github.com/openclaw/slacrawl/releases/latest/download/slacrawl-0.7.2-1.x86_64.rpm
-sudo rpm -i slacrawl-0.7.2-1.x86_64.rpm
+version=0.7.3
+curl -LO "https://github.com/openclaw/slacrawl/releases/download/v${version}/slacrawl-${version}-1.x86_64.rpm"
+sudo rpm -i "slacrawl-${version}-1.x86_64.rpm"
 ```
 
 </details>

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -54,6 +54,23 @@ func TestParseLookback(t *testing.T) {
 	}
 }
 
+func TestInitAcceptsRelativeDatabasePath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	var stdout bytes.Buffer
+	app := &App{Stdout: &stdout, Stderr: &stdout}
+	require.NoError(t, app.Run(context.Background(), []string{"--config", "config.toml", "init", "--db", "archive.db"}))
+
+	cfg, err := config.Load("config.toml")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "archive.db"), cfg.DBPath)
+	st, err := store.Open(cfg.DBPath)
+	require.NoError(t, err)
+	require.NoError(t, st.Close())
+	require.FileExists(t, cfg.DBPath)
+}
+
 func TestResolveMCPWorkspaceID(t *testing.T) {
 	workspaceID, err := resolveMCPWorkspaceID([]string{"T123"})
 	require.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -317,7 +317,11 @@ func ExpandPath(path string) (string, error) {
 	if path == "" {
 		return "", nil
 	}
-	return filepath.Clean(crawlconfig.ExpandHome(path)), nil
+	expanded := filepath.Clean(crawlconfig.ExpandHome(path))
+	if filepath.IsAbs(expanded) {
+		return expanded, nil
+	}
+	return filepath.Abs(expanded)
 }
 
 func (c Config) ResolveTokens() Tokens {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,6 +118,15 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	require.Equal(t, "https://example.com/private/slacrawl.git", loaded.Share.Remote)
 }
 
+func TestExpandPathMakesRelativePathsAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	expanded, err := ExpandPath(filepath.Join("state", "slacrawl.db"))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "state", "slacrawl.db"), expanded)
+}
+
 func TestSaveAndLoadStdioMCPConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")


### PR DESCRIPTION
## Summary

- normalize relative runtime paths before persisting config so `init --db archive.db` creates an archive the next command can open
- repair Linux install examples with exact version-matched v0.7.3 release assets
- reconcile released CrawlKit 0.13.0 and current unreleased dependency/workflow changes in the changelog

## Live proof

An isolated built CLI initialized `archive.db`, persisted its absolute path, imported a one-message Slack export, and returned the stored message through CLI SQL. The documented v0.7.3 amd64 DEB and x86_64 RPM URLs both followed redirects to HTTP 200.

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- source-blind behavior contract: 4 passed, 0 failed
- autoreview: clean
