### PR TITLE
chore(release): prepare v0.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.7.10 - 2026-07-26
 
 ### Fixes
 


### PR DESCRIPTION
Release prep for v0.7.10: stamp the changelog section shipping the Slack Desktop v16 IndexedDB decoding fix (#100, thanks @aliou).
