### PR TITLE
fix: make Git-share imports tombstone-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.7.8 - Unreleased
 
+### Fixes
+
+- Made routine Git-share imports merge-only so destination rows and newer message, user, and channel tombstones survive incomplete snapshots; exact replacement now requires `update --restore`, and removed file and mention rows retain source-attributed tombstones.
+
 ## 0.7.7 - 2026-07-09
 
 ### Maintenance

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Choose the path that matches your setup:
 - `report` summarizes archive activity and git-share freshness without writing SQL
 - `publish` exports the local SQLite archive into a git repo as compressed JSONL shards plus a manifest
 - `subscribe` configures a git-backed reader that can run without Slack credentials
-- `update` pulls and imports the latest git snapshot, or restores a historical tag/ref without moving the share checkout
+- `update` safely merges the latest git snapshot; `update --restore` performs explicit exact replacement, including historical tag/ref restores
 - `sync` performs a one-shot crawl from bot/API, MCP connector, wiretap/desktop, or both
 - `import` imports a Slack export ZIP or extracted export directory
 - `purge` previews or deletes messages and message-owned records older than a cutoff, with optional retained-event compaction
@@ -387,8 +387,9 @@ Behavior:
 - cached non-DM/non-private file media is included by default; use `--no-media` to omit it
 - `subscribe` writes a git-reader config, disables Slack API and desktop sources for that config, clones the repo, and imports the snapshot
 - pass `--db` to `subscribe` when you want the reader archive to land in a non-default SQLite path
-- `update` pulls and re-imports only when the manifest changes
-- `update --ref <tag-or-commit>` imports that historical snapshot without checking it out
+- `update` pulls and merges only when the manifest changes; rows absent from a snapshot remain local
+- `update --restore` explicitly replaces snapshot tables so the database exactly matches the latest snapshot
+- `update --restore --ref <tag-or-commit>` exactly restores that historical snapshot without checking it out
 - `status`, `search`, `messages`, `mentions`, `sql`, `users`, `channels`, and `report` auto-refresh stale git snapshots before reading when `auto_update = true`
 - `sync --source bot` and `sync --source all` warm from the git snapshot before hitting Slack when a share remote is configured
 - `status` and `doctor` surface the current git-share repo, last import time, and whether the local snapshot is stale
@@ -437,15 +438,16 @@ Relevant flags:
 
 ### `update`
 
-`update` is the explicit reader-side refresh. Use it when you want to pull and import on demand instead of waiting for automatic stale checks.
+`update` is the explicit reader-side refresh. Use it when you want to pull and safely merge on demand instead of waiting for automatic stale checks. Routine merges preserve destination-only rows, local sync state and embedding work, event history, and newer message, user, or channel tombstones. A row missing from a snapshot is not treated as deleted.
 
 ```bash
 go run ./cmd/slacrawl update
 go run ./cmd/slacrawl update --repo ~/.slacrawl/share --branch main
-go run ./cmd/slacrawl update --ref backup-2026-06-19
+go run ./cmd/slacrawl update --restore
+go run ./cmd/slacrawl update --restore --ref backup-2026-06-19
 ```
 
-`--ref` accepts a tag, branch, or commit. Historical imports read Git objects directly and leave the share repo's current branch and working tree unchanged.
+`--restore` is the explicit exact-replacement mode. `--ref` requires it and accepts a tag, branch, or commit. Historical restores read Git objects directly and leave the share repo's current branch and working tree unchanged.
 
 ### `report`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -317,7 +317,10 @@ Share config:
 - `[share].branch` defaults to `main`
 - `[share].auto_update` controls whether read commands import stale git snapshots before querying
 - `publish --tag <name>` creates an immutable tag for a committed snapshot
-- `update --ref <tag-or-commit>` restores a historical snapshot without changing the share checkout
+- routine `update` imports merge by stable row identity, preserve destination-only rows and newer tombstones, and never infer deletion from a row missing in the snapshot
+- `update --restore` is the explicit exact-replacement mode
+- `update --restore --ref <tag-or-commit>` restores a historical snapshot without changing the share checkout
+- file and mention rows retain `deleted_at`, `deletion_source`, and `deletion_reason` tombstones when an authoritative message payload or parent-delete event removes them
 - `[share].stale_after` defines how old the last successful import can be before auto-refresh runs
 - share sync state should record both the last successful import time and the last imported manifest generation time
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,8 @@ One config/database should represent one Slack visibility boundary: the messages
 - `sync --source mcp` fetches from a Slack connector exposed by the configured HTTP JSON-RPC MCP gateway
 - `sync --source wiretap` is an alias for `sync --source desktop` and reads the local Slack Desktop cache
 - `sync --source all` runs token-backed sync first, then desktop enrichment
-- `[share]` backs up or restores the current DB; it is not a second Slack data source
+- `[share]` backs up the current DB and safely merges snapshots by default; it is not a second Slack data source
+- exact latest or historical replacement requires `update --restore`
 
 Keep company and personal Slack archives in separate configs, DBs, and git remotes:
 

--- a/docs/retention.md
+++ b/docs/retention.md
@@ -69,6 +69,12 @@ Consecutive identical message snapshots are suppressed during normal ingest;
 real transitions, including a value changing and later reverting, remain in
 event history.
 
+When a complete message payload no longer contains a previously stored file or
+mention, Slacrawl retains that subordinate row with `deleted_at`,
+`deletion_source`, and `deletion_reason`. An explicit parent-message delete does
+the same. Normal file, mention, digest, and search reads exclude those
+tombstones; a later authoritative payload can resurrect the same stable row.
+
 Workspaces, channels, users, and sync state remain. Executed purges also record
 a per-channel retention floor so ordinary incremental API and MCP syncs do not
 restore deleted history through their repair overlap. New replies to expired
@@ -100,6 +106,9 @@ database operation while it rebuilds the file.
 
 ## Git-Backed Archives
 
-Purge changes the local database only. Publish a new snapshot after purging if
-other readers should receive the retention change. Importing an older snapshot
-can restore records that were removed locally.
+Purge changes the local database only. Publishing a snapshot after purging does
+not delete rows on normal readers because absence from a snapshot is not a
+deletion signal. Use an explicit `update --restore` on a reader when it must
+exactly adopt the published retention set. A historical restore uses
+`update --restore --ref <tag-or-commit>` and can bring back records removed
+locally.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2037,12 +2037,16 @@ func (a *App) runUpdate(ctx context.Context, configPath string, args []string, f
 	remote := fs.String("remote", cfg.Share.Remote, "git remote")
 	branch := fs.String("branch", cfg.Share.Branch, "git branch")
 	ref := fs.String("ref", "", "historical git ref to import")
+	restore := fs.Bool("restore", false, "exactly replace snapshot tables instead of merging")
 	noMedia := fs.Bool("no-media", !cfg.ShareMediaEnabled(), "skip restoring cached media")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
 		return errors.New("update takes no positional arguments")
+	}
+	if strings.TrimSpace(*ref) != "" && !*restore {
+		return errors.New("update --ref requires --restore because historical snapshots replace local rows")
 	}
 	st, err := a.openStore(cfg)
 	if err != nil {
@@ -2059,12 +2063,17 @@ func (a *App) runUpdate(ctx context.Context, configPath string, args []string, f
 		if err := share.Pull(ctx, opts); err != nil {
 			return err
 		}
-		manifest, imported, err = share.ImportIfChanged(ctx, st, opts)
+		if *restore {
+			manifest, err = share.Restore(ctx, st, opts)
+			imported = err == nil
+		} else {
+			manifest, imported, err = share.ImportIfChanged(ctx, st, opts)
+		}
 		if err != nil {
 			return err
 		}
 	} else {
-		manifest, err = share.ImportAt(ctx, st, opts, *ref)
+		manifest, err = share.RestoreAt(ctx, st, opts, *ref)
 		if err != nil {
 			return err
 		}
@@ -2078,6 +2087,7 @@ func (a *App) runUpdate(ctx context.Context, configPath string, args []string, f
 		"media":        manifest.Media,
 		"imported":     imported,
 		"ref":          strings.TrimSpace(*ref),
+		"restore":      *restore,
 	}, format, true)
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -756,7 +756,8 @@ func TestCompletionZshOutput(t *testing.T) {
 	require.Contains(t, out, "--keep-media")
 	require.Contains(t, out, "--keep-message-events[events retained per message, source, and type]")
 	require.Contains(t, out, "--tag[immutable snapshot tag]")
-	require.Contains(t, out, "--ref[historical Git ref to import]")
+	require.Contains(t, out, "--ref[historical Git ref to import; requires --restore]")
+	require.Contains(t, out, "--restore[exactly replace snapshot tables instead of merging]")
 	require.Contains(t, out, "--workspace[workspace id]")
 }
 
@@ -843,10 +844,12 @@ func TestPublishSubscribeAndSearchGitArchive(t *testing.T) {
 	require.Equal(t, "archive seed message", rows[0]["text"])
 
 	stdout.Reset()
-	require.NoError(t, app.Run(ctx, []string{"--config", readerCfgPath, "--json", "update", "--ref", "test-snapshot"}))
+	require.ErrorContains(t, app.Run(ctx, []string{"--config", readerCfgPath, "update", "--ref", "test-snapshot"}), "requires --restore")
+	require.NoError(t, app.Run(ctx, []string{"--config", readerCfgPath, "--json", "update", "--restore", "--ref", "test-snapshot"}))
 	var update map[string]any
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &update))
 	require.Equal(t, "test-snapshot", update["ref"])
+	require.Equal(t, true, update["restore"])
 }
 
 func TestSubscribePersistsNoMedia(t *testing.T) {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -173,7 +173,7 @@ _slacrawl()
             COMPREPLY=( $(compgen -W "--repo --db --remote --branch --stale-after --no-auto-update --no-import --no-media --help -h ${global_flags}" -- "${cur}") )
             ;;
         update)
-            COMPREPLY=( $(compgen -W "--repo --remote --branch --ref --no-media --help -h ${global_flags}" -- "${cur}") )
+			COMPREPLY=( $(compgen -W "--repo --remote --branch --ref --restore --no-media --help -h ${global_flags}" -- "${cur}") )
             ;;
         sync)
             COMPREPLY=( $(compgen -W "--source --workspace --channels --since --full --latest-only --concurrency --with-media --help -h ${global_flags}" -- "${cur}") )
@@ -311,7 +311,7 @@ _slacrawl() {
           _arguments '--repo[local clone path]:path:_files' '--db[database path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--stale-after[auto-refresh age threshold]:duration:' '--no-auto-update[disable read-time auto refresh]' '--no-import[skip initial import]' '--no-media[skip restoring cached media]'
           ;;
         update)
-          _arguments '--repo[local clone path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--ref[historical Git ref to import]:ref:' '--no-media[skip restoring cached media]'
+          _arguments '--repo[local clone path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--ref[historical Git ref to import; requires --restore]:ref:' '--restore[exactly replace snapshot tables instead of merging]' '--no-media[skip restoring cached media]'
           ;;
         sync)
           _arguments '--source[sync source]:source:(api bot desktop wiretap mcp connector all)' '--workspace[workspace id]:workspace id:' '--channels[channel ids]:channels:' '--since[start timestamp]:timestamp:' '--full[run full sync]' '--latest-only[skip first-time historical backfills]' '--concurrency[worker count]:count:' '--with-media[fetch file media after sync]'

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -203,6 +203,7 @@ join messages m on m.channel_id = mm.channel_id and m.ts = mm.ts
 left join users u on u.id = mm.target_id and u.workspace_id = m.workspace_id
 left join channels c on c.id = mm.target_id and c.workspace_id = m.workspace_id
 where m.ts not like 'draft:%'
+  and mm.deleted_at is null
   and instr(m.ts, '.') > 0
   and cast(substr(m.ts, 1, instr(m.ts, '.') - 1) as integer) >= ?
   and m.ts <= ?

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -209,19 +210,29 @@ func exportLocked(ctx context.Context, s *store.Store, opts Options) (Manifest, 
 }
 
 func Import(ctx context.Context, s *store.Store, opts Options) (Manifest, error) {
+	return importWithMode(ctx, s, opts, false)
+}
+
+// Restore replaces every snapshot table. Callers must expose this destructive
+// mode explicitly; routine imports merge and never remove destination rows.
+func Restore(ctx context.Context, s *store.Store, opts Options) (Manifest, error) {
+	return importWithMode(ctx, s, opts, true)
+}
+
+func importWithMode(ctx context.Context, s *store.Store, opts Options, restore bool) (Manifest, error) {
 	if opts.IncludeMedia && strings.TrimSpace(opts.CacheDir) != "" {
 		var manifest Manifest
 		err := media.WithCacheLock(ctx, opts.CacheDir, func() error {
 			var err error
-			manifest, err = importLocked(ctx, s, opts)
+			manifest, err = importLocked(ctx, s, opts, restore)
 			return err
 		})
 		return manifest, err
 	}
-	return importLocked(ctx, s, opts)
+	return importLocked(ctx, s, opts, restore)
 }
 
