### PR TITLE
chore: start v0.7.11 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v0.7.11 - Unreleased
+
 ## v0.7.10 - 2026-07-26
 
 ### Fixes


### PR DESCRIPTION
Routine post-release changelog rollover after v0.7.10.
