### PR TITLE
chore: prepare release 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## 0.7.4 - Unreleased
+## 0.7.4 - 2026-07-04
 
 ### Fixes
 
 - Fixed multi-workspace desktop/API sync scoping, fail-closed workspace authentication, workspace-qualified purges, and explicit watch workspace selection. Thanks @zm2231.
 - Prevented unchanged desktop refreshes from duplicating message events and added preview-first retained-history compaction with `purge --keep-message-events`. Thanks @barbieri.
 - Normalized relative runtime paths to absolute paths so commands can open databases created with `init --db <relative-path>`.
-- Treat nullable optional message metadata as empty when reading historical archives.
+- Treated nullable optional message metadata as empty when reading historical archives.
 
 ### Maintenance
 

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ brew install slacrawl
 <summary>Linux packages from GitHub Releases</summary>
 
 Download the package that matches your platform from the [latest release](https://github.com/openclaw/slacrawl/releases/latest).
-Set `version` to the release you want to install (shown for `0.7.3`).
+Set `version` to the release you want to install (shown for `0.7.4`).
 
 Debian/Ubuntu:
 
 ```bash
-version=0.7.3
+version=0.7.4
 curl -LO "https://github.com/openclaw/slacrawl/releases/download/v${version}/slacrawl_${version}_amd64.deb"
 sudo dpkg -i "slacrawl_${version}_amd64.deb"
 ```
@@ -100,7 +100,7 @@ sudo dpkg -i "slacrawl_${version}_amd64.deb"
 RHEL/Fedora:
 
 ```bash
-version=0.7.3
+version=0.7.4
 curl -LO "https://github.com/openclaw/slacrawl/releases/download/v${version}/slacrawl-${version}-1.x86_64.rpm"
 sudo rpm -i "slacrawl-${version}-1.x86_64.rpm"
 ```


### PR DESCRIPTION
## Summary

- finalize the 0.7.4 changelog date and wording
- update Linux package examples to the 0.7.4 release URLs

## Verification

- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `make generate-sqlc` with clean generated diff
- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish`
- source-blind nullable-message CLI contract: passed
- structured Codex autoreview of the final functional commit: clean