-func importLocked(ctx context.Context, s *store.Store, opts Options) (Manifest, error) {
+func importLocked(ctx context.Context, s *store.Store, opts Options, restore bool) (Manifest, error) {
 	manifest, err := ReadManifest(opts.RepoPath)
 	if err != nil {
 		return Manifest{}, err
@@ -246,17 +257,29 @@ func importLocked(ctx context.Context, s *store.Store, opts Options) (Manifest, 
 	if _, err := tx.ExecContext(ctx, `delete from message_fts`); err != nil {
 		return Manifest{}, fmt.Errorf("clear message_fts: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from message_event_heads`); err != nil {
-		return Manifest{}, fmt.Errorf("clear message event heads: %w", err)
-	}
-	for i := len(SnapshotTables) - 1; i >= 0; i-- {
-		table := SnapshotTables[i]
-		if _, err := tx.ExecContext(ctx, "delete from "+quoteIdent(table)); err != nil { //nolint:gosec // Snapshot table names are quoted identifiers from the fixed schema list.
-			return Manifest{}, fmt.Errorf("clear %s: %w", table, err)
+	if restore {
+		if _, err := tx.ExecContext(ctx, `delete from message_event_heads`); err != nil {
+			return Manifest{}, fmt.Errorf("clear message event heads: %w", err)
+		}
+		for i := len(SnapshotTables) - 1; i >= 0; i-- {
+			table := SnapshotTables[i]
+			if _, err := tx.ExecContext(ctx, "delete from "+quoteIdent(table)); err != nil { //nolint:gosec // Snapshot table names are quoted identifiers from the fixed schema list.
+				return Manifest{}, fmt.Errorf("clear %s: %w", table, err)
+			}
 		}
 	}
+	mergeState := &mergeImportState{
+		rejectedMessages:          map[string]struct{}{},
+		retentionRejectedMessages: map[string]struct{}{},
+		importedFiles:             map[string]struct{}{},
+	}
+	manifestTables := make(map[string]TableManifest, len(manifest.Tables))
 	for _, table := range manifest.Tables {
-		rows, err := importTable(ctx, tx, opts.RepoPath, table)
+		manifestTables[table.Name] = table
+	}
+	for _, tableName := range SnapshotTables {
+		table := manifestTables[tableName]
+		rows, err := importTable(ctx, tx, opts.RepoPath, table, restore, opts.IncludeMedia, mergeState)
 		if err != nil {
 			return Manifest{}, err
 		}
@@ -264,12 +287,27 @@ func importLocked(ctx context.Context, s *store.Store, opts Options) (Manifest, 
 			return Manifest{}, fmt.Errorf("manifest table %s row count mismatch: imported %d, expected %d", table.Name, rows, table.Rows)
 		}
 	}
+	if err := backfillDeletedMessageSubordinates(ctx, tx); err != nil {
+		return Manifest{}, err
+	}
+	if err := rebuildMessageFTS(ctx, tx); err != nil {
+		return Manifest{}, err
+	}
+	if err := rebuildMessageEventHeads(ctx, tx); err != nil {
+		return Manifest{}, err
+	}
 	var mediaManifest *MediaManifest
 	if opts.IncludeMedia {
 		mediaManifest = manifest.Media
 	}
-	if err := clearUnmanifestedFileMedia(ctx, tx, mediaManifest); err != nil {
-		return Manifest{}, err
+	if restore {
+		if err := clearUnmanifestedFileMedia(ctx, tx, mediaManifest); err != nil {
+			return Manifest{}, err
+		}
+	} else if opts.IncludeMedia {
+		if err := clearUnmanifestedImportedFileMedia(ctx, tx, mediaManifest, mergeState.importedFiles); err != nil {
+			return Manifest{}, err
+		}
 	}
 	if err := preserveImportedFileMedia(ctx, tx, existingMedia); err != nil {
 		return Manifest{}, err
@@ -283,13 +321,110 @@ func importLocked(ctx context.Context, s *store.Store, opts Options) (Manifest, 
 		return Manifest{}, err
 	}
 	committed = true
-	if err := s.RebuildSearchIndexes(ctx); err != nil {
-		return Manifest{}, err
-	}
 	if err := MarkImported(ctx, s, manifest); err != nil {
 		return Manifest{}, err
 	}
 	return manifest, nil
+}
+
+func rebuildMessageFTS(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `
+delete from message_fts;
+insert into message_fts (message_key, content)
+select m.channel_id || '|' || m.ts,
+       trim(m.normalized_text || ' ' || coalesce((
+         select group_concat(trim(f.name || ' ' || f.title || ' ' || f.plain_text || ' ' || f.preview_plain_text), ' ')
+         from message_files f
+         where f.channel_id = m.channel_id and f.ts = m.ts and f.deleted_at is null
+       ), ''))
+from messages m;
+`); err != nil {
+		return fmt.Errorf("rebuild message_fts: %w", err)
+	}
+	return nil
+}
+
+func backfillDeletedMessageSubordinates(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `
+update message_files
+set deleted_at = coalesce(nullif(deleted_at, ''), (
+      select m.updated_at from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    )),
+    deletion_source = coalesce(nullif(deletion_source, ''), (
+      select m.source_name from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    )),
+    deletion_reason = coalesce(nullif(deletion_reason, ''), 'parent_message_deleted'),
+    updated_at = coalesce((
+      select m.updated_at from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    ), updated_at)
+where exists (
+  select 1 from messages m
+  where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    and trim(coalesce(m.deleted_ts, '')) <> ''
+);
+
+update message_mentions
+set deleted_at = coalesce(nullif(deleted_at, ''), (
+      select m.updated_at from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    )),
+    deletion_source = coalesce(nullif(deletion_source, ''), (
+      select m.source_name from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    )),
+    deletion_reason = coalesce(nullif(deletion_reason, ''), 'parent_message_deleted'),
+    updated_at = coalesce((
+      select m.updated_at from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    ), updated_at)
+where exists (
+  select 1 from messages m
+  where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    and trim(coalesce(m.deleted_ts, '')) <> ''
+);
+`); err != nil {
+		return fmt.Errorf("backfill deleted message subordinates: %w", err)
+	}
+	return nil
+}
+
+func rebuildMessageEventHeads(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `
+insert into message_event_heads (channel_id, ts, event_type, source_name, payload_json)
+select e.channel_id, e.ts, e.event_type, e.source_name, e.payload_json
+from message_events e
+join (
+  select channel_id, ts, event_type, source_name, max(id) as id
+  from message_events
+  group by channel_id, ts, event_type, source_name
+) latest on latest.id = e.id
+where not exists (
+  select 1 from message_event_heads h
+  where h.channel_id = e.channel_id
+    and h.ts = e.ts
+    and h.event_type = e.event_type
+    and h.source_name = e.source_name
+);
+
+insert into message_event_heads (channel_id, ts, event_type, source_name, payload_json)
+select channel_id, ts,
+       case
+         when trim(coalesce(deleted_ts, '')) <> '' then 'message_deleted'
+         when trim(coalesce(edited_ts, '')) <> '' then 'message_changed'
+         else 'message'
+       end,
+       source_name, raw_json
+from messages
+where true
+on conflict(channel_id, ts, event_type, source_name) do update set
+  payload_json = excluded.payload_json;
+`); err != nil {
+		return fmt.Errorf("rebuild message event heads: %w", err)
+	}
+	return nil
 }
 
 func validateManifest(ctx context.Context, db *sql.DB, repoPath string, manifest Manifest) error {
@@ -322,7 +457,7 @@ func validateManifest(ctx context.Context, db *sql.DB, repoPath string, manifest
 		if err != nil {
 			return err
 		}
-		if !sameStrings(table.Columns, columns) {
+		if !compatibleTableColumns(table.Name, table.Columns, columns) {
 			return fmt.Errorf("manifest table %s columns mismatch", table.Name)
 		}
 	}
@@ -366,7 +501,7 @@ func importCurrentManifestLocked(ctx context.Context, s *store.Store, opts Optio
 			return Manifest{}, err
 		}
 		if missing {
-			return importLocked(ctx, s, opts)
+			return importLocked(ctx, s, opts, false)
 		}
 		if _, err := importMedia(ctx, opts, manifest.Media); err != nil {
 			return Manifest{}, err
@@ -453,11 +588,11 @@ func parseManifest(data []byte) (Manifest, error) {
 	return manifest, nil
 }
 
-// ImportAt restores a snapshot from a Git ref without changing the share checkout.
-func ImportAt(ctx context.Context, s *store.Store, opts Options, ref string) (Manifest, error) {
+// RestoreAt exactly restores a snapshot from a Git ref without changing the share checkout.
+func RestoreAt(ctx context.Context, s *store.Store, opts Options, ref string) (Manifest, error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
-		return Import(ctx, s, opts)
+		return Restore(ctx, s, opts)
 	}
 	if err := mirror.Fetch(ctx, mirrorOptions(opts)); err != nil {
 		return Manifest{}, err
@@ -496,7 +631,7 @@ func ImportAt(ctx context.Context, s *store.Store, opts Options, ref string) (Ma
 	historicalOpts.RepoPath = tempDir
 	historicalOpts.Remote = ""
 	historicalOpts.Tag = ""
-	return Import(ctx, s, historicalOpts)
+	return Restore(ctx, s, historicalOpts)
 }
 
 func materializeRefFile(ctx context.Context, opts mirror.Options, ref, filePath, targetRoot string) error {
@@ -590,16 +725,48 @@ func tableManifestFiles(table TableManifest) []string {
 	return nil
 }
 
-func importTable(ctx context.Context, tx *sql.Tx, repoPath string, table TableManifest) (int, error) {
+type mergeImportState struct {
+	rejectedMessages          map[string]struct{}
+	retentionRejectedMessages map[string]struct{}
+	importedFiles             map[string]struct{}
+}
+
+func importTable(ctx context.Context, tx *sql.Tx, repoPath string, table TableManifest, restore, includeMedia bool, state *mergeImportState) (int, error) {
 	files := tableManifestFiles(table)
-	stmt, err := tx.PrepareContext(ctx, insertSQL(table.Name, table.Columns))
+	columns := append([]string{}, table.Columns...)
+	legacyColumns := map[string][]string{
+		"message_files":    {"deleted_at", "deletion_source", "deletion_reason"},
+		"message_events":   {"event_key"},
+		"message_mentions": {"deleted_at", "deletion_source", "deletion_reason", "updated_at"},
+	}[table.Name]
+	for _, column := range legacyColumns {
+		if !containsString(columns, column) {
+			columns = append(columns, column)
+		}
+	}
+	if !restore && table.Name == "message_events" {
+		columns = withoutString(columns, "id")
+	}
+	statement := insertSQL(table.Name, columns)
+	if table.Name == "message_events" {
+		statement += " on conflict(event_key) do nothing"
+	} else if !restore {
+		statement = mergeSQL(table.Name, columns)
+	}
+	var stmt *sql.Stmt
+	var err error
+	if statement != "" {
+		stmt, err = tx.PrepareContext(ctx, statement)
+	}
 	if err != nil {
 		return 0, fmt.Errorf("prepare import %s: %w", table.Name, err)
 	}
-	defer func() { _ = stmt.Close() }()
+	if stmt != nil {
+		defer func() { _ = stmt.Close() }()
+	}
 	rows := 0
 	for _, rel := range files {
-		count, err := importTableFile(ctx, stmt, repoPath, table, rel)
+		count, err := importTableFile(ctx, tx, stmt, columns, repoPath, table, rel, restore, includeMedia, state)
 		if err != nil {
 			return 0, err
 		}
@@ -608,7 +775,7 @@ func importTable(ctx context.Context, tx *sql.Tx, repoPath string, table TableMa
 	return rows, nil
 }
 
-func importTableFile(ctx context.Context, stmt *sql.Stmt, repoPath string, table TableManifest, rel string) (int, error) {
+func importTableFile(ctx context.Context, tx *sql.Tx, stmt *sql.Stmt, columns []string, repoPath string, table TableManifest, rel string, restore, includeMedia bool, state *mergeImportState) (int, error) {
 	path, err := resolveManifestTableFile(repoPath, table.Name, rel)
 	if err != nil {
 		return 0, fmt.Errorf("manifest table %s file %q: %w", table.Name, rel, err)
@@ -635,16 +802,93 @@ func importTableFile(ctx context.Context, stmt *sql.Stmt, repoPath string, table
 		if err != nil {
 			return 0, fmt.Errorf("decode %s: %w", rel, err)
 		}
-		values := make([]any, len(table.Columns))
-		for i, column := range table.Columns {
+		if table.Name == "message_files" && !includeMedia {
+			row["media_path"] = nil
+			row["content_sha256"] = nil
+			row["content_size"] = json.Number("0")
+			row["fetched_at"] = nil
+			row["fetch_status"] = ""
+			row["fetch_error"] = ""
+		}
+		if (table.Name == "message_files" || table.Name == "message_mentions") && !containsString(table.Columns, "deleted_at") {
+			if err := synthesizeLegacySubordinateTombstone(ctx, tx, row); err != nil {
+				return 0, err
+			}
+		}
+		if table.Name == "message_mentions" && snapshotStringValue(row["updated_at"]) == "" {
+			var parentUpdated string
+			err := tx.QueryRowContext(ctx, `select updated_at from messages where channel_id = ? and ts = ?`, row["channel_id"], row["ts"]).Scan(&parentUpdated)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return 0, fmt.Errorf("read legacy mention parent version: %w", err)
+			}
+			row["updated_at"] = parentUpdated
+		}
+		if table.Name == "message_events" && snapshotStringValue(row["event_key"]) == "" {
+			row["event_key"] = legacyMessageEventKey(row)
+		}
+		if !restore {
+			apply, err := shouldMergeSnapshotRow(ctx, tx, table.Name, row, state)
+			if err != nil {
+				return 0, err
+			}
+			if !apply {
+				rows++
+				continue
+			}
+		}
+		values := make([]any, len(columns))
+		for i, column := range columns {
 			values[i] = importValue(row[column])
 		}
-		if _, err := stmt.ExecContext(ctx, values...); err != nil {
-			return 0, fmt.Errorf("insert %s: %w", table.Name, err)
+		if stmt != nil {
+			if _, err := stmt.ExecContext(ctx, values...); err != nil {
+				return 0, fmt.Errorf("insert %s: %w", table.Name, err)
+			}
+		}
+		if !restore && table.Name == "message_files" {
+			state.importedFiles[fileMediaKey(snapshotStringValue(row["channel_id"]), snapshotStringValue(row["ts"]), snapshotStringValue(row["file_id"]))] = struct{}{}
 		}
 		rows++
 	}
 	return rows, nil
+}
+
+func synthesizeLegacySubordinateTombstone(ctx context.Context, tx *sql.Tx, row map[string]any) error {
+	var parentUpdated, parentSource string
+	var parentDeleted bool
+	err := tx.QueryRowContext(ctx, `
+select updated_at, source_name, trim(coalesce(deleted_ts, '')) <> ''
+from messages
+where channel_id = ? and ts = ?
+`, importValue(row["channel_id"]), importValue(row["ts"])).Scan(&parentUpdated, &parentSource, &parentDeleted)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read legacy subordinate parent tombstone: %w", err)
+	}
+	if !parentDeleted {
+		return nil
+	}
+	row["deleted_at"] = parentUpdated
+	row["deletion_source"] = parentSource
+	row["deletion_reason"] = "parent_message_deleted"
+	row["updated_at"] = parentUpdated
+	return nil
+}
+
+func legacyMessageEventKey(row map[string]any) string {
+	parts := []string{
+		snapshotStringValue(row["id"]),
+		snapshotStringValue(row["channel_id"]),
+		snapshotStringValue(row["ts"]),
+		snapshotStringValue(row["event_type"]),
+		snapshotStringValue(row["source_name"]),
+		snapshotStringValue(row["payload_json"]),
+		snapshotStringValue(row["created_at"]),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return "legacy-" + hex.EncodeToString(sum[:])
 }
 
 func resolveManifestTableFile(repoPath string, tableName string, rel string) (string, error) {
@@ -720,6 +964,47 @@ func sameStrings(left, right []string) bool {
 	}
 	for i := range left {
 		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func compatibleTableColumns(table string, imported, current []string) bool {
+	if sameStrings(imported, current) {
+		return true
+	}
+	optional := map[string]map[string]struct{}{
+		"message_files": {
+			"deleted_at": {}, "deletion_source": {}, "deletion_reason": {},
+		},
+		"message_mentions": {
+			"deleted_at": {}, "deletion_source": {}, "deletion_reason": {}, "updated_at": {},
+		},
+		"message_events": {"event_key": {}},
+	}[table]
+	if len(optional) == 0 {
+		return false
+	}
+	currentSet := make(map[string]struct{}, len(current))
+	for _, column := range current {
+		currentSet[column] = struct{}{}
+	}
+	importedSet := make(map[string]struct{}, len(imported))
+	for _, column := range imported {
+		if _, ok := currentSet[column]; !ok {
+			return false
+		}
+		if _, duplicate := importedSet[column]; duplicate {
+			return false
+		}
+		importedSet[column] = struct{}{}
+	}
+	for _, column := range current {
+		if _, ok := importedSet[column]; ok {
+			continue
+		}
+		if _, ok := optional[column]; !ok {
 			return false
 		}
 	}
@@ -947,6 +1232,57 @@ where channel_id = ? and ts = ? and file_id = ?
 	defer func() { _ = stmt.Close() }()
 	for _, row := range clear {
 		if _, err := stmt.ExecContext(ctx, row.channelID, row.ts, row.fileID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func clearUnmanifestedImportedFileMedia(ctx context.Context, tx *sql.Tx, manifest *MediaManifest, imported map[string]struct{}) error {
+	if len(imported) == 0 {
+		return nil
+	}
+	manifested := map[string]struct{}{}
+	if manifest != nil {
+		for _, item := range manifest.Items {
+			mediaPath, ok := strings.CutPrefix(filepath.ToSlash(item.Path), "media/")
+			if ok && strings.TrimSpace(mediaPath) != "" {
+				manifested[mediaPath] = struct{}{}
+			}
+		}
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+update message_files
+set media_path = null, content_sha256 = null, content_size = 0, fetched_at = null,
+    fetch_status = '', fetch_error = ''
+where channel_id = ? and ts = ? and file_id = ?
+  and coalesce(media_path, '') <> ''
+  and coalesce(media_path, '') = ?
+`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = stmt.Close() }()
+	for key := range imported {
+		channelID, ts, fileID, ok := splitFileMediaKey(key)
+		if !ok {
+			continue
+		}
+		var mediaPath string
+		err := tx.QueryRowContext(ctx, `
+select coalesce(media_path, '') from message_files
+where channel_id = ? and ts = ? and file_id = ?
+`, channelID, ts, fileID).Scan(&mediaPath)
+		if errors.Is(err, sql.ErrNoRows) || mediaPath == "" {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if _, ok := manifested[mediaPath]; ok {
+			continue
+		}
+		if _, err := stmt.ExecContext(ctx, channelID, ts, fileID, mediaPath); err != nil {
 			return err
 		}
 	}
@@ -1200,6 +1536,280 @@ func insertSQL(table string, columns []string) string {
 		placeholders[i] = "?"
 	}
 	return "insert into " + quoteIdent(table) + "(" + strings.Join(quoted, ",") + ") values(" + strings.Join(placeholders, ",") + ")"
+}
+
+func mergeSQL(table string, columns []string) string {
+	if table == "embedding_jobs" {
+		return ""
+	}
+	if table == "message_events" {
+		return insertSQL(table, columns) + " on conflict(event_key) do nothing"
+	}
+	if table == "sync_state" {
+		return insertSQL(table, columns) + " on conflict do nothing"
+	}
+	primaryKeys := map[string]map[string]struct{}{
+		"workspaces":       {"id": {}},
+		"channels":         {"id": {}},
+		"users":            {"id": {}},
+		"messages":         {"channel_id": {}, "ts": {}},
+		"message_files":    {"channel_id": {}, "ts": {}, "file_id": {}},
+		"message_mentions": {"channel_id": {}, "ts": {}, "mention_type": {}, "target_id": {}},
+	}
+	keys, ok := primaryKeys[table]
+	if !ok {
+		return insertSQL(table, columns) + " on conflict do nothing"
+	}
+	updates := make([]string, 0, len(columns))
+	for _, column := range columns {
+		if _, key := keys[column]; key {
+			continue
+		}
+		quoted := quoteIdent(column)
+		updates = append(updates, quoted+"=excluded."+quoted)
+	}
+	if len(updates) == 0 {
+		return insertSQL(table, columns) + " on conflict do nothing"
+	}
+	sort.Strings(updates)
+	return insertSQL(table, columns) + " on conflict do update set " + strings.Join(updates, ",")
+}
+
+func shouldMergeSnapshotRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any, state *mergeImportState) (bool, error) {
+	type mergeKey struct {
+		query     string
+		args      []any
+		tombstone string
+	}
+	var key mergeKey
+	messageKey := snapshotStringValue(row["channel_id"]) + "\x00" + snapshotStringValue(row["ts"])
+	if table == "message_events" {
+		if _, rejected := state.retentionRejectedMessages[messageKey]; rejected {
+			return false, nil
+		}
+	}
+	if table == "message_files" || table == "message_mentions" {
+		if _, rejected := state.rejectedMessages[messageKey]; rejected {
+			return false, nil
+		}
+		allowed, err := subordinateAllowedByParent(ctx, tx, row)
+		if err != nil || !allowed {
+			return allowed, err
+		}
+	}
+	if table == "channels" || table == "users" || table == "messages" {
+		if err := rejectWorkspaceIdentityCollision(ctx, tx, table, row); err != nil {
+			return false, err
+		}
+	}
+	switch table {
+	case "workspaces":
+		key = mergeKey{query: `select updated_at, 0 from workspaces where id = ?`, args: []any{importValue(row["id"])}}
+	case "channels":
+		key = mergeKey{query: `select updated_at, is_archived from channels where id = ?`, args: []any{importValue(row["id"])}, tombstone: "is_archived"}
+	case "users":
+		key = mergeKey{query: `select updated_at, is_deleted from users where id = ?`, args: []any{importValue(row["id"])}, tombstone: "is_deleted"}
+	case "messages":
+		allowed, err := store.MessageAllowedByRetention(ctx, tx, store.Message{
+			WorkspaceID: snapshotStringValue(row["workspace_id"]),
+			ChannelID:   snapshotStringValue(row["channel_id"]),
+			TS:          snapshotStringValue(row["ts"]),
+			ThreadTS:    snapshotStringValue(row["thread_ts"]),
+		})
+		if err != nil {
+			return false, fmt.Errorf("apply local retention to snapshot message: %w", err)
+		}
+		if !allowed {
+			state.rejectedMessages[messageKey] = struct{}{}
+			state.retentionRejectedMessages[messageKey] = struct{}{}
+			return false, nil
+		}
+		key = mergeKey{query: `select updated_at, trim(coalesce(deleted_ts, '')) <> '' from messages where channel_id = ? and ts = ?`, args: []any{importValue(row["channel_id"]), importValue(row["ts"])}, tombstone: "deleted_ts"}
+	case "message_files":
+		key = mergeKey{query: `select updated_at, deleted_at is not null from message_files where channel_id = ? and ts = ? and file_id = ?`, args: []any{importValue(row["channel_id"]), importValue(row["ts"]), importValue(row["file_id"])}, tombstone: "deleted_at"}
+	case "message_mentions":
+		key = mergeKey{query: `select updated_at, deleted_at is not null from message_mentions where channel_id = ? and ts = ? and mention_type = ? and target_id = ?`, args: []any{importValue(row["channel_id"]), importValue(row["ts"]), importValue(row["mention_type"]), importValue(row["target_id"])}, tombstone: "deleted_at"}
+	default:
+		return true, nil
+	}
+	var localUpdated string
+	var localTombstone bool
+	err := tx.QueryRowContext(ctx, key.query, key.args...).Scan(&localUpdated, &localTombstone)
+	if errors.Is(err, sql.ErrNoRows) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read existing %s merge version: %w", table, err)
+	}
+	incomingUpdated := snapshotStringValue(row["updated_at"])
+	comparison := compareSnapshotTimes(incomingUpdated, localUpdated)
+	if comparison != 0 {
+		apply := comparison > 0
+		if table == "messages" && !apply {
+			state.rejectedMessages[messageKey] = struct{}{}
+		}
+		return apply, nil
+	}
+	incomingTombstone := false
+	if key.tombstone != "" {
+		incomingTombstone = snapshotTombstoneValue(row[key.tombstone])
+	}
+	if table == "messages" && !localTombstone {
+		var localSourceRank int64
+		var localRawJSON string
+		if err := tx.QueryRowContext(ctx, `select source_rank, raw_json from messages where channel_id = ? and ts = ?`, importValue(row["channel_id"]), importValue(row["ts"])).Scan(&localSourceRank, &localRawJSON); err != nil {
+			return false, fmt.Errorf("read existing message source rank: %w", err)
+		}
+		incomingSourceRank := snapshotInt64Value(row["source_rank"])
+		apply := incomingSourceRank <= localSourceRank
+		if !incomingTombstone {
+			apply = incomingSourceRank < localSourceRank || (incomingSourceRank == localSourceRank && snapshotStringValue(row["raw_json"]) == localRawJSON)
+		}
+		if !apply {
+			state.rejectedMessages[messageKey] = struct{}{}
+		}
+		return apply, nil
+	}
+	apply := !localTombstone || incomingTombstone
+	if table == "messages" && !apply {
+		state.rejectedMessages[messageKey] = struct{}{}
+	}
+	return apply, nil
+}
+
+func snapshotInt64Value(value any) int64 {
+	switch typed := value.(type) {
+	case json.Number:
+		parsed, _ := typed.Int64()
+		return parsed
+	case int64:
+		return typed
+	case float64:
+		return int64(typed)
+	case string:
+		parsed, _ := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func rejectWorkspaceIdentityCollision(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+	incomingWorkspace := snapshotStringValue(row["workspace_id"])
+	var existingWorkspace string
+	var id string
+	var err error
+	if table == "messages" {
+		id = messageSnapshotKey(row)
+		err = tx.QueryRowContext(ctx, `select workspace_id from messages where channel_id = ? and ts = ?`, importValue(row["channel_id"]), importValue(row["ts"])).Scan(&existingWorkspace)
+	} else {
+		id = snapshotStringValue(row["id"])
+		err = tx.QueryRowContext(ctx, "select workspace_id from "+quoteIdent(table)+" where id = ?", id).Scan(&existingWorkspace) //nolint:gosec // Fixed table allowlist above.
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read existing %s workspace: %w", table, err)
+	}
+	if existingWorkspace != incomingWorkspace {
+		return fmt.Errorf("merge %s %q workspace collision: existing %q, incoming %q", table, id, existingWorkspace, incomingWorkspace)
+	}
+	return nil
+}
+
+func messageSnapshotKey(row map[string]any) string {
+	return snapshotStringValue(row["channel_id"]) + "|" + snapshotStringValue(row["ts"])
+}
+
+func subordinateAllowedByParent(ctx context.Context, tx *sql.Tx, row map[string]any) (bool, error) {
+	channelID := snapshotStringValue(row["channel_id"])
+	ts := snapshotStringValue(row["ts"])
+	var parentUpdated string
+	var parentDeleted bool
+	err := tx.QueryRowContext(ctx, `
+select updated_at, trim(coalesce(deleted_ts, '')) <> ''
+from messages
+where channel_id = ? and ts = ?
+`, channelID, ts).Scan(&parentUpdated, &parentDeleted)
+	if errors.Is(err, sql.ErrNoRows) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read snapshot subordinate parent: %w", err)
+	}
+	if !parentDeleted {
+		return true, nil
+	}
+	comparison := compareSnapshotTimes(snapshotStringValue(row["updated_at"]), parentUpdated)
+	return comparison > 0 || (comparison == 0 && snapshotTombstoneValue(row["deleted_at"])), nil
+}
+
+func compareSnapshotTimes(left, right string) int {
+	leftTime, leftErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(left))
+	rightTime, rightErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(right))
+	if leftErr == nil && rightErr == nil {
+		switch {
+		case leftTime.Before(rightTime):
+			return -1
+		case leftTime.After(rightTime):
+			return 1
+		default:
+			return 0
+		}
+	}
+	return strings.Compare(strings.TrimSpace(left), strings.TrimSpace(right))
+}
+
+func snapshotTombstoneValue(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return typed
+	case json.Number:
+		return typed.String() != "0"
+	case float64:
+		return typed != 0
+	case int64:
+		return typed != 0
+	case string:
+		return strings.TrimSpace(typed) != "" && strings.TrimSpace(typed) != "0"
+	default:
+		return true
+	}
+}
+
+func snapshotStringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case []byte:
+		return string(typed)
+	case json.Number:
+		return typed.String()
+	default:
+		return ""
+	}
+}
+
+func withoutString(values []string, remove string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != remove {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func quoteIdent(s string) string {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -1,11 +1,14 @@
 package share
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -46,7 +49,663 @@ func TestExportImportRoundTrip(t *testing.T) {
 	require.Equal(t, "git backed archive works", rows[0].Text)
 	heads, err := reader.QueryReadOnly(ctx, `select count(*) as count from message_event_heads`)
 	require.NoError(t, err)
-	require.Equal(t, int64(0), heads[0]["count"])
+	require.Equal(t, int64(1), heads[0]["count"])
+}
+
+func TestImportMergesWithoutRemovingLocalRowsOrNewerTombstones(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	reader := seedStore(t, filepath.Join(dir, "reader.db"))
+	defer func() { require.NoError(t, reader.Close()) }()
+	newer := time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano)
+	_, err = reader.DB().ExecContext(ctx, `
+update channels set is_archived = 1, updated_at = ? where id = 'C1';
+update users set is_deleted = 1, updated_at = ? where id = 'U1';
+update messages set deleted_ts = '124.000', updated_at = ? where channel_id = 'C1' and ts = '123.456';
+`, newer, newer, newer)
+	require.NoError(t, err)
+	require.NoError(t, reader.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: "999.000", WorkspaceID: "T1", UserID: "U1",
+		Text: "local only", NormalizedText: "local only", SourceRank: 3,
+		SourceName: "desktop-indexeddb", RawJSON: `{"text":"local only"}`, UpdatedAt: time.Now().UTC(),
+	}, nil))
+	require.NoError(t, reader.SetSyncState(ctx, "local", "cursor", "C1", "keep"))
+
+	_, err = Import(ctx, reader, opts)
+	require.NoError(t, err)
+	rows, err := reader.QueryReadOnly(ctx, `
+select c.is_archived, u.is_deleted, coalesce(m.deleted_ts, '') as deleted_ts
+from channels c join users u on u.workspace_id = c.workspace_id
+join messages m on m.workspace_id = c.workspace_id
+where c.id = 'C1' and u.id = 'U1' and m.channel_id = 'C1' and m.ts = '123.456'
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"is_archived": int64(1), "is_deleted": int64(1), "deleted_ts": "124.000"}}, rows)
+	local, err := reader.QueryReadOnly(ctx, `select text from messages where channel_id = 'C1' and ts = '999.000'`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"text": "local only"}}, local)
+	matches, err := reader.Search(ctx, "", "local only", 10)
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	state, err := reader.GetSyncState(ctx, "local", "cursor", "C1")
+	require.NoError(t, err)
+	require.Equal(t, "keep", state)
+}
+
+func TestImportRejectsCrossWorkspaceIdentityCollisions(t *testing.T) {
+	ctx := context.Background()
+	for _, table := range []string{"channels", "users"} {
+		t.Run(table, func(t *testing.T) {
+			dir := t.TempDir()
+			source := seedStore(t, filepath.Join(dir, "source.db"))
+			defer func() { require.NoError(t, source.Close()) }()
+			_, err := source.DB().ExecContext(ctx, `insert into workspaces (id, name, raw_json, updated_at) values ('T2', 'other', '{}', '2026-07-17T00:00:00Z')`)
+			require.NoError(t, err)
+			_, err = source.DB().ExecContext(ctx, "update "+table+" set workspace_id = 'T2' where id = ?", map[string]string{"channels": "C1", "users": "U1"}[table])
+			require.NoError(t, err)
+			opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+			_, err = Export(ctx, source, opts)
+			require.NoError(t, err)
+
+			destination := seedStore(t, filepath.Join(dir, "destination.db"))
+			defer func() { require.NoError(t, destination.Close()) }()
+			_, err = Import(ctx, destination, opts)
+			require.ErrorContains(t, err, "workspace collision")
+			rows, queryErr := destination.QueryReadOnly(ctx, "select workspace_id from "+table+" where id = '"+map[string]string{"channels": "C1", "users": "U1"}[table]+"'")
+			require.NoError(t, queryErr)
+			require.Equal(t, "T1", rows[0]["workspace_id"])
+		})
+	}
+}
+
+func TestImportRejectsMessageWorkspaceCollisionWithoutLocalChannel(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	_, err := source.DB().ExecContext(ctx, `
+insert into workspaces (id, name, raw_json, updated_at) values ('T2', 'other', '{}', '2026-07-17T00:00:00Z');
+update channels set workspace_id = 'T2' where id = 'C1';
+update messages set workspace_id = 'T2', updated_at = '2026-07-17T00:00:01Z' where channel_id = 'C1' and ts = '123.456';
+`)
+	require.NoError(t, err)
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err = Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	destination := seedStore(t, filepath.Join(dir, "destination.db"))
+	defer func() { require.NoError(t, destination.Close()) }()
+	_, err = destination.DB().ExecContext(ctx, `delete from channels where id = 'C1'`)
+	require.NoError(t, err)
+	_, err = Import(ctx, destination, opts)
+	require.ErrorContains(t, err, "workspace collision")
+	rows, queryErr := destination.QueryReadOnly(ctx, `select workspace_id from messages where channel_id = 'C1' and ts = '123.456'`)
+	require.NoError(t, queryErr)
+	require.Equal(t, "T1", rows[0]["workspace_id"])
+}
+
+func TestImportPreservesHigherPriorityMessageOnEqualTimestamp(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	updatedAt := time.Now().UTC().Truncate(time.Second)
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	require.NoError(t, source.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: "123.456", WorkspaceID: "T1", UserID: "U1",
+		Text: "lower priority", NormalizedText: "lower priority", SourceRank: 4,
+		SourceName: "mcp", RawJSON: `{"source":"mcp"}`, UpdatedAt: updatedAt,
+		Files: []store.MessageFile{{FileID: "F-low", Name: "lower.txt", RawJSON: `{}`}},
+	}, nil))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	destination := seedStore(t, filepath.Join(dir, "destination.db"))
+	defer func() { require.NoError(t, destination.Close()) }()
+	require.NoError(t, destination.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: "123.456", WorkspaceID: "T1", UserID: "U1",
+		Text: "higher priority", NormalizedText: "higher priority", SourceRank: 1,
+		SourceName: "api-user", RawJSON: `{"source":"api"}`, UpdatedAt: updatedAt,
+	}, nil))
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	events, err := destination.QueryReadOnly(ctx, `select count(*) as count from message_events where channel_id = 'C1' and ts = '123.456' and source_name = 'mcp'`)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), events[0]["count"])
+	_, err = source.DB().ExecContext(ctx, `update messages set source_rank = 1 where channel_id = 'C1' and ts = '123.456'`)
+	require.NoError(t, err)
+	_, err = Export(ctx, source, opts)
+	require.NoError(t, err)
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	_, err = source.DB().ExecContext(ctx, `update messages set deleted_ts = '124.000', source_rank = 4 where channel_id = 'C1' and ts = '123.456'`)
+	require.NoError(t, err)
+	_, err = Export(ctx, source, opts)
+	require.NoError(t, err)
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `
+select text, source_rank, coalesce(deleted_ts, '') as deleted_ts,
+       (select count(*) from message_files where file_id = 'F-low') as low_files
+from messages where channel_id = 'C1' and ts = '123.456'
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"text": "higher priority", "source_rank": int64(1), "deleted_ts": "", "low_files": int64(0)}}, rows)
+}
+
+func TestImportDoesNotCrossLocalRetentionFloor(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	old := time.Unix(123, 456000000).UTC()
+	require.NoError(t, source.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: "123.456", WorkspaceID: "T1", UserID: "U1",
+		Text: "purged archive", NormalizedText: "purged archive", SourceRank: 2,
+		SourceName: "api-bot", RawJSON: `{}`, UpdatedAt: old,
+		Files: []store.MessageFile{{FileID: "F1", Name: "purged.txt", RawJSON: `{}`}},
+	}, []store.Mention{{Type: "user", TargetID: "U1"}}))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	destination, err := store.Open(filepath.Join(dir, "destination.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, destination.Close()) }()
+	require.NoError(t, destination.SetSyncState(ctx, "retention", "channel_floor", "T1|C1", "200.000000"))
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `
+select (select count(*) from messages) as messages,
+       (select count(*) from message_files) as files,
+       (select count(*) from message_mentions) as mentions,
+       (select count(*) from message_events) as events
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"messages": int64(0), "files": int64(0), "mentions": int64(0), "events": int64(0)}}, rows)
+	matches, err := destination.Search(ctx, "", "purged", 10)
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestImportRejectsUnseenChildrenBehindNewerParentTombstone(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	base := time.Now().UTC().Truncate(time.Second)
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	require.NoError(t, source.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: "123.456", WorkspaceID: "T1", UserID: "U1",
+		Text: "stale", NormalizedText: "stale", SourceRank: 2, SourceName: "api-bot",
+		RawJSON: `{}`, UpdatedAt: base,
+		Files: []store.MessageFile{{FileID: "F-never-local", Name: "secret.txt", RawJSON: `{}`}},
+	}, []store.Mention{{Type: "user", TargetID: "U-never-local"}}))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	destination := seedStore(t, filepath.Join(dir, "destination.db"))
+	defer func() { require.NoError(t, destination.Close()) }()
+	require.NoError(t, destination.MarkMessageDeleted(ctx, store.Message{
+		ChannelID: "C1", TS: "123.456", WorkspaceID: "T1", DeletedTS: "124.000",
+		SourceRank: 2, SourceName: "api-bot", RawJSON: `{"deleted":true}`, UpdatedAt: base.Add(time.Second),
+	}, nil))
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `
+select (select count(*) from message_files where file_id = 'F-never-local') as files,
+       (select count(*) from message_mentions where target_id = 'U-never-local') as mentions
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"files": int64(0), "mentions": int64(0)}}, rows)
+}
+
+func TestImportPreservesEqualVersionSubordinateTombstones(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	message := store.Message{
+		ChannelID: "C1", TS: "600.000", WorkspaceID: "T1", UserID: "U1",
+		Text: "deleted children", NormalizedText: "deleted children", SourceRank: 2,
+		SourceName: "api-bot", RawJSON: `{}`, UpdatedAt: now,
+		Files: []store.MessageFile{{FileID: "F-deleted", Name: "deleted.txt", RawJSON: `{}`}},
+	}
+	require.NoError(t, source.UpsertMessage(ctx, message, []store.Mention{{Type: "user", TargetID: "U-deleted"}}))
+	message.DeletedTS = "601.000"
+	message.UpdatedAt = now.Add(time.Second)
+	require.NoError(t, source.MarkMessageDeleted(ctx, message, nil))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	destination, err := store.Open(filepath.Join(dir, "destination.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, destination.Close()) }()
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `
+select (select count(*) from message_files where file_id = 'F-deleted' and deleted_at is not null and deletion_source = 'api-bot') as files,
+       (select count(*) from message_mentions where target_id = 'U-deleted' and deleted_at is not null and deletion_source = 'api-bot') as mentions
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"files": int64(1), "mentions": int64(1)}}, rows)
+}
+
+func TestImportRejectsUnseenChildrenBehindNewerActiveParent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	base := time.Now().UTC().Truncate(time.Second)
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	message := store.Message{
+		ChannelID: "C1", TS: "123.456", WorkspaceID: "T1", UserID: "U1",
+		Text: "stale child", NormalizedText: "stale child", SourceRank: 2,
+		SourceName: "api-bot", RawJSON: `{"version":"old"}`, UpdatedAt: base,
+		Files: []store.MessageFile{{FileID: "F-stale", Name: "stale-secret.txt", RawJSON: `{}`}},
+	}
+	require.NoError(t, source.UpsertMessage(ctx, message, []store.Mention{{Type: "user", TargetID: "U-stale"}}))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	destination := seedStore(t, filepath.Join(dir, "destination.db"))
+	defer func() { require.NoError(t, destination.Close()) }()
+	message.Text = "new canonical"
+	message.NormalizedText = "new canonical"
+	message.RawJSON = `{"version":"new"}`
+	message.UpdatedAt = base.Add(time.Second)
+	message.Files = nil
+	require.NoError(t, destination.UpsertMessage(ctx, message, nil))
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `
+select (select count(*) from message_files where file_id = 'F-stale') as files,
+       (select count(*) from message_mentions where target_id = 'U-stale') as mentions
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"files": int64(0), "mentions": int64(0)}}, rows)
+	matches, err := destination.Search(ctx, "", "stale", 10)
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestRestoreExactlyReplacesSnapshotTables(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	reader := seedStore(t, filepath.Join(dir, "reader.db"))
+	defer func() { require.NoError(t, reader.Close()) }()
+	require.NoError(t, reader.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: "999.000", WorkspaceID: "T1", Text: "local only",
+		NormalizedText: "local only", SourceRank: 3, SourceName: "desktop-indexeddb",
+		RawJSON: `{}`, UpdatedAt: time.Now().UTC(),
+	}, nil))
+	_, err = reader.DB().ExecContext(ctx, `update users set is_deleted = 1 where id = 'U1'`)
+	require.NoError(t, err)
+
+	_, err = Restore(ctx, reader, opts)
+	require.NoError(t, err)
+	rows, err := reader.QueryReadOnly(ctx, `select count(*) as count from messages where channel_id = 'C1' and ts = '999.000'`)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rows[0]["count"])
+	rows, err = reader.QueryReadOnly(ctx, `select is_deleted from users where id = 'U1'`)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rows[0]["is_deleted"])
+}
+
+func TestImportMergesVersionedSubordinateTombstonesAndResurrections(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	reader, err := store.Open(filepath.Join(dir, "reader.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reader.Close()) }()
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	base := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	message := store.Message{
+		ChannelID: "C1", TS: "200.000", WorkspaceID: "T1", UserID: "U1",
+		Text: "versioned", NormalizedText: "versioned", SourceRank: 2, SourceName: "api-bot",
+		RawJSON: `{}`, UpdatedAt: base,
+		Files: []store.MessageFile{{FileID: "F1", Name: "one.txt", RawJSON: `{}`}},
+	}
+	mention := store.Mention{Type: "user", TargetID: "U1", DisplayText: "alice"}
+	require.NoError(t, source.UpsertMessage(ctx, message, []store.Mention{mention}))
+	_, err = Export(ctx, source, opts)
+	require.NoError(t, err)
+	_, err = Import(ctx, reader, opts)
+	require.NoError(t, err)
+
+	message.UpdatedAt = base.Add(time.Second)
+	message.Files = []store.MessageFile{}
+	require.NoError(t, source.UpsertMessage(ctx, message, []store.Mention{}))
+	_, err = Export(ctx, source, opts)
+	require.NoError(t, err)
+	_, err = Import(ctx, reader, opts)
+	require.NoError(t, err)
+	rows, err := reader.QueryReadOnly(ctx, `
+select (select count(*) from message_files where channel_id = 'C1' and ts = '200.000' and deleted_at is not null) as files,
+       (select count(*) from message_mentions where channel_id = 'C1' and ts = '200.000' and deleted_at is not null) as mentions
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"files": int64(1), "mentions": int64(1)}}, rows)
+	matches, err := reader.Search(ctx, "", "one", 10)
+	require.NoError(t, err)
+	require.Empty(t, matches)
+
+	message.UpdatedAt = base.Add(2 * time.Second)
+	message.Files = []store.MessageFile{{FileID: "F1", Name: "one.txt", RawJSON: `{}`}}
+	require.NoError(t, source.UpsertMessage(ctx, message, []store.Mention{mention}))
+	_, err = Export(ctx, source, opts)
+	require.NoError(t, err)
+	_, err = Import(ctx, reader, opts)
+	require.NoError(t, err)
+	rows, err = reader.QueryReadOnly(ctx, `
+select (select count(*) from message_files where channel_id = 'C1' and ts = '200.000' and deleted_at is null) as files,
+       (select count(*) from message_mentions where channel_id = 'C1' and ts = '200.000' and deleted_at is null) as mentions
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"files": int64(1), "mentions": int64(1)}}, rows)
+	matches, err = reader.Search(ctx, "", "one", 10)
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+}
+
+func TestImportRebuildsMessageEventHeadsFromMergedHistory(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	reader := seedStore(t, filepath.Join(dir, "reader.db"))
+	defer func() { require.NoError(t, reader.Close()) }()
+	message := store.Message{
+		ChannelID: "C1", TS: "123.456", WorkspaceID: "T1", UserID: "U1",
+		Text: "new", NormalizedText: "new", SourceRank: 2, SourceName: "api-bot",
+		RawJSON: `{"version":"new"}`, UpdatedAt: time.Now().UTC().Add(time.Hour),
+	}
+	require.NoError(t, source.UpsertMessage(ctx, message, nil))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+	_, err = Import(ctx, reader, opts)
+	require.NoError(t, err)
+	rows, err := reader.QueryReadOnly(ctx, `select payload_json from message_event_heads where channel_id = 'C1' and ts = '123.456' and event_type = 'message' and source_name = 'api-bot'`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"payload_json": `{"version":"new"}`}}, rows)
+
+	message.Text = "reverted"
+	message.NormalizedText = "reverted"
+	message.RawJSON = `{}`
+	message.UpdatedAt = message.UpdatedAt.Add(time.Second)
+	require.NoError(t, reader.UpsertMessage(ctx, message, nil))
+	rows, err = reader.QueryReadOnly(ctx, `select payload_json from message_events where channel_id = 'C1' and ts = '123.456' order by created_at, id`)
+	require.NoError(t, err)
+	require.Len(t, rows, 4)
+	require.Equal(t, `{}`, rows[3]["payload_json"])
+	_, err = Import(ctx, reader, opts)
+	require.NoError(t, err)
+	rows, err = reader.QueryReadOnly(ctx, `select payload_json from message_events where channel_id = 'C1' and ts = '123.456' order by created_at, id`)
+	require.NoError(t, err)
+	require.Len(t, rows, 4)
+}
+
+func TestImportPreservesCompactedNewerEventHead(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	_, err := source.DB().ExecContext(ctx, `
+delete from message_events;
+insert into message_events (channel_id, ts, event_type, source_name, payload_json, created_at)
+values ('C1', '123.456', 'message', 'api-bot', '{"stale":true}', '2020-01-01T00:00:00Z');
+update messages set raw_json = '{"stale":true}', updated_at = '2020-01-01T00:00:00Z'
+where channel_id = 'C1' and ts = '123.456';
+`)
+	require.NoError(t, err)
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err = Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	destination := seedStore(t, filepath.Join(dir, "destination.db"))
+	defer func() { require.NoError(t, destination.Close()) }()
+	_, err = destination.DB().ExecContext(ctx, `delete from message_events`)
+	require.NoError(t, err)
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `select payload_json from message_event_heads where channel_id = 'C1' and ts = '123.456' and event_type = 'message' and source_name = 'api-bot'`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"payload_json": `{}`}}, rows)
+}
+
+func TestImportPreservesAmbiguousCompactedEventHeadAcrossPayloadReversion(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	_, err := source.DB().ExecContext(ctx, `
+insert into message_events (channel_id, ts, event_type, source_name, payload_json, created_at) values
+  ('C1', '123.456', 'message_changed', 'api-bot', '{"state":"A"}', '2026-07-17T00:00:00Z'),
+  ('C1', '123.456', 'message_changed', 'api-bot', '{"state":"B"}', '2026-07-17T00:00:01Z');
+insert into message_event_heads (channel_id, ts, event_type, source_name, payload_json)
+values ('C1', '123.456', 'message_changed', 'api-bot', '{"state":"B"}')
+on conflict(channel_id, ts, event_type, source_name) do update set payload_json = excluded.payload_json;
+`)
+	require.NoError(t, err)
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	_, err = Export(ctx, source, opts)
+	require.NoError(t, err)
+
+	destination := seedStore(t, filepath.Join(dir, "destination.db"))
+	defer func() { require.NoError(t, destination.Close()) }()
+	_, err = destination.DB().ExecContext(ctx, `
+delete from message_events where channel_id = 'C1' and ts = '123.456';
+insert into message_event_heads (channel_id, ts, event_type, source_name, payload_json)
+values ('C1', '123.456', 'message_changed', 'api-bot', '{"state":"A"}')
+on conflict(channel_id, ts, event_type, source_name) do update set payload_json = excluded.payload_json;
+`)
+	require.NoError(t, err)
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `select payload_json from message_event_heads where channel_id = 'C1' and ts = '123.456' and event_type = 'message_changed' and source_name = 'api-bot'`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"payload_json": `{"state":"A"}`}}, rows)
+}
+
+func TestCompareSnapshotTimesPreservesNanosecondsAndOffsets(t *testing.T) {
+	require.Equal(t, -1, compareSnapshotTimes("2026-07-17T12:00:00.000000100Z", "2026-07-17T12:00:00.000000200Z"))
+	require.Equal(t, 1, compareSnapshotTimes("2026-07-17T05:00:00.000000300-07:00", "2026-07-17T12:00:00.000000200Z"))
+	require.Zero(t, compareSnapshotTimes("2026-07-17T05:00:00-07:00", "2026-07-17T12:00:00Z"))
+}
+
+func TestRestorePreservesDistinctLegacyMessageEvents(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	manifest, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+	for i := range manifest.Tables {
+		if manifest.Tables[i].Name != "message_events" {
+			continue
+		}
+		manifest.Tables[i].Columns = withoutString(manifest.Tables[i].Columns, "event_key")
+		filePath := filepath.Join(opts.RepoPath, filepath.FromSlash(manifest.Tables[i].Files[0]))
+		file, err := os.Open(filePath)
+		require.NoError(t, err)
+		reader, err := gzip.NewReader(file)
+		require.NoError(t, err)
+		body, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.NoError(t, reader.Close())
+		require.NoError(t, file.Close())
+		var duplicate map[string]any
+		require.NoError(t, json.Unmarshal(bytes.TrimSpace(body), &duplicate))
+		delete(duplicate, "event_key")
+		duplicate["id"] = 999
+		bodyRows := bytes.Split(bytes.TrimSpace(body), []byte{'\n'})
+		for i := range bodyRows {
+			var row map[string]any
+			require.NoError(t, json.Unmarshal(bodyRows[i], &row))
+			delete(row, "event_key")
+			bodyRows[i], err = json.Marshal(row)
+			require.NoError(t, err)
+		}
+		body = append(bytes.Join(bodyRows, []byte{'\n'}), '\n')
+		duplicateBody, err := json.Marshal(duplicate)
+		require.NoError(t, err)
+		duplicateBody = append(duplicateBody, '\n')
+		var compressed bytes.Buffer
+		writer := gzip.NewWriter(&compressed)
+		_, err = writer.Write(append(append([]byte{}, body...), duplicateBody...))
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+		require.NoError(t, os.WriteFile(filePath, compressed.Bytes(), 0o600))
+		manifest.Tables[i].Rows *= 2
+	}
+	writeManifest(t, opts.RepoPath, manifest)
+
+	destination, err := store.Open(filepath.Join(dir, "destination.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, destination.Close()) }()
+	_, err = Restore(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `select count(*) as count, min(id) as min_id from message_events`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"count": int64(2), "min_id": int64(1)}}, rows)
+}
+
+func TestLegacySnapshotBackfillsDeletedSubordinates(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	now := time.Now().UTC().Add(time.Hour)
+	message := store.Message{
+		ChannelID: "C1", TS: "300.000", WorkspaceID: "T1", UserID: "U1",
+		Text: "deleted legacy", NormalizedText: "deleted legacy", SourceRank: 2,
+		SourceName: "api-bot", RawJSON: `{}`, UpdatedAt: now,
+		Files: []store.MessageFile{{FileID: "F-legacy", Name: "confidential.txt", RawJSON: `{}`}},
+	}
+	require.NoError(t, source.UpsertMessage(ctx, message, []store.Mention{{Type: "user", TargetID: "U1"}}))
+	message.DeletedTS = "301.000"
+	message.UpdatedAt = now.Add(time.Second)
+	require.NoError(t, source.MarkMessageDeleted(ctx, message, nil))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	manifest, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+	for i := range manifest.Tables {
+		switch manifest.Tables[i].Name {
+		case "message_files":
+			for _, column := range []string{"deleted_at", "deletion_source", "deletion_reason"} {
+				manifest.Tables[i].Columns = withoutString(manifest.Tables[i].Columns, column)
+			}
+			rewriteSnapshotTableRows(t, opts.RepoPath, manifest.Tables[i], func(row map[string]any) {
+				delete(row, "deleted_at")
+				delete(row, "deletion_source")
+				delete(row, "deletion_reason")
+			})
+		case "message_mentions":
+			for _, column := range []string{"deleted_at", "deletion_source", "deletion_reason", "updated_at"} {
+				manifest.Tables[i].Columns = withoutString(manifest.Tables[i].Columns, column)
+			}
+			rewriteSnapshotTableRows(t, opts.RepoPath, manifest.Tables[i], func(row map[string]any) {
+				delete(row, "deleted_at")
+				delete(row, "deletion_source")
+				delete(row, "deletion_reason")
+				delete(row, "updated_at")
+			})
+		}
+	}
+	writeManifest(t, opts.RepoPath, manifest)
+
+	destination, err := store.Open(filepath.Join(dir, "destination.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, destination.Close()) }()
+	_, err = Restore(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `
+select (select count(*) from message_files where file_id = 'F-legacy' and deletion_reason = 'parent_message_deleted') as files,
+       (select count(*) from message_mentions where channel_id = 'C1' and ts = '300.000' and deletion_reason = 'parent_message_deleted') as mentions
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"files": int64(1), "mentions": int64(1)}}, rows)
+	matches, err := destination.Search(ctx, "", "confidential", 10)
+	require.NoError(t, err)
+	require.Empty(t, matches)
+
+	mergeDestination, err := store.Open(filepath.Join(dir, "merge-destination.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, mergeDestination.Close()) }()
+	_, err = Import(ctx, mergeDestination, opts)
+	require.NoError(t, err)
+	rows, err = mergeDestination.QueryReadOnly(ctx, `
+select (select count(*) from message_files where file_id = 'F-legacy' and deletion_reason = 'parent_message_deleted' and deletion_source = 'api-bot') as files,
+       (select count(*) from message_mentions where channel_id = 'C1' and ts = '300.000' and deletion_reason = 'parent_message_deleted' and deletion_source = 'api-bot') as mentions
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"files": int64(1), "mentions": int64(1)}}, rows)
+	matches, err = mergeDestination.Search(ctx, "", "confidential", 10)
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestImportVersionsLegacyMentionsFromParent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	base := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	message := store.Message{
+		ChannelID: "C1", TS: "400.000", WorkspaceID: "T1", UserID: "U1",
+		Text: "active mention", NormalizedText: "active mention", SourceRank: 2,
+		SourceName: "api-bot", RawJSON: `{}`, UpdatedAt: base.Add(2 * time.Second),
+	}
+	mention := store.Mention{Type: "user", TargetID: "U1"}
+	require.NoError(t, source.UpsertMessage(ctx, message, []store.Mention{mention}))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	manifest, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+	for i := range manifest.Tables {
+		if manifest.Tables[i].Name != "message_mentions" {
+			continue
+		}
+		for _, column := range []string{"deleted_at", "deletion_source", "deletion_reason", "updated_at"} {
+			manifest.Tables[i].Columns = withoutString(manifest.Tables[i].Columns, column)
+		}
+		rewriteSnapshotTableRows(t, opts.RepoPath, manifest.Tables[i], func(row map[string]any) {
+			delete(row, "deleted_at")
+			delete(row, "deletion_source")
+			delete(row, "deletion_reason")
+			delete(row, "updated_at")
+		})
+	}
+	writeManifest(t, opts.RepoPath, manifest)
+
+	destination := seedStore(t, filepath.Join(dir, "destination.db"))
+	defer func() { require.NoError(t, destination.Close()) }()
+	message.UpdatedAt = base
+	require.NoError(t, destination.UpsertMessage(ctx, message, []store.Mention{mention}))
+	message.UpdatedAt = base.Add(time.Second)
+	require.NoError(t, destination.UpsertMessage(ctx, message, []store.Mention{}))
+	_, err = Import(ctx, destination, opts)
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `select count(*) as count from message_mentions where channel_id = 'C1' and ts = '400.000' and deleted_at is null`)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows[0]["count"])
 }
 
 func TestImportRejectsIncompleteManifestBeforeClearing(t *testing.T) {
@@ -251,7 +910,7 @@ func TestImportAtRestoresTaggedSnapshotWithoutMovingCheckout(t *testing.T) {
 	reader, err := store.Open(filepath.Join(dir, "reader.db"))
 	require.NoError(t, err)
 	defer func() { require.NoError(t, reader.Close()) }()
-	manifest, err := ImportAt(ctx, reader, opts, "snapshot-old")
+	manifest, err := RestoreAt(ctx, reader, opts, "snapshot-old")
 	require.NoError(t, err)
 	require.False(t, manifest.GeneratedAt.IsZero())
 	rows, err := reader.Search(ctx, "", "archive", 10)
@@ -361,6 +1020,59 @@ func TestExportImportRestoresMediaFiles(t *testing.T) {
 	require.NoError(t, <-lockDone)
 }
 
+func TestMergeClearsUnmanifestedIncomingMediaAndPreservesLocalCache(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	base := time.Now().UTC().Truncate(time.Second)
+	source := seedStore(t, filepath.Join(dir, "source.db"))
+	defer func() { require.NoError(t, source.Close()) }()
+	message := store.Message{
+		ChannelID: "C1", TS: "500.000", WorkspaceID: "T1", UserID: "U1",
+		Text: "shared media", NormalizedText: "shared media", SourceRank: 2,
+		SourceName: "api-bot", RawJSON: `{}`, UpdatedAt: base.Add(time.Second),
+		Files: []store.MessageFile{{
+			FileID: "F-shared", Name: "shared.txt", MediaPath: "files/source-only.txt",
+			ContentSHA256: "source-hash", ContentSize: 20, FetchStatus: "fetched", RawJSON: `{}`,
+		}},
+	}
+	require.NoError(t, source.UpsertMessage(ctx, message, nil))
+	opts := Options{RepoPath: filepath.Join(dir, "share"), Branch: "main"}
+	manifest, err := Export(ctx, source, opts)
+	require.NoError(t, err)
+	require.Nil(t, manifest.Media)
+
+	destination := seedStore(t, filepath.Join(dir, "destination.db"))
+	defer func() { require.NoError(t, destination.Close()) }()
+	message.UpdatedAt = base
+	message.Files[0].MediaPath = "files/local-cache.txt"
+	message.Files[0].ContentSHA256 = "local-hash"
+	message.Files[0].ContentSize = 10
+	require.NoError(t, destination.UpsertMessage(ctx, message, nil))
+	require.NoError(t, destination.UpsertMessage(ctx, store.Message{
+		ChannelID: "C1", TS: "501.000", WorkspaceID: "T1", UserID: "U1",
+		Text: "local media", NormalizedText: "local media", SourceRank: 2,
+		SourceName: "api-bot", RawJSON: `{}`, UpdatedAt: base,
+		Files: []store.MessageFile{{
+			FileID: "F-local", Name: "local.txt", MediaPath: "files/local-only.txt",
+			ContentSHA256: "local-only-hash", ContentSize: 30, FetchStatus: "fetched", RawJSON: `{}`,
+		}},
+	}, nil))
+
+	_, err = Import(ctx, destination, Options{RepoPath: opts.RepoPath, CacheDir: filepath.Join(dir, "cache"), Branch: "main", IncludeMedia: true})
+	require.NoError(t, err)
+	rows, err := destination.QueryReadOnly(ctx, `
+select file_id, coalesce(media_path, '') as media_path, coalesce(content_sha256, '') as content_sha256
+from message_files
+where file_id in ('F-shared', 'F-local')
+order by file_id
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{
+		{"file_id": "F-local", "media_path": "files/local-only.txt", "content_sha256": "local-only-hash"},
+		{"file_id": "F-shared", "media_path": "files/local-cache.txt", "content_sha256": "local-hash"},
+	}, rows)
+}
+
 func TestNeedsImportUsesLastImportTime(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -381,6 +1093,40 @@ func writeManifest(t *testing.T, repoPath string, manifest Manifest) {
 	require.NoError(t, err)
 	body = append(body, '\n')
 	require.NoError(t, os.WriteFile(filepath.Join(repoPath, ManifestName), body, 0o600))
+}
+
+func rewriteSnapshotTableRows(t *testing.T, repoPath string, table TableManifest, transform func(map[string]any)) {
+	t.Helper()
+	for _, relative := range tableManifestFiles(table) {
+		filePath := filepath.Join(repoPath, filepath.FromSlash(relative))
+		file, err := os.Open(filePath)
+		require.NoError(t, err)
+		reader, err := gzip.NewReader(file)
+		require.NoError(t, err)
+		decoder := json.NewDecoder(reader)
+		decoder.UseNumber()
+		var rows []map[string]any
+		for {
+			row := map[string]any{}
+			err := decoder.Decode(&row)
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			transform(row)
+			rows = append(rows, row)
+		}
+		require.NoError(t, reader.Close())
+		require.NoError(t, file.Close())
+		var compressed bytes.Buffer
+		writer := gzip.NewWriter(&compressed)
+		encoder := json.NewEncoder(writer)
+		for _, row := range rows {
+			require.NoError(t, encoder.Encode(row))
+		}
+		require.NoError(t, writer.Close())
+		require.NoError(t, os.WriteFile(filePath, compressed.Bytes(), 0o600))
+	}
 }
 
 func assertArchiveStillPresent(t *testing.T, ctx context.Context, s *store.Store) {

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -1354,14 +1354,16 @@ func TestHandleEventsAPIEventMarksOriginalMessageDeleted(t *testing.T) {
 	require.Equal(t, "gone [deleted]", rows[0]["normalized_text"])
 	files, err := st.Files(ctx, store.FileListOptions{FileID: "F123"})
 	require.NoError(t, err)
-	require.Len(t, files, 1)
-	require.Equal(t, "files/ab/hash-incident.txt", files[0].MediaPath)
+	require.Empty(t, files)
+	fileTombstones, err := st.QueryReadOnly(ctx, `select file_id, deletion_source, deletion_reason from message_files where deleted_at is not null`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"file_id": "F123", "deletion_source": "api-bot", "deletion_reason": "parent_message_deleted"}}, fileTombstones)
 	matches, err := st.Search(ctx, "T123", "deleted", 10)
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
 	matches, err = st.Search(ctx, "T123", "archived", 10)
 	require.NoError(t, err)
-	require.Len(t, matches, 1)
+	require.Empty(t, matches)
 }
 
 func TestHandleEventsAPIEventIndexesMentionsForDeletedTombstone(t *testing.T) {
@@ -1390,9 +1392,13 @@ func TestHandleEventsAPIEventIndexesMentionsForDeletedTombstone(t *testing.T) {
 
 	mentions, err := st.Mentions(ctx, "T123", "U234", 10)
 	require.NoError(t, err)
-	require.Len(t, mentions, 1)
-	require.Equal(t, "1710000000.000100", mentions[0].TS)
-	require.Equal(t, "sam", mentions[0].DisplayText)
+	require.Empty(t, mentions)
+	tombstones, err := st.QueryReadOnly(ctx, `select ts, target_id, display_text, deletion_source, deletion_reason from message_mentions where deleted_at is not null`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{
+		"ts": "1710000000.000100", "target_id": "U234", "display_text": "sam",
+		"deletion_source": "api-bot", "deletion_reason": "parent_message_deleted",
+	}}, tombstones)
 }
 
 func TestHandleEventsAPIEventIgnoresUnknown(t *testing.T) {

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -107,14 +107,20 @@ where messages.workspace_id = excluded.workspace_id
 -- name: GetMessageWorkspace :one
 select workspace_id from messages where channel_id = ? and ts = ?;
 
--- name: DeleteMessageMentions :exec
-delete from message_mentions where channel_id = ? and ts = ?;
+-- name: TombstoneMessageMentions :exec
+update message_mentions
+set deleted_at = ?, deletion_source = ?, deletion_reason = 'absent_from_authoritative_message_payload', updated_at = ?
+where channel_id = ? and ts = ?;
 
 -- name: UpsertMessageMention :exec
-insert into message_mentions (channel_id, ts, mention_type, target_id, display_text)
-values (?, ?, ?, ?, ?)
+insert into message_mentions (channel_id, ts, mention_type, target_id, display_text, updated_at)
+values (?, ?, ?, ?, ?, ?)
 on conflict(channel_id, ts, mention_type, target_id) do update set
-  display_text=excluded.display_text;
+  display_text=excluded.display_text,
+  deleted_at=null,
+  deletion_source=null,
+  deletion_reason=null,
+  updated_at=excluded.updated_at;
 
 -- name: ListExistingFileMedia :many
 select file_id, coalesce(media_path, '') as media_path,
@@ -155,6 +161,9 @@ on conflict(channel_id, ts, file_id) do update set
   fetched_at=excluded.fetched_at,
   fetch_status=excluded.fetch_status,
   fetch_error=excluded.fetch_error,
+  deleted_at=null,
+  deletion_source=null,
+  deletion_reason=null,
   raw_json=excluded.raw_json,
   updated_at=excluded.updated_at;
 
@@ -326,6 +335,7 @@ select m.workspace_id, mm.channel_id, mm.ts, mm.mention_type, mm.target_id, coal
 from message_mentions mm
 join messages m on m.channel_id = mm.channel_id and m.ts = mm.ts
 where (sqlc.arg(workspace_id) = '' or m.workspace_id = sqlc.arg(workspace_id))
+  and mm.deleted_at is null
   and (sqlc.arg(target) = '' or mm.target_id = sqlc.arg(target) or mm.display_text like sqlc.arg(target_like))
 order by mm.ts desc
 limit sqlc.arg(limit);

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -90,6 +90,9 @@ create table message_files (
   fetch_error text not null default '',
   raw_json text not null,
   updated_at text not null,
+  deleted_at text,
+  deletion_source text,
+  deletion_reason text,
   primary key (channel_id, ts, file_id)
 );
 
@@ -99,6 +102,7 @@ create index idx_message_files_name on message_files(name);
 
 create table message_events (
   id integer primary key autoincrement,
+  event_key text not null default (lower(hex(randomblob(16)))),
   channel_id text not null,
   ts text not null,
   event_type text not null,
@@ -106,6 +110,7 @@ create table message_events (
   payload_json text not null,
   created_at text not null
 );
+create unique index idx_message_events_identity on message_events(event_key);
 
 create table message_event_heads (
   channel_id text not null,
@@ -131,6 +136,10 @@ create table message_mentions (
   mention_type text not null,
   target_id text not null,
   display_text text,
+  deleted_at text,
+  deletion_source text,
+  deletion_reason text,
+  updated_at text not null default '',
   primary key (channel_id, ts, mention_type, target_id)
 );
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,7 +19,7 @@ import (
 	"github.com/openclaw/slacrawl/internal/store/storedb"
 )
 
-const schemaVersion = 5
+const schemaVersion = 6
 
 const schemaPragmas = `
 pragma foreign_keys = on;
@@ -154,6 +156,9 @@ create table if not exists message_files (
   fetch_error text not null default '',
   raw_json text not null,
   updated_at text not null,
+  deleted_at text,
+  deletion_source text,
+  deletion_reason text,
   primary key (channel_id, ts, file_id)
 );
 
@@ -163,6 +168,7 @@ create index if not exists idx_message_files_name on message_files(name);
 
 create table if not exists message_events (
   id integer primary key autoincrement,
+  event_key text not null default (lower(hex(randomblob(16)))),
   channel_id text not null,
   ts text not null,
   event_type text not null,
@@ -170,6 +176,8 @@ create table if not exists message_events (
   payload_json text not null,
   created_at text not null
 );
+create unique index if not exists idx_message_events_identity
+on message_events(event_key);
 ` + messageEventHeadsSchema + `
 create table if not exists sync_state (
   source_name text not null,
@@ -186,6 +194,10 @@ create table if not exists message_mentions (
   mention_type text not null,
   target_id text not null,
   display_text text,
+  deleted_at text,
+  deletion_source text,
+  deletion_reason text,
+  updated_at text not null default '',
   primary key (channel_id, ts, mention_type, target_id)
 );
 
@@ -249,6 +261,26 @@ create index if not exists idx_message_files_name on message_files(name);
 
 const schemaV4Migration = messageEventHeadsSchema
 const schemaV5Migration = messageEventHeadTriggerSchema
+const schemaV6Migration = `
+drop index if exists idx_message_events_identity;
+create table message_events_v6 (
+  id integer primary key autoincrement,
+  event_key text not null default (lower(hex(randomblob(16)))),
+  channel_id text not null,
+  ts text not null,
+  event_type text not null,
+  source_name text not null,
+  payload_json text not null,
+  created_at text not null
+);
+insert into message_events_v6 (id, event_key, channel_id, ts, event_type, source_name, payload_json, created_at)
+select id, event_key, channel_id, ts, event_type, source_name, payload_json, created_at
+from message_events;
+drop table message_events;
+alter table message_events_v6 rename to message_events;
+create unique index if not exists idx_message_events_identity
+on message_events(event_key);
+`
 
 type Store struct {
 	db *sql.DB
@@ -875,7 +907,7 @@ func (s *Store) upsertMessage(ctx context.Context, message Message, mentions []M
 		return false, fmt.Errorf("message %q upsert affected no rows", key)
 	}
 
-	if err := replaceMessageMentions(ctx, qtx, message.ChannelID, message.TS, mentions); err != nil {
+	if err := replaceMessageMentions(ctx, qtx, message, mentions); err != nil {
 		return false, err
 	}
 
@@ -885,7 +917,7 @@ func (s *Store) upsertMessage(ctx context.Context, message Message, mentions []M
 		if err != nil {
 			return false, err
 		}
-		if err := qtx.DeleteMessageFiles(ctx, storedb.DeleteMessageFilesParams{ChannelID: message.ChannelID, Ts: message.TS}); err != nil {
+		if err := tombstoneMissingMessageFiles(ctx, dbtx, message, message.Files); err != nil {
 			return false, err
 		}
 		for i, file := range message.Files {
@@ -1019,6 +1051,13 @@ func (s *Store) markMessageDeleted(ctx context.Context, message Message, mention
 		}
 	}
 	qtx := storedb.New(dbtx)
+	deleteWins, err := messageDeleteWins(ctx, dbtx, message)
+	if err != nil {
+		return false, err
+	}
+	if !deleteWins {
+		return false, nil
+	}
 
 	updatedAt := formatDBTime(message.UpdatedAt)
 	rows, err := qtx.MarkMessageDeleted(ctx, storedb.MarkMessageDeletedParams{
@@ -1065,10 +1104,12 @@ func (s *Store) markMessageDeleted(ctx context.Context, message Message, mention
 		if err := qtx.DeleteMessageFTS(ctx, key); err != nil {
 			return false, err
 		}
-		if err := qtx.InsertMessageFTS(ctx, storedb.InsertMessageFTSParams{MessageKey: key, Content: messageSearchContent(message)}); err != nil {
+		searchMessage := message
+		searchMessage.Files = nil
+		if err := qtx.InsertMessageFTS(ctx, storedb.InsertMessageFTSParams{MessageKey: key, Content: messageSearchContent(searchMessage)}); err != nil {
 			return false, err
 		}
-		if err := replaceMessageMentions(ctx, qtx, message.ChannelID, message.TS, mentions); err != nil {
+		if err := replaceMessageMentions(ctx, qtx, message, mentions); err != nil {
 			return false, err
 		}
 	default:
@@ -1076,19 +1117,29 @@ func (s *Store) markMessageDeleted(ctx context.Context, message Message, mention
 		if err != nil {
 			return false, err
 		}
-		filesForSearch, err := existingFilesForSearch(ctx, dbtx, message.ChannelID, message.TS)
-		if err != nil {
-			return false, err
-		}
 		searchMessage := message
 		searchMessage.NormalizedText = normalizedText
-		searchMessage.Files = filesForSearch
+		searchMessage.Files = nil
 		if err := qtx.DeleteMessageFTS(ctx, key); err != nil {
 			return false, err
 		}
 		if err := qtx.InsertMessageFTS(ctx, storedb.InsertMessageFTSParams{MessageKey: key, Content: messageSearchContent(searchMessage)}); err != nil {
 			return false, err
 		}
+	}
+	if _, err := dbtx.ExecContext(ctx, `
+update message_files
+set deleted_at = ?, deletion_source = ?, deletion_reason = 'parent_message_deleted', updated_at = ?
+where channel_id = ? and ts = ?
+`, updatedAt, message.SourceName, updatedAt, message.ChannelID, message.TS); err != nil {
+		return false, err
+	}
+	if _, err := dbtx.ExecContext(ctx, `
+update message_mentions
+set deleted_at = ?, deletion_source = ?, deletion_reason = 'parent_message_deleted', updated_at = ?
+where channel_id = ? and ts = ?
+`, updatedAt, message.SourceName, updatedAt, message.ChannelID, message.TS); err != nil {
+		return false, err
 	}
 	if err := appendMessageEvent(ctx, qtx, message, updatedAt); err != nil {
 		return false, err
@@ -1097,6 +1148,51 @@ func (s *Store) markMessageDeleted(ctx context.Context, message Message, mention
 		return false, err
 	}
 	return true, nil
+}
+
+func messageDeleteWins(ctx context.Context, dbtx storedb.DBTX, message Message) (bool, error) {
+	var workspaceID, updatedAt string
+	var sourceRank int64
+	var deletedTS sql.NullString
+	err := dbtx.QueryRowContext(ctx, `
+select workspace_id, updated_at, source_rank, deleted_ts
+from messages
+where channel_id = ? and ts = ?
+`, message.ChannelID, message.TS).Scan(&workspaceID, &updatedAt, &sourceRank, &deletedTS)
+	if errors.Is(err, sql.ErrNoRows) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if workspaceID != message.WorkspaceID {
+		return false, &WorkspaceCollisionError{Entity: "message", ID: messageKey(message.ChannelID, message.TS), ExistingWorkspaceID: workspaceID, WorkspaceID: message.WorkspaceID}
+	}
+	incomingUpdatedAt := formatDBTime(message.UpdatedAt)
+	comparison := compareDBTimes(incomingUpdatedAt, updatedAt)
+	if comparison != 0 {
+		return comparison > 0, nil
+	}
+	if strings.TrimSpace(deletedTS.String) != "" {
+		return true, nil
+	}
+	return int64(message.SourceRank) <= sourceRank, nil
+}
+
+func compareDBTimes(left, right string) int {
+	leftTime, leftErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(left))
+	rightTime, rightErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(right))
+	if leftErr == nil && rightErr == nil {
+		switch {
+		case leftTime.Before(rightTime):
+			return -1
+		case leftTime.After(rightTime):
+			return 1
+		default:
+			return 0
+		}
+	}
+	return strings.Compare(strings.TrimSpace(left), strings.TrimSpace(right))
 }
 
 func (s *Store) beginMessageTransaction(ctx context.Context, immediate bool) (storedb.DBTX, func() error, func(), error) {
@@ -1161,8 +1257,14 @@ func rejectWorkspaceCollision(ctx context.Context, workspaceID, entity, id strin
 	return nil
 }
 
-func replaceMessageMentions(ctx context.Context, qtx *storedb.Queries, channelID, ts string, mentions []Mention) error {
-	if err := qtx.DeleteMessageMentions(ctx, storedb.DeleteMessageMentionsParams{ChannelID: channelID, Ts: ts}); err != nil {
+func replaceMessageMentions(ctx context.Context, qtx *storedb.Queries, message Message, mentions []Mention) error {
+	if err := qtx.TombstoneMessageMentions(ctx, storedb.TombstoneMessageMentionsParams{
+		DeletedAt:      dbText(formatDBTime(message.UpdatedAt)),
+		DeletionSource: dbText(message.SourceName),
+		UpdatedAt:      formatDBTime(message.UpdatedAt),
+		ChannelID:      message.ChannelID,
+		Ts:             message.TS,
+	}); err != nil {
 		return err
 	}
 	seenMentions := map[string]struct{}{}
@@ -1173,12 +1275,48 @@ func replaceMessageMentions(ctx context.Context, qtx *storedb.Queries, channelID
 		}
 		seenMentions[key] = struct{}{}
 		if err := qtx.UpsertMessageMention(ctx, storedb.UpsertMessageMentionParams{
-			ChannelID:   channelID,
-			Ts:          ts,
+			ChannelID:   message.ChannelID,
+			Ts:          message.TS,
 			MentionType: mention.Type,
 			TargetID:    mention.TargetID,
 			DisplayText: dbText(mention.DisplayText),
+			UpdatedAt:   formatDBTime(message.UpdatedAt),
 		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func tombstoneMissingMessageFiles(ctx context.Context, dbtx storedb.DBTX, message Message, files []MessageFile) error {
+	active := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		active[file.FileID] = struct{}{}
+	}
+	rows, err := dbtx.QueryContext(ctx, `select file_id from message_files where channel_id = ? and ts = ?`, message.ChannelID, message.TS)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	var missing []string
+	for rows.Next() {
+		var fileID string
+		if err := rows.Scan(&fileID); err != nil {
+			return err
+		}
+		if _, ok := active[fileID]; !ok {
+			missing = append(missing, fileID)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, fileID := range missing {
+		if _, err := dbtx.ExecContext(ctx, `
+update message_files
+set deleted_at = ?, deletion_source = ?, deletion_reason = 'absent_from_authoritative_message_payload', updated_at = ?
+where channel_id = ? and ts = ? and file_id = ?
+`, formatDBTime(message.UpdatedAt), message.SourceName, formatDBTime(message.UpdatedAt), message.ChannelID, message.TS, fileID); err != nil {
 			return err
 		}
 	}
@@ -1209,7 +1347,7 @@ func existingFilesForSearch(ctx context.Context, q storedb.DBTX, channelID, ts s
 	rows, err := q.QueryContext(ctx, `
 select file_id, name, title, plain_text, preview_plain_text
 from message_files
-where channel_id = ? and ts = ?
+where channel_id = ? and ts = ? and deleted_at is null
 `, channelID, ts)
 	if err != nil {
 		return nil, err
@@ -1602,6 +1740,7 @@ select mm.channel_id, mm.ts, mm.target_id,
 from message_mentions mm
 left join users u on u.id = mm.target_id
 where mm.mention_type = 'user'
+  and mm.deleted_at is null
   and (mm.channel_id || '|' || mm.ts) in (` + placeholders + `)
 `
 		args := make([]any, 0, end-start)
@@ -1935,7 +2074,7 @@ select workspace_id, channel_id, ts, file_id, coalesce(user_id, ''), name, title
        coalesce(media_path, ''), coalesce(content_sha256, ''), content_size,
        coalesce(fetched_at, ''), fetch_status, fetch_error, updated_at
 from message_files
-where ` + strings.Join(clauses, " and ") + `
+where deleted_at is null and ` + strings.Join(clauses, " and ") + `
 order by ts desc, file_id asc
 `
 	if opts.Limit > 0 {
@@ -2103,6 +2242,12 @@ select exists (
 	return exists, err
 }
 
+// MessageAllowedByRetention reports whether a merge may restore a snapshot row
+// without crossing an explicit local purge floor.
+func MessageAllowedByRetention(ctx context.Context, tx *sql.Tx, message Message) (bool, error) {
+	return messageAllowedByRetention(ctx, tx, message)
+}
+
 func retentionTimestampAtLeast(value, floor string) bool {
 	valueNumber, valueOK := parseRetentionTimestamp(value)
 	floorNumber, floorOK := parseRetentionTimestamp(floor)
@@ -2221,7 +2366,7 @@ select m.channel_id || '|' || m.ts,
        trim(m.normalized_text || ' ' || coalesce((
          select group_concat(trim(f.name || ' ' || f.title || ' ' || f.plain_text || ' ' || f.preview_plain_text), ' ')
          from message_files f
-         where f.channel_id = m.channel_id and f.ts = m.ts
+         where f.channel_id = m.channel_id and f.ts = m.ts and f.deleted_at is null
        ), ''))
 from messages m
 `); err != nil {
@@ -2275,7 +2420,7 @@ func dbText(value string) sql.NullString {
 }
 
 func formatDBTime(value time.Time) string {
-	return value.Format(time.RFC3339)
+	return value.UTC().Format(time.RFC3339Nano)
 }
 
 func parseDBTime(value string) time.Time {
@@ -2433,6 +2578,12 @@ func migrateSchema(db *sql.DB, currentVersion int) error {
 		}
 		currentVersion = 5
 	}
+	if currentVersion < 6 {
+		if err := migrateTombstonesV6(tx); err != nil {
+			return fmt.Errorf("migrate sqlite schema to v6: %w", err)
+		}
+		currentVersion = 6
+	}
 	if currentVersion != schemaVersion {
 		return fmt.Errorf("no migration path from sqlite schema version %d to %d", currentVersion, schemaVersion)
 	}
@@ -2448,6 +2599,174 @@ func migrateSchema(db *sql.DB, currentVersion int) error {
 	return nil
 }
 
+func migrateTombstonesV6(tx *sql.Tx) error {
+	for _, column := range []struct {
+		table string
+		name  string
+	}{
+		{"message_files", "deleted_at"},
+		{"message_files", "deletion_source"},
+		{"message_files", "deletion_reason"},
+		{"message_mentions", "deleted_at"},
+		{"message_mentions", "deletion_source"},
+		{"message_mentions", "deletion_reason"},
+		{"message_mentions", "updated_at"},
+	} {
+		exists, err := schemaColumnExists(tx, column.table, column.name)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		definition := " text"
+		if column.name == "updated_at" {
+			definition = " text not null default ''"
+		}
+		if _, err := tx.Exec("alter table " + column.table + " add column " + column.name + definition); err != nil { //nolint:gosec // Fixed migration identifiers.
+			return err
+		}
+	}
+	eventKeyExists, err := schemaColumnExists(tx, "message_events", "event_key")
+	if err != nil {
+		return err
+	}
+	if !eventKeyExists {
+		if _, err := tx.Exec(`alter table message_events add column event_key text`); err != nil {
+			return err
+		}
+	}
+	type legacyEvent struct {
+		id                                                       int64
+		channelID, ts, eventType, sourceName, payload, createdAt string
+	}
+	const eventMigrationBatchSize = 500
+	lastID := int64(-1)
+	for {
+		eventRows, err := tx.Query(`
+select id, channel_id, ts, event_type, source_name, payload_json, created_at
+from message_events
+where (event_key is null or trim(event_key) = '') and id > ?
+order by id
+limit ?
+`, lastID, eventMigrationBatchSize)
+		if err != nil {
+			return err
+		}
+		legacyEvents := make([]legacyEvent, 0, eventMigrationBatchSize)
+		for eventRows.Next() {
+			var event legacyEvent
+			if err := eventRows.Scan(&event.id, &event.channelID, &event.ts, &event.eventType, &event.sourceName, &event.payload, &event.createdAt); err != nil {
+				_ = eventRows.Close()
+				return err
+			}
+			legacyEvents = append(legacyEvents, event)
+		}
+		if err := eventRows.Close(); err != nil {
+			return err
+		}
+		if err := eventRows.Err(); err != nil {
+			return err
+		}
+		if len(legacyEvents) == 0 {
+			break
+		}
+		for _, event := range legacyEvents {
+			parts := []string{strconv.FormatInt(event.id, 10), event.channelID, event.ts, event.eventType, event.sourceName, event.payload, event.createdAt}
+			sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+			key := "legacy-" + hex.EncodeToString(sum[:])
+			if _, err := tx.Exec(`update message_events set event_key = ? where id = ?`, key, event.id); err != nil {
+				return err
+			}
+		}
+		lastID = legacyEvents[len(legacyEvents)-1].id
+	}
+	if _, err := tx.Exec(`
+update message_mentions
+set updated_at = coalesce((
+  select m.updated_at from messages m
+  where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+), '')
+where updated_at = '';
+
+update message_files
+set deleted_at = coalesce(nullif(deleted_at, ''), (
+      select m.updated_at from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    )),
+    deletion_source = coalesce(nullif(deletion_source, ''), (
+      select m.source_name from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    )),
+    deletion_reason = 'parent_message_deleted',
+    updated_at = coalesce((
+      select m.updated_at from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    ), updated_at)
+where exists (
+  select 1 from messages m
+  where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    and trim(coalesce(m.deleted_ts, '')) <> ''
+);
+
+update message_mentions
+set deleted_at = coalesce(nullif(deleted_at, ''), (
+      select m.updated_at from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    )),
+    deletion_source = coalesce(nullif(deletion_source, ''), (
+      select m.source_name from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    )),
+    deletion_reason = 'parent_message_deleted',
+    updated_at = coalesce((
+      select m.updated_at from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    ), updated_at)
+where exists (
+  select 1 from messages m
+  where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    and trim(coalesce(m.deleted_ts, '')) <> ''
+);
+
+delete from message_fts;
+insert into message_fts (message_key, content)
+select m.channel_id || '|' || m.ts,
+       trim(m.normalized_text || ' ' || coalesce((
+         select group_concat(trim(f.name || ' ' || f.title || ' ' || f.plain_text || ' ' || f.preview_plain_text), ' ')
+         from message_files f
+         where f.channel_id = m.channel_id and f.ts = m.ts and f.deleted_at is null
+       ), ''))
+from messages m;
+`); err != nil {
+		return err
+	}
+	_, err = tx.Exec(schemaV6Migration)
+	return err
+}
+
+func schemaColumnExists(q schemaQueryer, table, column string) (bool, error) {
+	rows, err := q.QueryContext(context.Background(), fmt.Sprintf("pragma table_info(%s)", table))
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
 type schemaQueryer interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 }
@@ -2458,11 +2777,11 @@ func validateCurrentSchema(q schemaQueryer) error {
 		"channels":            {"id", "workspace_id", "name", "kind", "topic", "purpose", "is_private", "is_archived", "is_shared", "is_general", "raw_json", "updated_at"},
 		"users":               {"id", "workspace_id", "name", "real_name", "display_name", "title", "is_bot", "is_deleted", "raw_json", "updated_at"},
 		"messages":            {"channel_id", "ts", "workspace_id", "user_id", "subtype", "client_msg_id", "thread_ts", "parent_user_id", "text", "normalized_text", "reply_count", "latest_reply", "edited_ts", "deleted_ts", "source_rank", "source_name", "raw_json", "updated_at"},
-		"message_files":       {"workspace_id", "channel_id", "ts", "file_id", "user_id", "name", "title", "mimetype", "filetype", "pretty_type", "mode", "size", "url_private", "url_private_download", "permalink", "is_public", "plain_text", "preview_plain_text", "media_path", "content_sha256", "content_size", "fetched_at", "fetch_status", "fetch_error", "raw_json", "updated_at"},
-		"message_events":      {"id", "channel_id", "ts", "event_type", "source_name", "payload_json", "created_at"},
+		"message_files":       {"workspace_id", "channel_id", "ts", "file_id", "user_id", "name", "title", "mimetype", "filetype", "pretty_type", "mode", "size", "url_private", "url_private_download", "permalink", "is_public", "plain_text", "preview_plain_text", "media_path", "content_sha256", "content_size", "fetched_at", "fetch_status", "fetch_error", "raw_json", "updated_at", "deleted_at", "deletion_source", "deletion_reason"},
+		"message_events":      {"id", "event_key", "channel_id", "ts", "event_type", "source_name", "payload_json", "created_at"},
 		"message_event_heads": {"channel_id", "ts", "event_type", "source_name", "payload_json"},
 		"sync_state":          {"source_name", "entity_type", "entity_id", "value", "updated_at"},
-		"message_mentions":    {"channel_id", "ts", "mention_type", "target_id", "display_text"},
+		"message_mentions":    {"channel_id", "ts", "mention_type", "target_id", "display_text", "deleted_at", "deletion_source", "deletion_reason", "updated_at"},
 		"embedding_jobs":      {"id", "channel_id", "ts", "state", "created_at"},
 		"message_fts":         {"message_key", "content"},
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2350,31 +2350,6 @@ func (s *Store) ListSyncState(ctx context.Context, source, entityType string, li
 	return out, nil
 }
 
-func (s *Store) RebuildSearchIndexes(ctx context.Context) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if _, err := tx.ExecContext(ctx, `delete from message_fts`); err != nil {
-		return err
-	}
-	if _, err := tx.ExecContext(ctx, `
-insert into message_fts (message_key, content)
-select m.channel_id || '|' || m.ts,
-       trim(m.normalized_text || ' ' || coalesce((
-         select group_concat(trim(f.name || ' ' || f.title || ' ' || f.plain_text || ' ' || f.preview_plain_text), ' ')
-         from message_files f
-         where f.channel_id = m.channel_id and f.ts = m.ts and f.deleted_at is null
-       ), ''))
-from messages m
-`); err != nil {
-		return err
-	}
-	return tx.Commit()
-}
-
 func MarshalRaw(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -168,6 +168,101 @@ func TestUpsertMessageDeduplicatesMentions(t *testing.T) {
 	require.Equal(t, int64(1), rows[0]["n"])
 }
 
+func TestMessageSubordinatesUseTombstonesAndCanBeResurrected(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	message := Message{
+		ChannelID: "C1", TS: "123.45", WorkspaceID: "T1", UserID: "U1",
+		Text: "hello", NormalizedText: "hello", SourceRank: 2, SourceName: "api-bot",
+		RawJSON: `{}`, UpdatedAt: now,
+		Files: []MessageFile{{FileID: "F1", Name: "one.txt", RawJSON: `{}`}, {
+			FileID: "F2", Name: "two.txt", MediaPath: "files/aa/two.txt", ContentSHA256: "hash-two",
+			ContentSize: 42, FetchStatus: "fetched", RawJSON: `{}`,
+		}},
+	}
+	mentions := []Mention{{Type: "user", TargetID: "U1"}, {Type: "user", TargetID: "U2"}}
+	require.NoError(t, s.UpsertMessage(ctx, message, mentions))
+
+	message.UpdatedAt = now.Add(time.Second)
+	message.Files = message.Files[:1]
+	require.NoError(t, s.UpsertMessage(ctx, message, mentions[:1]))
+	rows, err := s.QueryReadOnly(ctx, `select file_id, coalesce(deletion_source, '') as source, coalesce(deletion_reason, '') as reason, updated_at from message_files where deleted_at is not null`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"file_id": "F2", "source": "api-bot", "reason": "absent_from_authoritative_message_payload", "updated_at": formatDBTime(now.Add(time.Second))}}, rows)
+	rows, err = s.QueryReadOnly(ctx, `select target_id, coalesce(deletion_source, '') as source, coalesce(deletion_reason, '') as reason, updated_at from message_mentions where deleted_at is not null`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"target_id": "U2", "source": "api-bot", "reason": "absent_from_authoritative_message_payload", "updated_at": formatDBTime(now.Add(time.Second))}}, rows)
+	files, err := s.Files(ctx, FileListOptions{})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	message.UpdatedAt = now.Add(2 * time.Second)
+	message.Files = append(message.Files, MessageFile{FileID: "F2", Name: "two.txt", RawJSON: `{}`})
+	require.NoError(t, s.UpsertMessage(ctx, message, mentions))
+	rows, err = s.QueryReadOnly(ctx, `select count(*) as count from message_files where deleted_at is not null`)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rows[0]["count"])
+	rows, err = s.QueryReadOnly(ctx, `select media_path, content_sha256, content_size, fetch_status from message_files where file_id = 'F2'`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"media_path": "files/aa/two.txt", "content_sha256": "hash-two", "content_size": int64(42), "fetch_status": "fetched"}}, rows)
+	rows, err = s.QueryReadOnly(ctx, `select count(*) as count from message_mentions where deleted_at is not null`)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rows[0]["count"])
+
+	message.UpdatedAt = now.Add(3 * time.Second)
+	message.DeletedTS = "124.00"
+	require.NoError(t, s.MarkMessageDeleted(ctx, message, mentions))
+	rows, err = s.QueryReadOnly(ctx, `select count(*) as count from message_files where deletion_reason = 'parent_message_deleted'`)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), rows[0]["count"])
+	rows, err = s.QueryReadOnly(ctx, `select count(*) as count from message_mentions where deletion_reason = 'parent_message_deleted'`)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), rows[0]["count"])
+}
+
+func TestRejectedMessageDeletePreservesActiveSubordinates(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	active := Message{
+		ChannelID: "C1", TS: "123.45", WorkspaceID: "T1", UserID: "U1",
+		Text: "active", NormalizedText: "active", SourceRank: 1, SourceName: "api-user",
+		RawJSON: `{"active":true}`, UpdatedAt: now.Add(2 * time.Second),
+		Files: []MessageFile{{FileID: "F1", Name: "active-file.txt", RawJSON: `{}`}},
+	}
+	require.NoError(t, s.UpsertMessage(ctx, active, []Mention{{Type: "user", TargetID: "U1"}}))
+	staleDelete := active
+	staleDelete.DeletedTS = "124.00"
+	staleDelete.SourceRank = 2
+	staleDelete.SourceName = "api-bot"
+	staleDelete.UpdatedAt = now.Add(time.Second)
+	applied, err := s.MarkMessageDeletedWithRetention(ctx, staleDelete, nil)
+	require.NoError(t, err)
+	require.False(t, applied)
+	staleDelete.UpdatedAt = active.UpdatedAt
+	staleDelete.SourceRank = 4
+	applied, err = s.MarkMessageDeletedWithRetention(ctx, staleDelete, nil)
+	require.NoError(t, err)
+	require.False(t, applied)
+	rows, err := s.QueryReadOnly(ctx, `
+select coalesce(deleted_ts, '') as deleted_ts,
+       (select count(*) from message_files where file_id = 'F1' and deleted_at is null) as files,
+       (select count(*) from message_mentions where target_id = 'U1' and deleted_at is null) as mentions
+from messages where channel_id = 'C1' and ts = '123.45'
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"deleted_ts": "", "files": int64(1), "mentions": int64(1)}}, rows)
+	rows, err = s.QueryReadOnly(ctx, `select count(*) as count from message_fts where message_key = 'C1|123.45' and instr(content, 'active-file.txt') > 0`)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows[0]["count"])
+}
+
 func TestUpsertMessageSuppressesConsecutiveDuplicateEventsAndPreservesReversions(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	s, err := Open(dbPath)
@@ -797,6 +892,147 @@ from sqlite_master
 where type = 'trigger' and name = 'seed_message_event_head_before_update'
 `).Scan(&triggerCount))
 	require.Equal(t, 1, triggerCount)
