### PR TITLE
perf: make event-head upgrades lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Normalized relative runtime paths to absolute paths so commands can open databases created with `init --db <relative-path>`.
 - Treated nullable optional message metadata as empty when reading historical archives.
 
+### Performance
+
+- Made event-history upgrades constant-time by lazily seeding compact message heads on update instead of scanning the entire archive.
+
 ### Maintenance
 
 - Hardened release workflows, MCP stdio environment forwarding, command completion, and canonical Homebrew tap targeting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.7.5 - Unreleased
 
+### Performance
+
+- Made event-history upgrades constant-time by lazily seeding compact message heads on update instead of scanning the entire archive.
+
 ## 0.7.4 - 2026-07-04
 
 ### Fixes
@@ -10,10 +14,6 @@
 - Prevented unchanged desktop refreshes from duplicating message events and added preview-first retained-history compaction with `purge --keep-message-events`. Thanks @barbieri.
 - Normalized relative runtime paths to absolute paths so commands can open databases created with `init --db <relative-path>`.
 - Treated nullable optional message metadata as empty when reading historical archives.
-
-### Performance
-
-- Made event-history upgrades constant-time by lazily seeding compact message heads on update instead of scanning the entire archive.
 
 ### Maintenance
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openclaw/slacrawl/internal/store/storedb"
 )
 
-const schemaVersion = 4
+const schemaVersion = 5
 
 const schemaPragmas = `
 pragma foreign_keys = on;
@@ -25,7 +25,7 @@ pragma journal_mode = wal;
 pragma busy_timeout = 5000;
 `
 
-const messageEventHeadsSchema = `
+const messageEventHeadsTableSchema = `
 create table if not exists message_event_heads (
   channel_id text not null,
   ts text not null,
@@ -34,7 +34,9 @@ create table if not exists message_event_heads (
   payload_json text not null,
   primary key (channel_id, ts, event_type, source_name)
 ) without rowid;
+`
 
+const messageEventHeadTriggerSchema = `
 create trigger if not exists seed_message_event_head_before_update
 before update on messages
 begin
@@ -53,6 +55,8 @@ begin
   ) on conflict (channel_id, ts, event_type, source_name) do nothing;
 end;
 `
+
+const messageEventHeadsSchema = messageEventHeadsTableSchema + messageEventHeadTriggerSchema
 
 const schema = `
 pragma foreign_keys = on;
@@ -244,6 +248,7 @@ create index if not exists idx_message_files_name on message_files(name);
 `
 
 const schemaV4Migration = messageEventHeadsSchema
+const schemaV5Migration = messageEventHeadTriggerSchema
 
 type Store struct {
 	db *sql.DB
@@ -2421,6 +2426,12 @@ func migrateSchema(db *sql.DB, currentVersion int) error {
 			return fmt.Errorf("migrate sqlite schema to v4: %w", err)
 		}
 		currentVersion = 4
+	}
+	if currentVersion < 5 {
+		if _, err := tx.Exec(schemaV5Migration); err != nil {
+			return fmt.Errorf("migrate sqlite schema to v5: %w", err)
+		}
+		currentVersion = 5
 	}
 	if currentVersion != schemaVersion {
 		return fmt.Errorf("no migration path from sqlite schema version %d to %d", currentVersion, schemaVersion)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -25,6 +25,35 @@ pragma journal_mode = wal;
 pragma busy_timeout = 5000;
 `
 
+const messageEventHeadsSchema = `
+create table if not exists message_event_heads (
+  channel_id text not null,
+  ts text not null,
+  event_type text not null,
+  source_name text not null,
+  payload_json text not null,
+  primary key (channel_id, ts, event_type, source_name)
+) without rowid;
+
+create trigger if not exists seed_message_event_head_before_update
+before update on messages
+begin
+  insert into message_event_heads (
+    channel_id, ts, event_type, source_name, payload_json
+  ) values (
+    old.channel_id,
+    old.ts,
+    case
+      when trim(coalesce(old.deleted_ts, '')) <> '' then 'message_deleted'
+      when trim(coalesce(old.edited_ts, '')) <> '' then 'message_changed'
+      else 'message'
+    end,
+    old.source_name,
+    old.raw_json
+  ) on conflict (channel_id, ts, event_type, source_name) do nothing;
+end;
+`
+
 const schema = `
 pragma foreign_keys = on;
 pragma journal_mode = wal;
@@ -137,16 +166,7 @@ create table if not exists message_events (
   payload_json text not null,
   created_at text not null
 );
-
-create table if not exists message_event_heads (
-  channel_id text not null,
-  ts text not null,
-  event_type text not null,
-  source_name text not null,
-  payload_json text not null,
-  primary key (channel_id, ts, event_type, source_name)
-);
-
+` + messageEventHeadsSchema + `
 create table if not exists sync_state (
   source_name text not null,
   entity_type text not null,
@@ -223,33 +243,7 @@ create index if not exists idx_message_files_file_id on message_files(file_id);
 create index if not exists idx_message_files_name on message_files(name);
 `
 
