### PR TITLE
fix: wiretap sync imports no messages from recent Slack Desktop caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+
+- Restored wiretap imports from Slack Desktop caches written with V8 wire format 16 (Snappy + Blink v21 envelope), kept older formats working, and made complete IndexedDB decode failures visible instead of reporting an empty successful sync.
 ## 0.7.9 - 2026-07-20
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Restored wiretap imports from Slack Desktop caches written with V8 wire format 16 (Snappy + Blink v21 envelope), kept older formats working, and made complete IndexedDB decode failures visible instead of reporting an empty successful sync.
+
 ## 0.7.9 - 2026-07-20
 
 ### Highlights

--- a/docs/desktop-mode.md
+++ b/docs/desktop-mode.md
@@ -106,7 +106,7 @@ slacrawl sql "select entity_id, value from sync_state where source_name = 'deskt
 
 - Rich IndexedDB redux blob decoding uses `node` when available.
 - If `node` is unavailable, desktop sync still runs, but decoded cached channel/user/message coverage will be reduced.
-- IndexedDB redux blobs are decoded per blob across known framings: bare V8 wire format 15/16, Slack Snappy wrapping, historical split Blink/V8 headers, and the current Snappy + Blink v21 envelope. V8 v16 payloads are decoded through an explicit v16-to-v15 compatibility adaptation; unknown future versions are reported as unsupported, never relabeled.
-- `doctor` reports IndexedDB blob totals, recognized candidates, decoded counts, detected V8 versions, and decode failures grouped by stage. Desktop sync fails instead of reporting success when every recognized candidate fails to decode.
+- IndexedDB redux blobs are decoded per blob across known framings: bare V8 wire format 15/16, Slack Snappy wrapping, historical split Blink/V8 headers, and the current Snappy + Blink v21 envelope. V8 v16 payloads use an explicit v16-to-v15 compatibility adaptation; unknown future versions are reported as unsupported and never relabeled.
+- `doctor` reports IndexedDB blob totals, recognized candidates, decoded counts, detected V8 versions, and decode failures grouped by stage. Desktop sync fails rather than reporting success when every recognized candidate fails to decode.
 - Desktop data is merged at lower precedence than API data.
 - Re-running desktop sync is safe; canonical rows are upserted by Slack-native keys.

--- a/docs/desktop-mode.md
+++ b/docs/desktop-mode.md
@@ -106,5 +106,7 @@ slacrawl sql "select entity_id, value from sync_state where source_name = 'deskt
 
 - Rich IndexedDB redux blob decoding uses `node` when available.
 - If `node` is unavailable, desktop sync still runs, but decoded cached channel/user/message coverage will be reduced.
+- IndexedDB redux blobs are decoded per blob across known framings: bare V8 wire format 15/16, Slack Snappy wrapping, historical split Blink/V8 headers, and the current Snappy + Blink v21 envelope. V8 v16 payloads are decoded through an explicit v16-to-v15 compatibility adaptation; unknown future versions are reported as unsupported, never relabeled.
+- `doctor` reports IndexedDB blob totals, recognized candidates, decoded counts, detected V8 versions, and decode failures grouped by stage. Desktop sync fails instead of reporting success when every recognized candidate fails to decode.
 - Desktop data is merged at lower precedence than API data.
 - Re-running desktop sync is safe; canonical rows are upserted by Slack-native keys.

