### PR TITLE
chore: reopen changelog after 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.7.5 - Unreleased
+
 ## 0.7.4 - 2026-07-04
 
 ### Fixes


### PR DESCRIPTION
## Summary

- reopen the changelog for 0.7.5 after the verified 0.7.4 release

## Verification

- documentation-only release closeout
- `git diff --check`