-const schemaV4Migration = `
-create table if not exists message_event_heads (
-  channel_id text not null,
-  ts text not null,
-  event_type text not null,
-  source_name text not null,
-  payload_json text not null,
-  primary key (channel_id, ts, event_type, source_name)
-);
-
--- Seed canonical snapshots without scanning potentially multi-gigabyte event
--- history during database open. Non-canonical source/type partitions seed
--- lazily on their next event, bounding upgrade overhead to one row per active
--- partition instead of an unbounded migration.
-insert or ignore into message_event_heads (channel_id, ts, event_type, source_name, payload_json)
-select
-  channel_id,
-  ts,
-  case
-    when trim(coalesce(deleted_ts, '')) <> '' then 'message_deleted'
-    when trim(coalesce(edited_ts, '')) <> '' then 'message_changed'
-    else 'message'
-  end,
-  source_name,
-  raw_json
-from messages;
-`
+const schemaV4Migration = messageEventHeadsSchema
 
 type Store struct {
 	db *sql.DB
@@ -375,6 +369,18 @@ type MessageRow struct {
 	Subtype        string `json:"subtype"`
 	SourceName     string `json:"source_name,omitempty"`
 }
+
+// Keep this projection in the same order as scanMessageRows.
+const messageRowSelect = `m.workspace_id, coalesce(w.name, ''), m.channel_id, coalesce(c.name, ''),
+       m.ts, coalesce(m.user_id, ''),
+       coalesce(nullif(u.display_name, ''), nullif(u.real_name, ''), nullif(u.name, ''), ''),
+       m.text, m.normalized_text, coalesce(m.thread_ts, ''), m.reply_count,
+       coalesce(m.latest_reply, ''), coalesce(m.subtype, ''), m.source_name`
+
+const messageRowJoins = `
+left join workspaces w on w.id = m.workspace_id
+left join channels c on c.id = m.channel_id
+left join users u on u.id = m.user_id`
 
 type SearchMode string
 
@@ -1372,58 +1378,30 @@ func (s *Store) searchAuto(ctx context.Context, workspaceID string, query string
 
 func (s *Store) searchFTS(ctx context.Context, workspaceID string, query string, limit int) ([]MessageRow, error) {
 	sqlQuery := `
-select m.workspace_id, coalesce(w.name, ''), m.channel_id, coalesce(c.name, ''), m.ts, coalesce(m.user_id, ''),
-       coalesce(nullif(u.display_name, ''), nullif(u.real_name, ''), nullif(u.name, ''), ''),
-       m.text, m.normalized_text, coalesce(m.thread_ts, ''), m.reply_count,
-       coalesce(m.latest_reply, ''), coalesce(m.subtype, ''), m.source_name
+select ` + messageRowSelect + `
 from message_fts f
 join messages m on f.message_key = m.channel_id || '|' || m.ts
-left join workspaces w on w.id = m.workspace_id
-left join channels c on c.id = m.channel_id
-left join users u on u.id = m.user_id
+` + messageRowJoins + `
 where message_fts match ?
   and (? = '' or m.workspace_id = ?)
 order by m.ts desc
 limit ?
 `
-	rows, err := s.db.QueryContext(ctx, sqlQuery, query, workspaceID, workspaceID, RequireLimit(limit))
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-	out, err := scanMessageRows(rows)
-	if err != nil {
-		return nil, err
-	}
-	return out, s.resolveMessageRowMentions(ctx, out)
+	return s.queryMessageRows(ctx, sqlQuery, query, workspaceID, workspaceID, RequireLimit(limit))
 }
 
 func (s *Store) searchLike(ctx context.Context, workspaceID string, query string, limit int) ([]MessageRow, error) {
 	pattern := "%" + escapeLike(strings.ToLower(strings.TrimSpace(query))) + "%"
 	sqlQuery := `
-select m.workspace_id, coalesce(w.name, ''), m.channel_id, coalesce(c.name, ''), m.ts, coalesce(m.user_id, ''),
-       coalesce(nullif(u.display_name, ''), nullif(u.real_name, ''), nullif(u.name, ''), ''),
-       m.text, m.normalized_text, coalesce(m.thread_ts, ''), m.reply_count,
-       coalesce(m.latest_reply, ''), coalesce(m.subtype, ''), m.source_name
+select ` + messageRowSelect + `
 from messages m
-left join workspaces w on w.id = m.workspace_id
-left join channels c on c.id = m.channel_id
-left join users u on u.id = m.user_id
+` + messageRowJoins + `
 where (? = '' or m.workspace_id = ?)
   and (lower(m.text) like ? escape '\' or lower(m.normalized_text) like ? escape '\')
 order by m.ts desc
 limit ?
 `
-	rows, err := s.db.QueryContext(ctx, sqlQuery, workspaceID, workspaceID, pattern, pattern, RequireLimit(limit))
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-	out, err := scanMessageRows(rows)
-	if err != nil {
-		return nil, err
-	}
-	return out, s.resolveMessageRowMentions(ctx, out)
+	return s.queryMessageRows(ctx, sqlQuery, workspaceID, workspaceID, pattern, pattern, RequireLimit(limit))
 }
 
 func termsFTS5Query(query string) string {
@@ -1473,14 +1451,9 @@ func escapeLike(value string) string {
 
 func (s *Store) Messages(ctx context.Context, workspaceID string, channelID string, userID string, limit int) ([]MessageRow, error) {
 	query := `
-select m.workspace_id, coalesce(w.name, ''), m.channel_id, coalesce(c.name, ''), m.ts, coalesce(m.user_id, ''),
-       coalesce(nullif(u.display_name, ''), nullif(u.real_name, ''), nullif(u.name, ''), ''),
-       m.text, m.normalized_text, coalesce(m.thread_ts, ''), m.reply_count,
-       coalesce(m.latest_reply, ''), coalesce(m.subtype, ''), m.source_name
+select ` + messageRowSelect + `
 from messages m
-left join workspaces w on w.id = m.workspace_id
-left join channels c on c.id = m.channel_id
-left join users u on u.id = m.user_id
+` + messageRowJoins + `
 where 1=1`
 	args := []any{}
 	if workspaceID != "" {
@@ -1497,16 +1470,7 @@ where 1=1`
 	}
 	query += ` order by m.ts desc limit ?`
 	args = append(args, limit)
-	rows, err := s.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	out, err := scanMessageRows(rows)
-	if err != nil {
-		return nil, err
-	}
-	return out, s.resolveMessageRowMentions(ctx, out)
+	return s.queryMessageRows(ctx, query, args...)
 }
 
 func (s *Store) MessagesWithThreadContext(ctx context.Context, workspaceID string, channelID string, userID string, limit int) ([]MessageRow, error) {
@@ -1560,28 +1524,15 @@ func (s *Store) hydrateThreadContext(ctx context.Context, rows []MessageRow, lim
 		contextLimit = 2000
 	}
 	query := `
-select m.workspace_id, coalesce(w.name, ''), m.channel_id, coalesce(c.name, ''), m.ts, coalesce(m.user_id, ''),
-       coalesce(nullif(u.display_name, ''), nullif(u.real_name, ''), nullif(u.name, ''), ''),
-       m.text, m.normalized_text, coalesce(m.thread_ts, ''), m.reply_count,
-       coalesce(m.latest_reply, ''), coalesce(m.subtype, ''), m.source_name
+select ` + messageRowSelect + `
 from messages m
-left join workspaces w on w.id = m.workspace_id
-left join channels c on c.id = m.channel_id
-left join users u on u.id = m.user_id
+` + messageRowJoins + `
 where ` + strings.Join(clauses, " or ") + `
 order by m.ts desc
 limit ?`
 	args = append(args, contextLimit)
-	contextRows, err := s.db.QueryContext(ctx, query, args...)
+	extra, err := s.queryMessageRows(ctx, query, args...)
 	if err != nil {
-		return nil, err
-	}
-	defer contextRows.Close()
-	extra, err := scanMessageRows(contextRows)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.resolveMessageRowMentions(ctx, extra); err != nil {
 		return nil, err
 	}
 	return mergeMessageRows(rows, extra), nil
@@ -1669,6 +1620,10 @@ where mm.mention_type = 'user'
 			}
 			key := messageKey(channelID, ts)
 			byKey[key] = append(byKey[key], messageMentionDisplay{target: target, display: display})
+		}
+		if err := mentionRows.Err(); err != nil {
+			_ = mentionRows.Close()
+			return err
 		}
 		if err := mentionRows.Close(); err != nil {
 			return err
@@ -2290,6 +2245,19 @@ func scanMessageRows(rows *sql.Rows) ([]MessageRow, error) {
 	return out, rows.Err()
 }
 
+func (s *Store) queryMessageRows(ctx context.Context, query string, args ...any) ([]MessageRow, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out, err := scanMessageRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return out, s.resolveMessageRowMentions(ctx, out)
+}
+
 func boolInt(value bool) int64 {
 	if value {
 		return 1
@@ -2344,17 +2312,18 @@ func appendMessageEvent(ctx context.Context, qtx *storedb.Queries, message Messa
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("read message event head: %w", err)
 	}
-	if errors.Is(err, sql.ErrNoRows) || head != message.RawJSON {
-		if err := qtx.InsertMessageEvent(ctx, storedb.InsertMessageEventParams{
-			ChannelID:   message.ChannelID,
-			Ts:          message.TS,
-			EventType:   typeName,
-			SourceName:  message.SourceName,
-			PayloadJson: message.RawJSON,
-			CreatedAt:   createdAt,
-		}); err != nil {
-			return err
-		}
+	if err == nil && head == message.RawJSON {
+		return nil
+	}
+	if err := qtx.InsertMessageEvent(ctx, storedb.InsertMessageEventParams{
+		ChannelID:   message.ChannelID,
+		Ts:          message.TS,
+		EventType:   typeName,
+		SourceName:  message.SourceName,
+		PayloadJson: message.RawJSON,
+		CreatedAt:   createdAt,
+	}); err != nil {
+		return err
 	}
 	if err := qtx.UpsertMessageEventHead(ctx, storedb.UpsertMessageEventHeadParams{
 		ChannelID:   message.ChannelID,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -768,6 +768,37 @@ end;
 	require.Zero(t, headUpdates)
 }
 
+func TestOpenMigratesVersion4AndInstallsLazyEventHeadTrigger(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+drop trigger seed_message_event_head_before_update;
+pragma user_version = 4;
+`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	s, err = Open(dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+
+	var version int
+	require.NoError(t, s.DB().QueryRow(`pragma user_version`).Scan(&version))
+	require.Equal(t, schemaVersion, version)
+	var triggerCount int
+	require.NoError(t, s.DB().QueryRow(`
+select count(*)
+from sqlite_master
+where type = 'trigger' and name = 'seed_message_event_head_before_update'
+`).Scan(&triggerCount))
+	require.Equal(t, 1, triggerCount)
+}
+
 func TestOpenDoesNotStampInvalidOldSchema(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	db, err := sql.Open("sqlite", dbPath)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -96,6 +96,16 @@ where channel_id = 'C1' and ts = '123.45'
 	assertEmptyOptionals(t, rows, err)
 	rows, err = s.Messages(ctx, "T1", "C1", "", 10)
 	assertEmptyOptionals(t, rows, err)
+
+	rows, err = s.hydrateThreadContext(ctx, []MessageRow{{
+		WorkspaceID: "T1",
+		ChannelID:   "C1",
+		TS:          "999.99",
+		ThreadTS:    "123.45",
+	}}, 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assertEmptyOptionals(t, rows[1:], nil)
 }
 
 func TestSearchMessagesAutoEscapesAndFallsBack(t *testing.T) {
@@ -669,7 +679,7 @@ func TestOpenMigratesVersion2Schema(t *testing.T) {
 	requireTableCount(t, s, "message_event_heads", 1)
 }
 
-func TestOpenMigratesVersion3AndSeedsCanonicalEventHeads(t *testing.T) {
+func TestOpenMigratesVersion3AndLazilySeedsCanonicalEventHeads(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	s, err := Open(dbPath)
 	require.NoError(t, err)
@@ -685,17 +695,77 @@ func TestOpenMigratesVersion3AndSeedsCanonicalEventHeads(t *testing.T) {
 
 	db, err := sql.Open("sqlite", dbPath)
 	require.NoError(t, err)
-	_, err = db.Exec(`drop table message_event_heads; pragma user_version = 3;`)
+	_, err = db.Exec(`
+drop trigger seed_message_event_head_before_update;
+drop table message_event_heads;
+pragma user_version = 3;
+`)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
 	s, err = Open(dbPath)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, s.Close()) }()
-	requireTableCount(t, s, "message_event_heads", 1)
+	requireTableCount(t, s, "message_event_heads", 0)
+	var withoutRowID int
+	require.NoError(t, s.DB().QueryRow(`
+select instr(lower(sql), 'without rowid') > 0
+from sqlite_master
+where type = 'table' and name = 'message_event_heads'
+`).Scan(&withoutRowID))
+	require.Equal(t, 1, withoutRowID)
+
+	lowerPriority := message
+	lowerPriority.SourceRank = message.SourceRank + 1
+	lowerPriority.RawJSON = `{"text":"ignored"}`
+	updated, err := s.UpsertMessageByPriority(ctx, lowerPriority, nil)
+	require.NoError(t, err)
+	require.False(t, updated)
+	requireTableCount(t, s, "message_event_heads", 0)
+	requireTableCount(t, s, "message_events", 1)
+
 	message.UpdatedAt = now.Add(time.Second)
 	require.NoError(t, s.UpsertMessage(ctx, message, nil))
+	requireTableCount(t, s, "message_event_heads", 1)
 	requireTableCount(t, s, "message_events", 1)
+
+	message.RawJSON = `{"text":"changed"}`
+	message.UpdatedAt = now.Add(2 * time.Second)
+	require.NoError(t, s.UpsertMessage(ctx, message, nil))
+	requireTableCount(t, s, "message_event_heads", 1)
+	requireTableCount(t, s, "message_events", 2)
+
+	message.SourceName = "api-bot"
+	message.RawJSON = `{"text":"new source"}`
+	message.UpdatedAt = now.Add(3 * time.Second)
+	require.NoError(t, s.UpsertMessage(ctx, message, nil))
+	requireTableCount(t, s, "message_event_heads", 2)
+	requireTableCount(t, s, "message_events", 3)
+
+	message.EditedTS = "124.00"
+	message.RawJSON = `{"text":"edited"}`
+	message.UpdatedAt = now.Add(4 * time.Second)
+	require.NoError(t, s.UpsertMessage(ctx, message, nil))
+	requireTableCount(t, s, "message_event_heads", 3)
+	requireTableCount(t, s, "message_events", 4)
+
+	_, err = s.DB().Exec(`
+create table message_event_head_updates (count integer not null);
+insert into message_event_head_updates values (0);
+create trigger count_message_event_head_updates
+after update on message_event_heads
+begin
+  update message_event_head_updates set count = count + 1;
+end;
+`)
+	require.NoError(t, err)
+	message.UpdatedAt = now.Add(5 * time.Second)
+	require.NoError(t, s.UpsertMessage(ctx, message, nil))
+	requireTableCount(t, s, "message_event_heads", 3)
+	requireTableCount(t, s, "message_events", 4)
+	var headUpdates int
+	require.NoError(t, s.DB().QueryRow(`select count from message_event_head_updates`).Scan(&headUpdates))
+	require.Zero(t, headUpdates)
 }
 
 func TestOpenDoesNotStampInvalidOldSchema(t *testing.T) {


### PR DESCRIPTION
## Summary

- replace the eager message-event head backfill with an atomic lazy trigger
- use a compact `WITHOUT ROWID` head table and skip unchanged head rewrites
- centralize message-row projection, scanning, and mention hydration across read paths
- add an explicit schema v5 migration for databases created by the released v4 schema

## Verification

- `GOWORK=off go test ./...`
- large-archive v3-to-v5 open completed in under 100 ms with zero eager head rows
- structured Codex autoreview: clean, no accepted/actionable findings
