### PR TITLE
chore: reopen changelog after 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.7.7 - Unreleased
+
 ## 0.7.6 - 2026-07-06
 
 ### Maintenance


### PR DESCRIPTION
## Summary

- reopen the changelog for 0.7.7 development after the verified 0.7.6 release

## Verification

- `git diff --check`
- v0.7.6 GitHub assets and checksums verified
- v0.7.6 Homebrew install, formula test, and live CLI smoke passed
