### PR TITLE
fix(ci): restore Cloudsmith package namespace

### DIFF
--- a/.github/workflows/publish-apt.yml
+++ b/.github/workflows/publish-apt.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Publish to Cloudsmith APT repository
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
-          CLOUDSMITH_REPO: openclaw/slacrawl
+          CLOUDSMITH_REPO: vincentkoc/slacrawl
           CLOUDSMITH_APT_TARGETS: ${{ vars.CLOUDSMITH_APT_TARGETS }}
           CLOUDSMITH_DISTRIBUTION: ${{ vars.CLOUDSMITH_DISTRIBUTION }}
           CLOUDSMITH_RELEASE: ${{ vars.CLOUDSMITH_RELEASE }}

--- a/.github/workflows/publish-rpm.yml
+++ b/.github/workflows/publish-rpm.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Publish to Cloudsmith RPM repository
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
-          CLOUDSMITH_REPO: openclaw/slacrawl
+          CLOUDSMITH_REPO: vincentkoc/slacrawl
           CLOUDSMITH_RPM_DISTRIBUTION: ${{ vars.CLOUDSMITH_RPM_DISTRIBUTION }}
           CLOUDSMITH_RPM_RELEASE: ${{ vars.CLOUDSMITH_RPM_RELEASE }}
         run: |


### PR DESCRIPTION
## Summary

- restore the established `vincentkoc/slacrawl` Cloudsmith namespace in both package publishers
- keep the new unified-release inventory and checksum verification unchanged

## Proof

- `actionlint .github/workflows/publish-apt.yml .github/workflows/publish-rpm.yml`
- AutoReview clean
- prior successful package runs used this exact Cloudsmith namespace
