### PR TITLE
chore: prepare release 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.5 - Unreleased
+## 0.7.5 - 2026-07-04
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ brew install slacrawl
 <summary>Linux packages from GitHub Releases</summary>
 
 Download the package that matches your platform from the [latest release](https://github.com/openclaw/slacrawl/releases/latest).
-Set `version` to the release you want to install (shown for `0.7.4`).
+Set `version` to the release you want to install (shown for `0.7.5`).
 
 Debian/Ubuntu:
 
 ```bash
-version=0.7.4
+version=0.7.5
 curl -LO "https://github.com/openclaw/slacrawl/releases/download/v${version}/slacrawl_${version}_amd64.deb"
 sudo dpkg -i "slacrawl_${version}_amd64.deb"
 ```
@@ -100,7 +100,7 @@ sudo dpkg -i "slacrawl_${version}_amd64.deb"
 RHEL/Fedora:
 
 ```bash
-version=0.7.4
+version=0.7.5
 curl -LO "https://github.com/openclaw/slacrawl/releases/download/v${version}/slacrawl-${version}-1.x86_64.rpm"
 sudo rpm -i "slacrawl-${version}-1.x86_64.rpm"
 ```


### PR DESCRIPTION
## Summary

- date the 0.7.5 changelog section for release
- update pinned Linux package examples to 0.7.5

## Verification

- `go test ./...`
- `make build`
- `goreleaser release --snapshot --clean`
