### PR TITLE
Fix desktop decoding for newer Slack V8 blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ If one of those gaps matters to your workflow, open an issue so it can be tracke
 ## Requirements
 
 - Go `1.26.5+`
-- `node` if you want richer desktop-local IndexedDB blob decoding
+- `node` if you want richer desktop-local IndexedDB blob decoding; newer Slack
+  releases may require a newer V8 runtime supplied through
+  `SLACRAWL_V8_RUNTIME`
 - a Slack bot token for standard API sync
 - a configured Slack MCP connector if you want MCP-backed sync
 - an app token if you want to use `tail`

--- a/docs/desktop-mode.md
+++ b/docs/desktop-mode.md
@@ -105,6 +105,10 @@ slacrawl sql "select entity_id, value from sync_state where source_name = 'deskt
 ## Operational Notes
 
 - Rich IndexedDB redux blob decoding uses `node` when available.
+- Slack Desktop can write a newer V8 wire format than the installed Node
+  release supports. Set `SLACRAWL_V8_RUNTIME` to a compatible Node or Electron
+  executable in that case. Electron is launched with
+  `ELECTRON_RUN_AS_NODE=1`.
 - If `node` is unavailable, desktop sync still runs, but decoded cached channel/user/message coverage will be reduced.
 - Desktop data is merged at lower precedence than API data.
 - Re-running desktop sync is safe; canonical rows are upserted by Slack-native keys.

--- a/internal/slackdesktop/desktop_test.go
+++ b/internal/slackdesktop/desktop_test.go
@@ -398,7 +398,9 @@ fs.writeFileSync(process.argv[1], v8.serialize(value));
 
 	serialized, err := os.ReadFile(payloadPath) //nolint:gosec // Test reads the payload it just wrote to t.TempDir.
 	require.NoError(t, err)
-	blobPayload := append([]byte{0xff, 0x11, 0x02}, snappy.Encode(nil, serialized)...)
+	blinkEnvelope := append([]byte{0xff, 0x15, 0xfe}, make([]byte, 12)...)
+	blinkEnvelope = append(blinkEnvelope, serialized...)
+	blobPayload := append([]byte{0xff, 0x11, 0x02}, snappy.Encode(nil, blinkEnvelope)...)
 	require.NoError(t, os.WriteFile(filepath.Join(root, "IndexedDB", "https_app.slack.com_0.indexeddb.blob", "1", "cd", "cd9a"), blobPayload, 0o600))
 
 	states, err := ExtractIndexedDBStates(root)
@@ -418,6 +420,43 @@ fs.writeFileSync(process.argv[1], v8.serialize(value));
 	require.Equal(t, "1710000001.000200", byTS["1710000002.000300"].ThreadTS)
 	require.Equal(t, "thread reply", byTS["1710000002.000300"].Text)
 	require.Equal(t, "D111", byTS["1710000003.000400"].Channel)
