### PR TITLE
chore(release): prepare v0.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v0.7.11 - Unreleased
+## v0.7.11 - 2026-07-26
+
+- Re-release v0.7.10's content through the official signed and notarized release pipeline; v0.7.10's macOS archives were signed but not notarized.
 
 ## v0.7.10 - 2026-07-26
 


### PR DESCRIPTION
Prepare the superseding v0.7.11 release through the official unified notarized pipeline.