### PR TITLE
chore: reopen changelog after 0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.7.7 - Unreleased
+## 0.7.8 - Unreleased
+
+## 0.7.7 - 2026-07-09
 
 ### Maintenance
 


### PR DESCRIPTION
## Summary

- mark v0.7.7 released on 2026-07-09
- reopen the changelog for v0.7.8

## Verification

- `git diff --check`
- v0.7.7 public release, signed assets, Go proxy install, and Homebrew install/test/signature proof completed