--- a/internal/slackdesktop/desktop.go
+++ b/internal/slackdesktop/desktop.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -78,8 +79,30 @@ type LocalStorageSummary struct {
 }
 
 type IndexedDBSummary struct {
-	ObjectStores      []string `json:"object_stores"`
-	DecodedStateCount int      `json:"decoded_state_count"`
+	ObjectStores       []string       `json:"object_stores"`
+	NodeAvailable      bool           `json:"node_available"`
+	BlobFileCount      int            `json:"blob_file_count"`
+	CandidateCount     int            `json:"candidate_count"`
+	DecodedBlobCount   int            `json:"decoded_blob_count"`
+	DecodedStateCount  int            `json:"decoded_state_count"`
+	DecodeFailureCount int            `json:"decode_failure_count"`
+	DecodeFailures     map[string]int `json:"decode_failures,omitempty"`
+	V8Versions         map[string]int `json:"v8_versions,omitempty"`
+}
+
+func (summary *IndexedDBSummary) recordDecodeFailure(stage string) {
+	if summary.DecodeFailures == nil {
+		summary.DecodeFailures = map[string]int{}
+	}
+	summary.DecodeFailures[stage]++
+	summary.DecodeFailureCount++
+}
+
+func (summary *IndexedDBSummary) recordV8Version(version byte) {
+	if summary.V8Versions == nil {
+		summary.V8Versions = map[string]int{}
+	}
+	summary.V8Versions[strconv.Itoa(int(version))]++
 }
 
 type Snapshot struct {
@@ -253,7 +276,6 @@ func Inspect(path string) (Source, error) {
 	source.Summary = extracted.RootState.Summary
 	source.Local = localSummary(extracted)
 	source.IndexedDB = extracted.IndexedDB
-	source.IndexedDB.DecodedStateCount = len(extracted.ReduxStates)
 	return source, nil
 }
 
@@ -322,11 +344,18 @@ func Extract(path string) (ExtractedData, error) {
 	if err != nil && !os.IsNotExist(err) {
 		return ExtractedData{}, err
 	}
-	reduxStates, err := ExtractIndexedDBStates(path)
+	reduxStates, decodeSummary, err := extractIndexedDBStates(path)
 	if err != nil {
 		return ExtractedData{}, err
 	}
-	indexed.DecodedStateCount = len(reduxStates)
+	indexed.NodeAvailable = decodeSummary.NodeAvailable
+	indexed.BlobFileCount = decodeSummary.BlobFileCount
+	indexed.CandidateCount = decodeSummary.CandidateCount
+	indexed.DecodedBlobCount = decodeSummary.DecodedBlobCount
+	indexed.DecodedStateCount = decodeSummary.DecodedStateCount
+	indexed.DecodeFailureCount = decodeSummary.DecodeFailureCount
+	indexed.DecodeFailures = decodeSummary.DecodeFailures
+	indexed.V8Versions = decodeSummary.V8Versions
 
 	return ExtractedData{
 		RootState:   root,
@@ -360,6 +389,13 @@ func Ingest(ctx context.Context, st *store.Store, sourcePath string, opts Ingest
 	extracted, err := Extract(snapshot.Root)
 	if err != nil {
 		return Source{}, err
+	}
+	if extracted.IndexedDB.NodeAvailable && extracted.IndexedDB.CandidateCount > 0 && extracted.IndexedDB.DecodedBlobCount == 0 {
+		return Source{}, fmt.Errorf(
+			"desktop IndexedDB: failed to decode all %d candidate blob(s): %s",
+			extracted.IndexedDB.CandidateCount,
+			formatDecodeFailures(extracted.IndexedDB.DecodeFailures),
+		)
 	}
 	source.Summary = extracted.RootState.Summary
 	source.Local = localSummary(extracted)
@@ -1096,6 +1132,22 @@ func ScanIndexedDB(path string) (IndexedDBSummary, error) {
 	}
 	sort.Strings(names)
 	return IndexedDBSummary{ObjectStores: names}, nil
+}
+
+func formatDecodeFailures(failures map[string]int) string {
+	if len(failures) == 0 {
+		return "unknown failure"
+	}
+	stages := make([]string, 0, len(failures))
+	for stage := range failures {
+		stages = append(stages, stage)
+	}
+	sort.Strings(stages)
+	parts := make([]string, 0, len(stages))
+	for _, stage := range stages {
+		parts = append(parts, fmt.Sprintf("%s=%d", stage, failures[stage]))
+	}
+	return strings.Join(parts, ", ")
 }
 
 type indexedDBComparer struct{}

--- a/internal/slackdesktop/redux.go
+++ b/internal/slackdesktop/redux.go
@@ -33,10 +33,10 @@ const (
 	minWireVersionWindow = byte(13)
 	maxWireVersionWindow = byte(32)
 
-	blinkEnvelopeVersion21    = byte(21)
-	blinkEnvelopeTag          = byte(0xfe)
-	maxBlinkEnvelopePrefixLen = 64
-	maxBlinkEnvelopeVersion   = byte(21)
+	blinkEnvelopeVersion21     = byte(21)
+	blinkEnvelopeTag           = byte(0xfe)
+	blinkV21InnerPayloadOffset = 15
+	maxBlinkEnvelopeVersion    = byte(21)
 )
 
 //go:embed redux_decoder.js
@@ -135,14 +135,15 @@ func extractIndexedDBStates(path string) ([]ReduxDecodedState, IndexedDBSummary,
 		NodeAvailable: nodeAvailable(),
 		BlobFileCount: len(refs),
 	}
-	if !summary.NodeAvailable {
-		return nil, summary, nil
-	}
 
 	byIdentity := map[string]ReduxDecodedState{}
 	for _, ref := range refs {
-		result := decodeReduxBlob(ref.Path)
+		result := analyzeReduxBlob(ref.Path)
 		if !result.candidate {
+			if result.err != nil {
+				// Unreadable files are reported but never count as candidates.
+				summary.recordDecodeFailure(decodeErrorStage(result.err))
+			}
 			continue
 		}
 		summary.CandidateCount++
@@ -153,7 +154,14 @@ func extractIndexedDBStates(path string) ([]ReduxDecodedState, IndexedDBSummary,
 			summary.recordDecodeFailure(decodeErrorStage(result.err))
 			continue
 		}
-		state := result.state
+		if !summary.NodeAvailable {
+			continue
+		}
+		state, err := runReduxDecoder(result.payload)
+		if err != nil {
+			summary.recordDecodeFailure(decodeErrorStage(err))
+			continue
+		}
 		if state.WorkspaceID == "" {
 			state.WorkspaceID = ref.WorkspaceID
 		}
@@ -435,14 +443,35 @@ func decodeErrorStage(err error) string {
 type reduxBlobDecode struct {
 	candidate bool
 	v8Version byte
+	payload   []byte
 	state     ReduxDecodedState
 	err       error
 }
 
+// decodeReduxBlob analyzes a blob file and, for supported candidates, decodes
+// it with Node.
 func decodeReduxBlob(blobPath string) reduxBlobDecode {
+	result := analyzeReduxBlob(blobPath)
+	if !result.candidate || result.err != nil {
+		return result
+	}
+	state, err := runReduxDecoder(result.payload)
+	if err != nil {
+		result.payload = nil
+		result.err = err
+		return result
+	}
+	result.state = state
+	return result
+}
+
+// analyzeReduxBlob classifies a blob file and prepares the V8 payload for
+// supported candidates without invoking Node. Files whose framing is not
+// recognized are not Redux candidates and are ignored by callers.
+func analyzeReduxBlob(blobPath string) reduxBlobDecode {
 	raw, err := os.ReadFile(blobPath) //nolint:gosec // Blob path is discovered inside the Slack IndexedDB directory.
 	if err != nil {
-		return reduxBlobDecode{candidate: true, err: newReduxDecodeError("read", err)}
+		return reduxBlobDecode{err: newReduxDecodeError("read", err)}
 	}
 
 	decoded := raw
@@ -479,11 +508,7 @@ func decodeReduxBlob(blobPath string) reduxBlobDecode {
 		payload[1] = v8WireFormatV15
 	}
 
-	state, err := runReduxDecoder(payload)
-	if err != nil {
-		return reduxBlobDecode{candidate: true, v8Version: version, err: err}
-	}
-	return reduxBlobDecode{candidate: true, v8Version: version, state: state}
+	return reduxBlobDecode{candidate: true, v8Version: version, payload: payload}
 }
 
 // locateInnerV8Payload finds the inner V8 serialization header in a decoded
@@ -500,16 +525,13 @@ func locateInnerV8Payload(decoded []byte) (int, byte) {
 	if len(decoded) >= 4 && decoded[2] == 0xff && isKnownBlinkVersion(outer) && isRecognizedWireVersion(decoded[3]) {
 		return 2, decoded[3]
 	}
-	// Current Blink v21 envelope: ff 15 fe, a bounded binary header, then the
-	// inner V8 payload (observed at offset 15). Check this before the bare
-	// header because Blink version 21 (0x15) also falls in the wire version
-	// window.
+	// Current Blink v21 envelope: ff 15 fe, a fixed-size binary header, then
+	// the inner V8 payload anchored at offset 15 in every observed cache.
+	// Check this before the bare header because Blink version 21 (0x15) also
+	// falls in the wire version window.
 	if len(decoded) >= 3 && outer == blinkEnvelopeVersion21 && decoded[2] == blinkEnvelopeTag {
-		limit := min(len(decoded), maxBlinkEnvelopePrefixLen)
-		for offset := 3; offset+1 < limit; offset++ {
-			if decoded[offset] == 0xff && isRecognizedWireVersion(decoded[offset+1]) {
-				return offset, decoded[offset+1]
-			}
+		if len(decoded) > blinkV21InnerPayloadOffset+1 && decoded[blinkV21InnerPayloadOffset] == 0xff && isRecognizedWireVersion(decoded[blinkV21InnerPayloadOffset+1]) {
+			return blinkV21InnerPayloadOffset, decoded[blinkV21InnerPayloadOffset+1]
 		}
 		return -1, 0
 	}

--- a/internal/slackdesktop/redux.go
+++ b/internal/slackdesktop/redux.go
@@ -1,10 +1,10 @@
 package slackdesktop
 
 import (
-	"bytes"
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -23,9 +23,21 @@ import (
 const (
 	indexedDBBlobDir    = "IndexedDB/https_app.slack.com_0.indexeddb.blob"
 	indexedDBSourceName = "desktop-indexeddb"
-)
 
-var reduxV8Header = []byte{0xff, 0x0f}
+	v8WireFormatV15 = byte(15)
+	v8WireFormatV16 = byte(16)
+
+	// minWireVersionWindow and maxWireVersionWindow bound which version bytes
+	// are treated as V8-family framing. Versions inside the window but not
+	// explicitly supported are reported as unsupported instead of ignored.
+	minWireVersionWindow = byte(13)
+	maxWireVersionWindow = byte(32)
+
+	blinkEnvelopeVersion21    = byte(21)
+	blinkEnvelopeTag          = byte(0xfe)
+	maxBlinkEnvelopePrefixLen = 64
+	maxBlinkEnvelopeVersion   = byte(21)
+)
 
 //go:embed redux_decoder.js
 var reduxDecoderScript string
@@ -109,21 +121,39 @@ func nodeAvailable() bool {
 }
 
 func ExtractIndexedDBStates(path string) ([]ReduxDecodedState, error) {
-	if !nodeAvailable() {
-		return nil, nil
-	}
+	states, _, err := extractIndexedDBStates(path)
+	return states, err
+}
 
+func extractIndexedDBStates(path string) ([]ReduxDecodedState, IndexedDBSummary, error) {
 	refs, err := scanReduxBlobRefs(filepath.Join(path, indexedDBBlobDir))
 	if err != nil {
-		return nil, err
+		return nil, IndexedDBSummary{}, err
+	}
+
+	summary := IndexedDBSummary{
+		NodeAvailable: nodeAvailable(),
+		BlobFileCount: len(refs),
+	}
+	if !summary.NodeAvailable {
+		return nil, summary, nil
 	}
 
 	byIdentity := map[string]ReduxDecodedState{}
 	for _, ref := range refs {
-		state, err := decodeReduxBlob(ref.Path)
-		if err != nil {
+		result := decodeReduxBlob(ref.Path)
+		if !result.candidate {
 			continue
 		}
+		summary.CandidateCount++
+		if result.v8Version > 0 {
+			summary.recordV8Version(result.v8Version)
+		}
+		if result.err != nil {
+			summary.recordDecodeFailure(decodeErrorStage(result.err))
+			continue
+		}
+		state := result.state
 		if state.WorkspaceID == "" {
 			state.WorkspaceID = ref.WorkspaceID
 		}
@@ -131,8 +161,10 @@ func ExtractIndexedDBStates(path string) ([]ReduxDecodedState, error) {
 			state.UserID = ref.UserID
 		}
 		if state.WorkspaceID == "" && state.UserID == "" {
+			summary.recordDecodeFailure("identity")
 			continue
 		}
+		summary.DecodedBlobCount++
 		key := state.WorkspaceID + "|" + state.UserID
 		current, ok := byIdentity[key]
 		if !ok || reduxStateScore(state) > reduxStateScore(current) {
@@ -150,7 +182,8 @@ func ExtractIndexedDBStates(path string) ([]ReduxDecodedState, error) {
 		}
 		return states[i].WorkspaceID < states[j].WorkspaceID
 	})
-	return states, nil
+	summary.DecodedStateCount = len(states)
+	return states, summary, nil
 }
 
 func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecodedState, now time.Time, filter ingestFilter) error {
@@ -379,48 +412,145 @@ func scanReduxBlobRefs(blobRoot string) ([]reduxBlobRef, error) {
 	return refs, nil
 }
 
-func decodeReduxBlob(blobPath string) (ReduxDecodedState, error) {
+type reduxDecodeError struct {
+	stage string
+	err   error
+}
+
+func (e *reduxDecodeError) Error() string { return e.err.Error() }
+func (e *reduxDecodeError) Unwrap() error { return e.err }
+
+func newReduxDecodeError(stage string, err error) error {
+	return &reduxDecodeError{stage: stage, err: err}
+}
+
+func decodeErrorStage(err error) string {
+	var decodeErr *reduxDecodeError
+	if errors.As(err, &decodeErr) {
+		return decodeErr.stage
+	}
+	return "unknown"
+}
+
+type reduxBlobDecode struct {
+	candidate bool
+	v8Version byte
+	state     ReduxDecodedState
+	err       error
+}
+
+func decodeReduxBlob(blobPath string) reduxBlobDecode {
 	raw, err := os.ReadFile(blobPath) //nolint:gosec // Blob path is discovered inside the Slack IndexedDB directory.
 	if err != nil {
-		return ReduxDecodedState{}, err
+		return reduxBlobDecode{candidate: true, err: newReduxDecodeError("read", err)}
 	}
 
 	decoded := raw
-	if len(raw) >= 3 && raw[0] == 0xff && raw[1] == 0x11 && raw[2] == 0x02 {
+	wrapped := len(raw) >= 3 && raw[0] == 0xff && raw[1] == 0x11 && raw[2] == 0x02
+	if wrapped {
 		decoded, err = snappy.Decode(nil, raw[3:])
 		if err != nil {
-			return ReduxDecodedState{}, err
+			return reduxBlobDecode{candidate: true, err: newReduxDecodeError("snappy", err)}
 		}
 	}
 
-	offset := bytes.Index(decoded, reduxV8Header)
+	offset, version := locateInnerV8Payload(decoded)
 	if offset < 0 {
-		return ReduxDecodedState{}, fmt.Errorf("v8 payload not found in %s", blobPath)
+		// Snappy-wrapped blobs without V8 framing and files without any known
+		// header are unrelated blob content, not Redux candidates.
+		return reduxBlobDecode{}
+	}
+	if version != v8WireFormatV15 && version != v8WireFormatV16 {
+		// Never relabel unknown future versions.
+		return reduxBlobDecode{
+			candidate: true,
+			v8Version: version,
+			err:       newReduxDecodeError("version", fmt.Errorf("unsupported V8 wire format version %d", version)),
+		}
 	}
 
+	payload := append([]byte(nil), decoded[offset:]...)
+	if version == v8WireFormatV16 {
+		// V8 wire format 16 only widens ArrayBuffer length and offset fields
+		// beyond 32 bits. Relabel a temporary copy to 15 so released Node
+		// runtimes can deserialize it; the decoded Redux state is validated
+		// before use, and any mismatch surfaces as a decode failure for this
+		// blob only.
+		payload[1] = v8WireFormatV15
+	}
+
+	state, err := runReduxDecoder(payload)
+	if err != nil {
+		return reduxBlobDecode{candidate: true, v8Version: version, err: err}
+	}
+	return reduxBlobDecode{candidate: true, v8Version: version, state: state}
+}
+
+// locateInnerV8Payload finds the inner V8 serialization header in a decoded
+// blob using only anchored or bounded structural recognition. It returns the
+// payload offset and the detected wire format version.
+func locateInnerV8Payload(decoded []byte) (int, byte) {
+	if len(decoded) < 2 || decoded[0] != 0xff {
+		return -1, 0
+	}
+	outer := decoded[1]
+	// Historical split framing: an outer Blink header followed by the inner
+	// V8 header at offset 2. 0xff is never a value tag, so a second version
+	// header at offset 2 is unambiguous.
+	if len(decoded) >= 4 && decoded[2] == 0xff && isKnownBlinkVersion(outer) && isRecognizedWireVersion(decoded[3]) {
+		return 2, decoded[3]
+	}
+	// Current Blink v21 envelope: ff 15 fe, a bounded binary header, then the
+	// inner V8 payload (observed at offset 15). Check this before the bare
+	// header because Blink version 21 (0x15) also falls in the wire version
+	// window.
+	if len(decoded) >= 3 && outer == blinkEnvelopeVersion21 && decoded[2] == blinkEnvelopeTag {
+		limit := min(len(decoded), maxBlinkEnvelopePrefixLen)
+		for offset := 3; offset+1 < limit; offset++ {
+			if decoded[offset] == 0xff && isRecognizedWireVersion(decoded[offset+1]) {
+				return offset, decoded[offset+1]
+			}
+		}
+		return -1, 0
+	}
+	if isRecognizedWireVersion(outer) {
+		return 0, outer
+	}
+	return -1, 0
+}
+
+func isRecognizedWireVersion(version byte) bool {
+	return version >= minWireVersionWindow && version <= maxWireVersionWindow
+}
+
+func isKnownBlinkVersion(version byte) bool {
+	return version >= minWireVersionWindow && version <= maxBlinkEnvelopeVersion
+}
+
+func runReduxDecoder(payload []byte) (ReduxDecodedState, error) {
 	tempFile, err := os.CreateTemp("", "slacrawl-redux-*.bin")
 	if err != nil {
-		return ReduxDecodedState{}, err
+		return ReduxDecodedState{}, newReduxDecodeError("temp", err)
 	}
 	tempPath := tempFile.Name()
 	defer func() { _ = os.Remove(tempPath) }()
-	if _, err := tempFile.Write(decoded[offset:]); err != nil {
+	if _, err := tempFile.Write(payload); err != nil {
 		_ = tempFile.Close()
-		return ReduxDecodedState{}, err
+		return ReduxDecodedState{}, newReduxDecodeError("temp", err)
 	}
 	if err := tempFile.Close(); err != nil {
-		return ReduxDecodedState{}, err
+		return ReduxDecodedState{}, newReduxDecodeError("temp", err)
 	}
 
 	cmd := exec.Command("node", "-e", reduxDecoderScript, tempPath) //nolint:gosec // Node decodes a temporary V8 payload copied from the Slack data directory.
 	output, err := cmd.Output()
 	if err != nil {
-		return ReduxDecodedState{}, err
+		return ReduxDecodedState{}, newReduxDecodeError("node", err)
 	}
 
 	var state ReduxDecodedState
 	if err := json.Unmarshal(output, &state); err != nil {
-		return ReduxDecodedState{}, err
+		return ReduxDecodedState{}, newReduxDecodeError("json", err)
 	}
 	return state, nil
 }

--- a/internal/slackdesktop/redux_decode_test.go
+++ b/internal/slackdesktop/redux_decode_test.go
@@ -1,0 +1,370 @@
+package slackdesktop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/golang/snappy"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openclaw/slacrawl/internal/store"
+)
+
+func requireNode(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is required for redux blob decoding")
+	}
+}
+
+// serializeReduxFixture builds a synthetic Redux state with node. Current Node
+// releases emit V8 wire format 15, so the returned bytes always start with
+// ff 0f regardless of the installed Node version.
+func serializeReduxFixture(t *testing.T, workspaceID, userID string) []byte {
+	t.Helper()
+	requireNode(t)
+
+	payloadPath := filepath.Join(t.TempDir(), "redux.bin")
+	//nolint:gosec // Test builds a controlled V8 fixture with node.
+	cmd := exec.Command("node", "-e", fmt.Sprintf(`
+const fs = require("fs");
+const v8 = require("v8");
+fs.writeFileSync(process.argv[1], v8.serialize({
+  selfTeamIds: { teamId: %[1]q, defaultWorkspaceId: %[1]q },
+  bootData: { user_id: %[2]q },
+  channels: {
+    C111: { id: "C111", name: "kept", is_channel: true, context_team_id: %[1]q },
+    C222: { id: "C222", name: "excluded", is_channel: true, context_team_id: %[1]q }
+  },
+  members: {
+    %[2]q: { id: %[2]q, name: "alice", team_id: %[1]q }
+  },
+  messages: {
+    C111: { "1710000001.000200": { channel: "C111", ts: "1710000001.000200", type: "message", user: %[2]q, text: "kept message" } },
+    C222: { "1710000002.000200": { channel: "C222", ts: "1710000002.000200", type: "message", user: %[2]q, text: "excluded message" } }
+  }
+}));
+`, workspaceID, userID), payloadPath)
+	require.NoError(t, cmd.Run())
+
+	serialized, err := os.ReadFile(payloadPath) //nolint:gosec // Test reads the fixture it just wrote.
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(serialized), 2)
+	require.Equal(t, byte(0xff), serialized[0])
+	require.Equal(t, v8WireFormatV15, serialized[1])
+	return serialized
+}
+
+func snappyWrap(payload []byte) []byte {
+	return append([]byte{0xff, 0x11, 0x02}, snappy.Encode(nil, payload)...)
+}
+
+// blink21Wrap reproduces the current Slack Desktop framing: Blink envelope
+// version 21 (ff 15 fe), a 12-byte binary header, then the inner V8 payload.
+func blink21Wrap(v8Payload []byte) []byte {
+	envelope := append([]byte{0xff, blinkEnvelopeVersion21, blinkEnvelopeTag}, make([]byte, 12)...)
+	return append(envelope, v8Payload...)
+}
+
+func asWireFormatV16(v8Payload []byte) []byte {
+	converted := append([]byte(nil), v8Payload...)
+	converted[1] = v8WireFormatV16
+	return converted
+}
+
+func writeBlob(t *testing.T, root, name string, payload []byte) {
+	t.Helper()
+	dir := filepath.Join(root, indexedDBBlobDir, "1", "00")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), payload, 0o600))
+}
+
+func decodeFixtureBlob(t *testing.T, payload []byte) reduxBlobDecode {
+	t.Helper()
+	blobPath := filepath.Join(t.TempDir(), "redux.blob")
+	require.NoError(t, os.WriteFile(blobPath, payload, 0o600))
+	return decodeReduxBlob(blobPath)
+}
+
+func TestDecodeReduxBlobBareV15(t *testing.T) {
+	result := decodeFixtureBlob(t, serializeReduxFixture(t, "T111", "U111"))
+	require.True(t, result.candidate)
+	require.Equal(t, v8WireFormatV15, result.v8Version)
+	require.NoError(t, result.err)
+	require.Equal(t, "T111", result.state.WorkspaceID)
+	require.Equal(t, "U111", result.state.UserID)
+}
+
+func TestDecodeReduxBlobSnappyV15(t *testing.T) {
+	result := decodeFixtureBlob(t, snappyWrap(serializeReduxFixture(t, "T111", "U111")))
+	require.True(t, result.candidate)
+	require.Equal(t, v8WireFormatV15, result.v8Version)
+	require.NoError(t, result.err)
+	require.Equal(t, "T111", result.state.WorkspaceID)
+}
+
+func TestDecodeReduxBlobSplitBlinkV8Framing(t *testing.T) {
+	// Historical layout: an outer Blink header directly followed by the inner
+	// V8 header at offset 2.
+	framed := append([]byte{0xff, v8WireFormatV15}, serializeReduxFixture(t, "T111", "U111")...)
+	result := decodeFixtureBlob(t, snappyWrap(framed))
+	require.True(t, result.candidate)
+	require.Equal(t, v8WireFormatV15, result.v8Version)
+	require.NoError(t, result.err)
+	require.Equal(t, "T111", result.state.WorkspaceID)
+}
+
+func TestDecodeReduxBlobBareV16(t *testing.T) {
+	result := decodeFixtureBlob(t, asWireFormatV16(serializeReduxFixture(t, "T111", "U111")))
+	require.True(t, result.candidate)
+	require.Equal(t, v8WireFormatV16, result.v8Version)
+	require.NoError(t, result.err)
+	require.Equal(t, "T111", result.state.WorkspaceID)
+	require.Equal(t, "U111", result.state.UserID)
+	require.Len(t, result.state.Channels, 2)
+	require.Len(t, result.state.Messages, 2)
+}
+
+func TestDecodeReduxBlobSnappyBlink21V16(t *testing.T) {
+	blob := snappyWrap(blink21Wrap(asWireFormatV16(serializeReduxFixture(t, "T111", "U111"))))
+	result := decodeFixtureBlob(t, blob)
+	require.True(t, result.candidate)
+	require.Equal(t, v8WireFormatV16, result.v8Version)
+	require.NoError(t, result.err)
+	require.Equal(t, "T111", result.state.WorkspaceID)
+	require.Equal(t, "U111", result.state.UserID)
+	require.Len(t, result.state.Messages, 2)
+}
+
+func TestDecodeReduxBlobRejectsUnknownFutureVersion(t *testing.T) {
+	result := decodeFixtureBlob(t, []byte{0xff, 17, 0x6f, 0x7b})
+	require.True(t, result.candidate)
+	require.Equal(t, byte(17), result.v8Version)
+	require.Error(t, result.err)
+	require.Equal(t, "version", decodeErrorStage(result.err))
+	require.EqualError(t, result.err, "unsupported V8 wire format version 17")
+}
+
+func TestLocateInnerV8Payload(t *testing.T) {
+	blink21 := blink21Wrap([]byte{0xff, v8WireFormatV16, 'o'})
+
+	tests := []struct {
+		name    string
+		decoded []byte
+		offset  int
+		version byte
+	}{
+		{name: "bare v15", decoded: []byte{0xff, v8WireFormatV15, 'o'}, offset: 0, version: v8WireFormatV15},
+		{name: "bare v16", decoded: []byte{0xff, v8WireFormatV16, 'o'}, offset: 0, version: v8WireFormatV16},
+		{name: "bare unsupported", decoded: []byte{0xff, 17, 'o'}, offset: 0, version: 17},
+		{name: "split framing", decoded: []byte{0xff, v8WireFormatV15, 0xff, v8WireFormatV15, 'o'}, offset: 2, version: v8WireFormatV15},
+		{name: "blink v21 envelope", decoded: blink21, offset: 15, version: v8WireFormatV16},
+		{name: "unrelated content", decoded: []byte("plain blob content"), offset: -1},
+		{name: "jpeg magic", decoded: []byte{0xff, 0xd8, 0xff, 0xe0}, offset: -1},
+		{name: "header outside bounded prefix", decoded: append(append([]byte{0xff, blinkEnvelopeVersion21, blinkEnvelopeTag}, make([]byte, maxBlinkEnvelopePrefixLen)...), 0xff, v8WireFormatV15, 'o'), offset: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			offset, version := locateInnerV8Payload(tt.decoded)
+			require.Equal(t, tt.offset, offset)
+			if tt.offset >= 0 {
+				require.Equal(t, tt.version, version)
+			}
+		})
+	}
+}
+
+func TestExtractIndexedDBStatesMixedV15AndV16(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "v15", serializeReduxFixture(t, "T111", "U111"))
+	writeBlob(t, root, "v16", snappyWrap(blink21Wrap(asWireFormatV16(serializeReduxFixture(t, "T222", "U222")))))
+
+	states, summary, err := extractIndexedDBStates(root)
+	require.NoError(t, err)
+	require.Len(t, states, 2)
+	require.Equal(t, "T111", states[0].WorkspaceID)
+	require.Equal(t, "T222", states[1].WorkspaceID)
+
+	require.True(t, summary.NodeAvailable)
+	require.Equal(t, 2, summary.BlobFileCount)
+	require.Equal(t, 2, summary.CandidateCount)
+	require.Equal(t, 2, summary.DecodedBlobCount)
+	require.Equal(t, 2, summary.DecodedStateCount)
+	require.Zero(t, summary.DecodeFailureCount)
+	require.Equal(t, map[string]int{"15": 1, "16": 1}, summary.V8Versions)
+}
+
+func TestExtractIndexedDBStatesRetainsValidStatesWhenACandidateIsCorrupt(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "valid", serializeReduxFixture(t, "T111", "U111"))
+	// Recognized V8 v15 header with a truncated payload: node must reject it.
+	writeBlob(t, root, "truncated", []byte{0xff, v8WireFormatV15, 0x6f})
+
+	states, summary, err := extractIndexedDBStates(root)
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	require.Equal(t, "T111", states[0].WorkspaceID)
+
+	require.Equal(t, 2, summary.BlobFileCount)
+	require.Equal(t, 2, summary.CandidateCount)
+	require.Equal(t, 1, summary.DecodedBlobCount)
+	require.Equal(t, 1, summary.DecodeFailureCount)
+	require.Equal(t, map[string]int{"node": 1}, summary.DecodeFailures)
+}
+
+func TestExtractIndexedDBStatesIgnoresUnrelatedBlobFiles(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "valid", serializeReduxFixture(t, "T111", "U111"))
+	writeBlob(t, root, "unrelated", []byte("exported attachment bytes, not a redux state"))
+
+	states, summary, err := extractIndexedDBStates(root)
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	require.Equal(t, 2, summary.BlobFileCount)
+	require.Equal(t, 1, summary.CandidateCount)
+	require.Equal(t, 1, summary.DecodedBlobCount)
+	require.Zero(t, summary.DecodeFailureCount)
+}
+
+func TestExtractIndexedDBStatesNoCandidatesIsSuccessful(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "unrelated", []byte("not a redux blob"))
+
+	states, summary, err := extractIndexedDBStates(root)
+	require.NoError(t, err)
+	require.Empty(t, states)
+	require.Equal(t, 1, summary.BlobFileCount)
+	require.Zero(t, summary.CandidateCount)
+	require.Zero(t, summary.DecodeFailureCount)
+}
+
+func TestExtractIndexedDBStatesClassifiesMalformedSnappy(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "malformed", append([]byte{0xff, 0x11, 0x02}, []byte("%%%not-snappy%%%")...))
+
+	states, summary, err := extractIndexedDBStates(root)
+	require.NoError(t, err)
+	require.Empty(t, states)
+	require.Equal(t, 1, summary.CandidateCount)
+	require.Equal(t, 1, summary.DecodeFailureCount)
+	require.Equal(t, map[string]int{"snappy": 1}, summary.DecodeFailures)
+}
+
+func TestExtractIndexedDBStatesReportsUnsupportedVersion(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "future", []byte{0xff, 17, 0x6f, 0x7b})
+
+	states, summary, err := extractIndexedDBStates(root)
+	require.NoError(t, err)
+	require.Empty(t, states)
+	require.Equal(t, 1, summary.CandidateCount)
+	require.Equal(t, 1, summary.DecodeFailureCount)
+	require.Equal(t, map[string]int{"version": 1}, summary.DecodeFailures)
+	require.Equal(t, map[string]int{"17": 1}, summary.V8Versions)
+}
+
+func TestExtractIndexedDBStatesNodeUnavailable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	root := t.TempDir()
+	writeBlob(t, root, "v15", []byte{0xff, v8WireFormatV15, 0x6f})
+
+	states, summary, err := extractIndexedDBStates(root)
+	require.NoError(t, err)
+	require.Empty(t, states)
+	require.False(t, summary.NodeAvailable)
+	require.Equal(t, 1, summary.BlobFileCount)
+	require.Zero(t, summary.CandidateCount)
+	require.Zero(t, summary.DecodeFailureCount)
+}
+
+func TestInspectReportsAllCandidateFailureWithoutError(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "truncated", []byte{0xff, v8WireFormatV15, 0x6f})
+
+	source, err := Inspect(root)
+	require.NoError(t, err)
+	require.True(t, source.IndexedDB.NodeAvailable)
+	require.Equal(t, 1, source.IndexedDB.BlobFileCount)
+	require.Equal(t, 1, source.IndexedDB.CandidateCount)
+	require.Zero(t, source.IndexedDB.DecodedBlobCount)
+	require.Zero(t, source.IndexedDB.DecodedStateCount)
+	require.Equal(t, 1, source.IndexedDB.DecodeFailureCount)
+	require.Equal(t, map[string]int{"node": 1}, source.IndexedDB.DecodeFailures)
+}
+
+func TestIngestFailsWhenEveryCandidateFails(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "truncated", []byte{0xff, v8WireFormatV15, 0x6f})
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	_, err = Ingest(context.Background(), st, root, IngestOptions{})
+	require.EqualError(t, err, "desktop IndexedDB: failed to decode all 1 candidate blob(s): node=1")
+}
+
+func TestIngestDecodesV16WithFilteringAndUpserts(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "v16", snappyWrap(blink21Wrap(asWireFormatV16(serializeReduxFixture(t, "T111", "U111")))))
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "slacrawl.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	source, err := Ingest(context.Background(), st, root, IngestOptions{
+		WorkspaceID:     "T111",
+		ExcludeChannels: []string{"#excluded"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, source.IndexedDB.DecodedStateCount)
+	require.Equal(t, map[string]int{"16": 1}, source.IndexedDB.V8Versions)
+
+	ctx := context.Background()
+	messages, err := st.Messages(ctx, "T111", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, "C111", messages[0].ChannelID)
+	require.Equal(t, "kept message", messages[0].Text)
+	require.Equal(t, indexedDBSourceName, messages[0].SourceName)
+
+	channels, err := st.Channels(ctx, "T111", "", 10)
+	require.NoError(t, err)
+	require.Len(t, channels, 1)
+	require.Equal(t, "kept", channels[0].Name)
+}
+
+func TestDoctorJSONIncludesIndexedDBDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "malformed", append([]byte{0xff, 0x11, 0x02}, []byte("supersecretpayload")...))
+
+	source, err := Inspect(root)
+	require.NoError(t, err)
+
+	rendered, err := json.Marshal(source)
+	require.NoError(t, err)
+
+	var decoded struct {
+		IndexedDB map[string]any `json:"indexeddb"`
+	}
+	require.NoError(t, json.Unmarshal(rendered, &decoded))
+	for _, key := range []string{
+		"node_available",
+		"blob_file_count",
+		"candidate_count",
+		"decoded_blob_count",
+		"decoded_state_count",
+		"decode_failure_count",
+		"decode_failures",
+	} {
+		require.Contains(t, decoded.IndexedDB, key)
+	}
+	require.NotContains(t, strings.ToLower(string(rendered)), "supersecretpayload")
+}