+}
+
+func TestLocateV8Payload(t *testing.T) {
+	t.Run("direct V8 envelope", func(t *testing.T) {
+		payload := []byte{0xff, 0x0f, 'o'}
+		got := locateV8Payloads(payload)
+		require.Equal(t, [][]byte{payload}, got)
+	})
+
+	t.Run("Blink envelope before trailer support", func(t *testing.T) {
+		payload := []byte{0xff, 0x10, 'o'}
+		decoded := append([]byte{0xff, 0x14}, payload...)
+		got := locateV8Payloads(decoded)
+		require.Equal(t, payload, got[0])
+	})
+
+	t.Run("Blink envelope with trailer offset", func(t *testing.T) {
+		payload := []byte{0xff, 0x10, 'o'}
+		decoded := append([]byte{0xff, 0x15, 0xfe}, make([]byte, 12)...)
+		decoded = append(decoded, payload...)
+		got := locateV8Payloads(decoded)
+		require.Equal(t, payload, got[0])
+	})
+
+	t.Run("prefix before payload", func(t *testing.T) {
+		payload := []byte{0xff, 0x0f, 'o'}
+		falseCandidate := []byte{0xff, 0x09, 'x'}
+		decoded := append(falseCandidate, payload...)
+		got := locateV8Payloads(decoded)
+		require.Len(t, got, 2)
+		require.Equal(t, decoded, got[0])
+		require.Equal(t, payload, got[1])
+	})
+
+	t.Run("missing payload", func(t *testing.T) {
+		require.Empty(t, locateV8Payloads([]byte("not serialized")))
+	})
 }
 
 func TestIngestReduxStatesIncludesIMs(t *testing.T) {

--- a/internal/slackdesktop/redux.go
+++ b/internal/slackdesktop/redux.go
@@ -23,9 +23,12 @@ import (
 const (
 	indexedDBBlobDir    = "IndexedDB/https_app.slack.com_0.indexeddb.blob"
 	indexedDBSourceName = "desktop-indexeddb"
-)
+	v8RuntimeEnv        = "SLACRAWL_V8_RUNTIME"
 
-var reduxV8Header = []byte{0xff, 0x0f}
+	blinkMinSeparateEnvelopeVersion = 16
+	blinkMinTrailerVersion          = 21
+	blinkTrailerSize                = 1 + 8 + 4
+)
 
 //go:embed redux_decoder.js
 var reduxDecoderScript string
@@ -104,8 +107,16 @@ type reduxBlobRef struct {
 }
 
 func nodeAvailable() bool {
-	_, err := exec.LookPath("node")
+	_, err := reduxV8Runtime()
 	return err == nil
+}
+
+func reduxV8Runtime() (string, error) {
+	runtime := strings.TrimSpace(os.Getenv(v8RuntimeEnv))
+	if runtime == "" {
+		runtime = "node"
+	}
+	return exec.LookPath(runtime)
 }
 
 func ExtractIndexedDBStates(path string) ([]ReduxDecodedState, error) {
@@ -119,11 +130,17 @@ func ExtractIndexedDBStates(path string) ([]ReduxDecodedState, error) {
 	}
 
 	byIdentity := map[string]ReduxDecodedState{}
+	var firstDecodeErr error
+	decodedBlobCount := 0
 	for _, ref := range refs {
 		state, err := decodeReduxBlob(ref.Path)
 		if err != nil {
+			if firstDecodeErr == nil {
+				firstDecodeErr = err
+			}
 			continue
 		}
+		decodedBlobCount++
 		if state.WorkspaceID == "" {
 			state.WorkspaceID = ref.WorkspaceID
 		}
@@ -138,6 +155,9 @@ func ExtractIndexedDBStates(path string) ([]ReduxDecodedState, error) {
 		if !ok || reduxStateScore(state) > reduxStateScore(current) {
 			byIdentity[key] = state
 		}
+	}
+	if len(refs) > 0 && decodedBlobCount == 0 && firstDecodeErr != nil {
+		return nil, fmt.Errorf("decode Slack IndexedDB blobs: %w", firstDecodeErr)
 	}
 
 	states := make([]ReduxDecodedState, 0, len(byIdentity))
@@ -393,8 +413,8 @@ func decodeReduxBlob(blobPath string) (ReduxDecodedState, error) {
 		}
 	}
 
-	offset := bytes.Index(decoded, reduxV8Header)
-	if offset < 0 {
+	payloads := locateV8Payloads(decoded)
+	if len(payloads) == 0 {
 		return ReduxDecodedState{}, fmt.Errorf("v8 payload not found in %s", blobPath)
 	}
 
@@ -404,25 +424,106 @@ func decodeReduxBlob(blobPath string) (ReduxDecodedState, error) {
 	}
 	tempPath := tempFile.Name()
 	defer func() { _ = os.Remove(tempPath) }()
-	if _, err := tempFile.Write(decoded[offset:]); err != nil {
-		_ = tempFile.Close()
-		return ReduxDecodedState{}, err
-	}
 	if err := tempFile.Close(); err != nil {
 		return ReduxDecodedState{}, err
 	}
 
-	cmd := exec.Command("node", "-e", reduxDecoderScript, tempPath) //nolint:gosec // Node decodes a temporary V8 payload copied from the Slack data directory.
-	output, err := cmd.Output()
+	runtime, err := reduxV8Runtime()
 	if err != nil {
-		return ReduxDecodedState{}, err
+		return ReduxDecodedState{}, fmt.Errorf("find V8 runtime: %w", err)
+	}
+	var firstDecodeErr error
+	for _, payload := range payloads {
+		if err := os.WriteFile(tempPath, payload, 0o600); err != nil {
+			return ReduxDecodedState{}, err
+		}
+		cmd := exec.Command(runtime, "-e", reduxDecoderScript, tempPath) //nolint:gosec // The configured runtime decodes a temporary V8 payload copied from the Slack data directory.
+		cmd.Env = append(os.Environ(), "ELECTRON_RUN_AS_NODE=1")
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err != nil {
+			if firstDecodeErr == nil {
+				firstDecodeErr = fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+			}
+			continue
+		}
+
+		var state ReduxDecodedState
+		if err := json.Unmarshal(stdout.Bytes(), &state); err != nil {
+			if firstDecodeErr == nil {
+				firstDecodeErr = err
+			}
+			continue
+		}
+		return state, nil
+	}
+	return ReduxDecodedState{}, fmt.Errorf(
+		"decode V8 payload with %s: %w (set %s to a newer Node or Electron runtime if the wire format is unsupported)",
+		runtime,
+		firstDecodeErr,
+		v8RuntimeEnv,
+	)
+}
+
+func locateV8Payloads(decoded []byte) [][]byte {
+	var blinkPayloads [][]byte
+	var directPayloads [][]byte
+	seenOffsets := map[int]struct{}{}
+	addPayload := func(target *[][]byte, offset int) {
+		if _, ok := seenOffsets[offset]; ok {
+			return
+		}
+		seenOffsets[offset] = struct{}{}
+		*target = append(*target, decoded[offset:])
 	}
 
-	var state ReduxDecodedState
-	if err := json.Unmarshal(output, &state); err != nil {
-		return ReduxDecodedState{}, err
+	for offset := 0; offset < len(decoded); offset++ {
+		if decoded[offset] != 0xff {
+			continue
+		}
+		version, versionBytes, ok := readUint32Varint(decoded[offset+1:])
+		if !ok || version < 9 || version > 64 {
+			continue
+		}
+
+		afterVersion := offset + 1 + versionBytes
+		if version >= blinkMinSeparateEnvelopeVersion &&
+			version < blinkMinTrailerVersion &&
+			afterVersion < len(decoded) &&
+			decoded[afterVersion] == 0xff {
+			addPayload(&blinkPayloads, afterVersion)
+			continue
+		}
+		if version >= blinkMinTrailerVersion &&
+			afterVersion+blinkTrailerSize < len(decoded) &&
+			decoded[afterVersion] == 0xfe &&
+			decoded[afterVersion+blinkTrailerSize] == 0xff {
+			addPayload(&blinkPayloads, afterVersion+blinkTrailerSize)
+			continue
+		}
+
+		// This is a direct V8 envelope rather than Blink's outer envelope.
+		addPayload(&directPayloads, offset)
 	}
-	return state, nil
+	return append(blinkPayloads, directPayloads...)
+}
+
+func readUint32Varint(data []byte) (uint32, int, bool) {
+	var value uint32
+	for i := 0; i < len(data) && i < 5; i++ {
+		current := data[i]
+		if i == 4 && current > 0x0f {
+			return 0, 0, false
+		}
+		value |= uint32(current&0x7f) << (7 * i)
+		if current&0x80 == 0 {
+			return value, i + 1, true
+		}
+	}
+	return 0, 0, false
 }
 
 func reduxChannelKind(channel ReduxChannel) string {


### PR DESCRIPTION
## What changed

- recognize Blink's separate IndexedDB serialization envelope, including the
  version-21 trailer layout, before passing the inner V8 payload to the decoder
- support a compatible Node or Electron runtime through
  `SLACRAWL_V8_RUNTIME`
- try all plausible V8 payload candidates instead of accepting an unvalidated
  marker in a binary prefix
- surface a useful error when every discovered IndexedDB blob fails to decode
- document the runtime override and add regression coverage

## Why

Recent Slack Desktop releases can persist Snappy-compressed IndexedDB blobs
with a Blink version-21 outer envelope and a V8 format-16 inner payload. The
existing decoder searches only for the older `ff0f` V8 header, so these blobs
are silently skipped and desktop archives stop refreshing.

Stable Node releases may also lag the V8 wire format used by Electron. The
runtime override lets users select a compatible Node or Electron executable
without hard-coding an Electron dependency into slacrawl.

## Validation

- `go test ./...`
- isolated autoreview: clean, no accepted/actionable findings
- end-to-end sync against a current Slack Desktop cache using Electron 43.1.1:
  one IndexedDB state decoded and 3,721 messages imported
- repeated the same sync and confirmed the temporary archive remained at
  3,721 messages and 3,721 message events