+}
+
+func TestOpenMigratesVersion5SubordinatesToTombstones(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	message := Message{
+		ChannelID: "C1", TS: "123.45", WorkspaceID: "T1", Text: "deleted",
+		NormalizedText: "deleted", DeletedTS: "124.00", SourceRank: 2,
+		SourceName: "api-bot", RawJSON: `{}`, UpdatedAt: now,
+		Files: []MessageFile{{FileID: "F1", Name: "legacy-secret.txt", RawJSON: `{}`}},
+	}
+	require.NoError(t, s.UpsertMessage(ctx, message, []Mention{{Type: "user", TargetID: "U1"}}))
+	require.NoError(t, s.Close())
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+alter table message_files rename to message_files_v6;
+drop index idx_message_files_workspace_ts;
+drop index idx_message_files_file_id;
+drop index idx_message_files_name;
+create table message_files (
+  workspace_id text not null, channel_id text not null, ts text not null, file_id text not null,
+  user_id text, name text not null default '', title text not null default '', mimetype text,
+  filetype text, pretty_type text, mode text, size integer not null default 0, url_private text,
+  url_private_download text, permalink text, is_public integer not null default 0,
+  plain_text text not null default '', preview_plain_text text not null default '', media_path text,
+  content_sha256 text, content_size integer not null default 0, fetched_at text,
+  fetch_status text not null default '', fetch_error text not null default '', raw_json text not null,
+  updated_at text not null, primary key (channel_id, ts, file_id)
+);
+insert into message_files
+select workspace_id, channel_id, ts, file_id, user_id, name, title, mimetype, filetype,
+       pretty_type, mode, size, url_private, url_private_download, permalink, is_public,
+       plain_text, preview_plain_text, media_path, content_sha256, content_size, fetched_at,
+       fetch_status, fetch_error, raw_json, updated_at
+from message_files_v6;
+drop table message_files_v6;
+create index idx_message_files_workspace_ts on message_files(workspace_id, ts desc);
+create index idx_message_files_file_id on message_files(file_id);
+create index idx_message_files_name on message_files(name);
+alter table message_mentions rename to message_mentions_v6;
+drop index idx_message_mentions_target_ts;
+create table message_mentions (
+  channel_id text not null, ts text not null, mention_type text not null, target_id text not null,
+  display_text text, primary key (channel_id, ts, mention_type, target_id)
+);
+insert into message_mentions select channel_id, ts, mention_type, target_id, display_text from message_mentions_v6;
+drop table message_mentions_v6;
+create index idx_message_mentions_target_ts on message_mentions(target_id, ts desc);
+delete from message_fts;
+insert into message_fts (message_key, content) values ('C1|123.45', 'deleted legacy-secret.txt');
+pragma user_version = 5;
+`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	s, err = Open(dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+	rows, err := s.QueryReadOnly(ctx, `
+select (select count(*) from message_files where deletion_reason = 'parent_message_deleted') as files,
+       (select count(*) from message_mentions where deletion_reason = 'parent_message_deleted' and updated_at <> '') as mentions
+`)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"files": int64(1), "mentions": int64(1)}}, rows)
+	matches, err := s.Search(ctx, "", "legacy", 10)
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestOpenMigratesVersion5WithoutCollapsingSameSecondEventReversions(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+drop index idx_message_events_identity;
+drop table message_events;
+create table message_events (
+  id integer primary key autoincrement,
+  channel_id text not null,
+  ts text not null,
+  event_type text not null,
+  source_name text not null,
+  payload_json text not null,
+  created_at text not null
+);
+insert into message_events (channel_id, ts, event_type, source_name, payload_json, created_at) values
+  ('C1', '123.45', 'message', 'api-bot', '{"state":"A"}', '2026-07-17T12:00:00Z'),
+  ('C1', '123.45', 'message', 'api-bot', '{"state":"B"}', '2026-07-17T12:00:00Z'),
+  ('C1', '123.45', 'message', 'api-bot', '{"state":"A"}', '2026-07-17T12:00:00Z'),
+  ('C1', '123.45', 'message', 'api-bot', '{"state":"B"}', '2026-07-17T12:00:00Z');
+with recursive counter(n) as (
+  values(1)
+  union all
+  select n + 1 from counter where n < 501
+)
+insert into message_events (channel_id, ts, event_type, source_name, payload_json, created_at)
+select 'C-batch', printf('%d.00', n), 'message', 'api-bot', printf('{"n":%d}', n), '2026-07-17T12:00:00Z'
+from counter;
+pragma user_version = 5;
+`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	s, err = Open(dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+	rows, err := s.QueryReadOnly(context.Background(), `select payload_json, event_key from message_events where channel_id = 'C1' order by id`)
+	require.NoError(t, err)
+	require.Len(t, rows, 4)
+	require.Equal(t, `{"state":"A"}`, rows[0]["payload_json"])
+	require.Equal(t, `{"state":"B"}`, rows[1]["payload_json"])
+	require.Equal(t, `{"state":"A"}`, rows[2]["payload_json"])
+	require.Equal(t, `{"state":"B"}`, rows[3]["payload_json"])
+	require.NotEqual(t, rows[0]["event_key"], rows[2]["event_key"])
+	require.NotEqual(t, rows[1]["event_key"], rows[3]["event_key"])
+	var migratedEvents int
+	require.NoError(t, s.DB().QueryRow(`select count(*) from message_events where event_key is not null and trim(event_key) <> ''`).Scan(&migratedEvents))
+	require.Equal(t, 505, migratedEvents)
+	require.NoError(t, s.UpsertMessage(context.Background(), Message{
+		ChannelID: "C1", TS: "900.00", WorkspaceID: "T1", Text: "post-upgrade",
+		NormalizedText: "post-upgrade", SourceRank: 2, SourceName: "api-bot",
+		RawJSON: `{}`, UpdatedAt: time.Now().UTC(),
+	}, nil))
+	rows, err = s.QueryReadOnly(context.Background(), `select event_key from message_events where ts = '900.00'`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.NotEmpty(t, rows[0]["event_key"])
+	var notNull int
+	var defaultValue string
+	require.NoError(t, s.DB().QueryRow(`select "notnull", coalesce(dflt_value, '') from pragma_table_info('message_events') where name = 'event_key'`).Scan(&notNull, &defaultValue))
+	require.Equal(t, 1, notNull)
+	require.Contains(t, defaultValue, "randomblob")
 }
 
 func TestOpenDoesNotStampInvalidOldSchema(t *testing.T) {

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -54,6 +54,7 @@ type Message struct {
 
 type MessageEvent struct {
 	ID          int64  `json:"id"`
+	EventKey    string `json:"event_key"`
 	ChannelID   string `json:"channel_id"`
 	Ts          string `json:"ts"`
 	EventType   string `json:"event_type"`
@@ -97,6 +98,9 @@ type MessageFile struct {
 	FetchError         string         `json:"fetch_error"`
 	RawJson            string         `json:"raw_json"`
 	UpdatedAt          string         `json:"updated_at"`
+	DeletedAt          sql.NullString `json:"deleted_at"`
+	DeletionSource     sql.NullString `json:"deletion_source"`
+	DeletionReason     sql.NullString `json:"deletion_reason"`
 }
 
 type MessageFt struct {
@@ -105,11 +109,15 @@ type MessageFt struct {
 }
 
 type MessageMention struct {
-	ChannelID   string         `json:"channel_id"`
-	Ts          string         `json:"ts"`
-	MentionType string         `json:"mention_type"`
-	TargetID    string         `json:"target_id"`
-	DisplayText sql.NullString `json:"display_text"`
+	ChannelID      string         `json:"channel_id"`
+	Ts             string         `json:"ts"`
+	MentionType    string         `json:"mention_type"`
+	TargetID       string         `json:"target_id"`
+	DisplayText    sql.NullString `json:"display_text"`
+	DeletedAt      sql.NullString `json:"deleted_at"`
+	DeletionSource sql.NullString `json:"deletion_source"`
+	DeletionReason sql.NullString `json:"deletion_reason"`
+	UpdatedAt      string         `json:"updated_at"`
 }
 
 type SyncState struct {

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -158,20 +158,6 @@ func (q *Queries) DeleteMessageFiles(ctx context.Context, arg DeleteMessageFiles
 	return err
 }
 
-const deleteMessageMentions = `-- name: DeleteMessageMentions :exec
-delete from message_mentions where channel_id = ? and ts = ?
-`
-
-type DeleteMessageMentionsParams struct {
-	ChannelID string `json:"channel_id"`
-	Ts        string `json:"ts"`
-}
-
-func (q *Queries) DeleteMessageMentions(ctx context.Context, arg DeleteMessageMentionsParams) error {
-	_, err := q.db.ExecContext(ctx, deleteMessageMentions, arg.ChannelID, arg.Ts)
-	return err
-}
-
 const deleteSyncState = `-- name: DeleteSyncState :exec
 delete from sync_state
 where source_name = ? and entity_type = ? and entity_id = ?
@@ -389,6 +375,9 @@ on conflict(channel_id, ts, file_id) do update set
   fetched_at=excluded.fetched_at,
   fetch_status=excluded.fetch_status,
   fetch_error=excluded.fetch_error,
+  deleted_at=null,
+  deletion_source=null,
+  deletion_reason=null,
   raw_json=excluded.raw_json,
   updated_at=excluded.updated_at
 `
@@ -585,6 +574,7 @@ select m.workspace_id, mm.channel_id, mm.ts, mm.mention_type, mm.target_id, coal
 from message_mentions mm
 join messages m on m.channel_id = mm.channel_id and m.ts = mm.ts
 where (?1 = '' or m.workspace_id = ?1)
+  and mm.deleted_at is null
   and (?2 = '' or mm.target_id = ?2 or mm.display_text like ?3)
 order by mm.ts desc
 limit ?4
@@ -1315,6 +1305,31 @@ func (q *Queries) ThreadCoverageState(ctx context.Context) (string, error) {
 	return value, err
 }
 
+const tombstoneMessageMentions = `-- name: TombstoneMessageMentions :exec
+update message_mentions
+set deleted_at = ?, deletion_source = ?, deletion_reason = 'absent_from_authoritative_message_payload', updated_at = ?
+where channel_id = ? and ts = ?
+`
+
+type TombstoneMessageMentionsParams struct {
+	DeletedAt      sql.NullString `json:"deleted_at"`
+	DeletionSource sql.NullString `json:"deletion_source"`
+	UpdatedAt      string         `json:"updated_at"`
+	ChannelID      string         `json:"channel_id"`
+	Ts             string         `json:"ts"`
+}
+
+func (q *Queries) TombstoneMessageMentions(ctx context.Context, arg TombstoneMessageMentionsParams) error {
+	_, err := q.db.ExecContext(ctx, tombstoneMessageMentions,
+		arg.DeletedAt,
+		arg.DeletionSource,
+		arg.UpdatedAt,
+		arg.ChannelID,
+		arg.Ts,
+	)
+	return err
+}
+
 const updateFileFetchStatus = `-- name: UpdateFileFetchStatus :exec
 update message_files
 set fetched_at = ?,
@@ -1626,10 +1641,14 @@ func (q *Queries) UpsertMessageEventHead(ctx context.Context, arg UpsertMessageE
 }
 
 const upsertMessageMention = `-- name: UpsertMessageMention :exec
-insert into message_mentions (channel_id, ts, mention_type, target_id, display_text)
-values (?, ?, ?, ?, ?)
+insert into message_mentions (channel_id, ts, mention_type, target_id, display_text, updated_at)
+values (?, ?, ?, ?, ?, ?)
 on conflict(channel_id, ts, mention_type, target_id) do update set
-  display_text=excluded.display_text
+  display_text=excluded.display_text,
+  deleted_at=null,
+  deletion_source=null,
+  deletion_reason=null,
+  updated_at=excluded.updated_at
 `
 
 type UpsertMessageMentionParams struct {
@@ -1638,6 +1657,7 @@ type UpsertMessageMentionParams struct {
 	MentionType string         `json:"mention_type"`
 	TargetID    string         `json:"target_id"`
 	DisplayText sql.NullString `json:"display_text"`
+	UpdatedAt   string         `json:"updated_at"`
 }
 
 func (q *Queries) UpsertMessageMention(ctx context.Context, arg UpsertMessageMentionParams) error {
@@ -1647,6 +1667,7 @@ func (q *Queries) UpsertMessageMention(ctx context.Context, arg UpsertMessageMen
 		arg.MentionType,
 		arg.TargetID,
 		arg.DisplayText,
+		arg.UpdatedAt,
 	)
 	return err
 }


### PR DESCRIPTION
## Summary

- make routine Git-share updates merge-only, preserving destination-only rows and newer message, user, and channel tombstones
- add source-attributed tombstones for message files and mentions, with stable message-event identity and append-only event-history merging
- rebuild derived FTS/event-head state from canonical merged rows while protecting retention floors
- add explicit `update --restore` replacement mode; reject `--ref` without restore because historical snapshots replace local rows

## Retention contract

- canonical row identities remain stable
- absence from an incomplete sync or share snapshot does not imply deletion
- authoritative child absence and explicit source deletes create tombstones with source/reason metadata
- exact replacement requires explicit restore mode
- derived indexes are rebuildable; canonical rows are not silently removed

`VISION.md` does not exist in this repository, so no VISION update was possible.

## Proof

- `make test`
- `make build`
- `git diff --check`
- AutoReview: clean, no accepted/actionable findings

Real `bin/slacrawl` fixture proof:

| State | Destination-only message | Message/user/channel tombstones | File/mention tombstones | Event history |
| --- | ---: | ---: | ---: | ---: |
| Before update | 1 | 1 / 1 / 1 | 1 / 1 | 2 |
| Default `update` | 1 | 1 / 1 / 1 | 1 / 1 | 3 |
| Explicit `update --restore` | 0 | 0 / 0 / 0 | 0 / 0 | 1 |

The default update retained the destination-only row in both SQL and search results. Restore replaced the snapshot tables and search result. `update --ref` without `--restore` failed with exit 1 and explained that historical snapshots replace local rows.
