### PR TITLE
docs: changelog for Slack Desktop v16 cache decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Restored wiretap imports from Slack Desktop caches written with V8 wire format 16 (Snappy + Blink v21 envelope), kept older formats working, and made complete IndexedDB decode failures visible instead of reporting an empty successful sync.
+- Restored wiretap imports from Slack Desktop caches written with V8 wire format 16 (Snappy + Blink v21 envelope), kept older formats working, and made complete IndexedDB decode failures visible instead of reporting an empty successful sync. Thanks @aliou.
 
 ## 0.7.9 - 2026-07-20
 


### PR DESCRIPTION
Maintainer follow-up to #100: credit @aliou in the Unreleased changelog entry for Slack Desktop V8 v16 cache decoding.

Proof: the diff is limited to the contributor credit, git diff --check passes, and autoreview reported no accepted or actionable findings.
