### PR TITLE
chore: reopen changelog after 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.7.6 - Unreleased
+
 ## 0.7.5 - 2026-07-04
 
 ### Performance


### PR DESCRIPTION
## Summary

- reopen the changelog for 0.7.6 development after the verified 0.7.5 release

## Verification

- `git diff --check`