--- a/internal/slackdesktop/redux_decode_test.go
+++ b/internal/slackdesktop/redux_decode_test.go
@@ -167,7 +167,7 @@ func TestLocateInnerV8Payload(t *testing.T) {
 		{name: "blink v21 envelope", decoded: blink21, offset: 15, version: v8WireFormatV16},
 		{name: "unrelated content", decoded: []byte("plain blob content"), offset: -1},
 		{name: "jpeg magic", decoded: []byte{0xff, 0xd8, 0xff, 0xe0}, offset: -1},
-		{name: "header outside bounded prefix", decoded: append(append([]byte{0xff, blinkEnvelopeVersion21, blinkEnvelopeTag}, make([]byte, maxBlinkEnvelopePrefixLen)...), 0xff, v8WireFormatV15, 'o'), offset: -1},
+		{name: "inner payload not at anchored offset", decoded: append(append([]byte{0xff, blinkEnvelopeVersion21, blinkEnvelopeTag}, make([]byte, 64)...), 0xff, v8WireFormatV15, 'o'), offset: -1},
 	}
 
 	for _, tt := range tests {
@@ -233,6 +233,24 @@ func TestExtractIndexedDBStatesIgnoresUnrelatedBlobFiles(t *testing.T) {
 	require.Zero(t, summary.DecodeFailureCount)
 }
 
+func TestExtractIndexedDBStatesUnreadableFileIsNotACandidate(t *testing.T) {
+	root := t.TempDir()
+	writeBlob(t, root, "valid", serializeReduxFixture(t, "T111", "U111"))
+	unreadable := filepath.Join(root, indexedDBBlobDir, "1", "00", "unreadable")
+	require.NoError(t, os.WriteFile(unreadable, []byte("anything"), 0o600))
+	require.NoError(t, os.Chmod(unreadable, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o600) })
+
+	states, summary, err := extractIndexedDBStates(root)
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	require.Equal(t, 2, summary.BlobFileCount)
+	require.Equal(t, 1, summary.CandidateCount)
+	require.Equal(t, 1, summary.DecodedBlobCount)
+	require.Equal(t, 1, summary.DecodeFailureCount)
+	require.Equal(t, map[string]int{"read": 1}, summary.DecodeFailures)
+}
+
 func TestExtractIndexedDBStatesNoCandidatesIsSuccessful(t *testing.T) {
 	root := t.TempDir()
 	writeBlob(t, root, "unrelated", []byte("not a redux blob"))
@@ -280,7 +298,10 @@ func TestExtractIndexedDBStatesNodeUnavailable(t *testing.T) {
 	require.Empty(t, states)
 	require.False(t, summary.NodeAvailable)
 	require.Equal(t, 1, summary.BlobFileCount)
-	require.Zero(t, summary.CandidateCount)
+	// Candidates are still classified without node; only decoding is skipped.
+	require.Equal(t, 1, summary.CandidateCount)
+	require.Equal(t, map[string]int{"15": 1}, summary.V8Versions)
+	require.Zero(t, summary.DecodedBlobCount)
 	require.Zero(t, summary.DecodeFailureCount)
 }
 


### PR DESCRIPTION
Hello!

Noticed that running the wiretap sync stopped working and had an agent investigate: it is because of a change of the format of the IndexDB blobs (see below for full research/agent recap).

Because it's linked to the Slack version and that all users may not have their versions up to date, the PR includes support for both the old version and the newer one. Let me know if that's fine or if it should just support the latest version.

Also linked at the research and debugging sessions if more context is needed on the agent decisions.

Let me know if you want/need more changes!

---

## Agent sessions
- [Research / Debugging (gpt-5.6-sol)](https://assets.aliou.me/traces/2026-07-24T11-27-38-029Z.html)
- [Implementation (kimi-k3)](https://assets.aliou.me/traces/2026-07-24T11-59-04-086Z.html)

## What Problem This Solves

Fixes an issue where users running wiretap/Desktop sync would import zero recent messages when recent Slack Desktop releases wrote IndexedDB Redux cache blobs with V8 wire format 16 inside a Snappy-wrapped Blink v21 envelope. Complete decode failure was silently reported as a successful empty sync.

## Investigation

We reproduced the issue with slacrawl 0.7.9, Slack Desktop 4.51.180 on macOS arm64, Electron 43.1.1, and Node 22.22.3.

Read-only inspection found eight recently updated IndexedDB blobs totaling about 5 MB. Each blob used Slack's `ff 11 02` Snappy framing. After decompression, each value began with a Blink v21 envelope (`ff 15 fe`) and contained an inner V8 wire-format v16 payload (`ff 10`) at offset 15. The existing decoder searched only for the v15 header (`ff 0f`), skipped every decode error, and returned zero decoded states as success.

Experiments on temporary payload copies showed that extracting the inner payload and changing only its v16 header to v15 allowed Node to decode all eight blobs. The decoded cache contained timestamps newer than the existing archive, confirming that the expected recent data was present locally. Node 22.22.3, 24.15.0, and 26.3.0 rejected the unadapted v16 payload, so upgrading Node alone did not address the hardcoded header detection.

This ruled out the discovered Slack path, missing cache data, Redux-state shape, workspace/channel filtering, and SQLite ingestion as causes of the empty result. Workspace names and IDs, channel names and IDs, user data, message contents, credentials, and payload contents are intentionally omitted.

- Research session: [sanitized investigation](https://assets.aliou.me/traces/2026-07-24T11-27-38-029Z.html)
- Implementation session: [implementation and verification](https://assets.aliou.me/traces/2026-07-24T11-59-04-086Z.html)

## Why This Change Was Made

The desktop decoder now recognizes supported blob framing per file, preserves V8 v15 compatibility, and adapts only known V8 v16 payloads on a temporary copy for Node deserialization. Unknown versions are never relabeled, unrelated blobs are excluded from the failure denominator, partial successes remain usable, and a sync fails when Node is available but every recognized candidate fails.

- `internal/slackdesktop/redux.go` adds bounded framing detection, explicit v15/v16 handling, candidate classification, and staged decode diagnostics.
- `internal/slackdesktop/desktop.go` exposes sanitized IndexedDB diagnostics through inspection/doctor output and rejects complete candidate decode failure during ingestion.
- `internal/slackdesktop/redux_decode_test.go` covers old and current framings, mixed and partial results, unsupported versions, Node absence, diagnostics, filtering, and SQLite ingestion.
- `docs/desktop-mode.md` and `CHANGELOG.md` document the supported behavior.

## User Impact

Wiretap/Desktop sync can import cached channels, users, messages, and threads from current Slack Desktop releases while remaining compatible with older caches. Operators can distinguish missing cache data, unavailable Node support, partial decoding, unsupported formats, and complete decode failure without exposing Slack payload contents.

## Evidence

Validated on macOS arm64 in `nix-shell -p go nodejs` with Go 1.26.5 and Node 24.15.0:

- `go mod verify`
- `go mod tidy -diff`
- `gofmt -l .`
- `go vet ./...`
- `go test -count=1 ./internal/slackdesktop`
- `go test -count=1 ./...`
- `go build -o /tmp/slacrawl-pr-build ./cmd/slacrawl`

The full suite passed with an isolated Git/XDG configuration so the machine's global `*.gz` ignore rule did not affect Git-archive fixtures.
