### PR TITLE
build: unify Makefile targets across crawler repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Standardized the Makefile's build, check, snapshot, and fail-closed release targets across the crawler repositories.
+
 ## v0.7.11 - 2026-07-26
 
 - Re-release v0.7.10's content through the official signed and notarized release pipeline; v0.7.10's macOS archives were signed but not notarized.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ Requirements:
 Build and test:
 
 ```bash
-go test ./...
-go build ./cmd/slacrawl
+make build
+make check
 ```
 
 Run the CLI locally:
@@ -50,7 +50,7 @@ go run ./cmd/slacrawl --help
 GoReleaser snapshot builds stay credential-free and cross-platform:
 
 ```bash
-make release-snapshot
+make snapshot
 ```
 
 Official releases run through the manual **Release (unified)** GitHub Actions
@@ -61,12 +61,13 @@ verified bytes, updates the canonical Homebrew tap, and opens the next
 `Unreleased` changelog PR.
 
 ```bash
-gh workflow run release-unified.yml -f version=0.7.8
+gh workflow run release-unified.yml --repo openclaw/slacrawl -f version=0.7.8
 ```
 
 `make release` and `scripts/release.sh` fail closed and point to that workflow;
 the former local path could publish signed macOS binaries before verifying
-notarization. Use `make release-snapshot` for local, credential-free packaging.
+notarization. Use `make snapshot` for local, credential-free packaging;
+`make release-snapshot` remains a compatibility alias.
 
 The renamed **Release Validation (legacy, manual only)** workflow remains as a
 manual fallback for the old validation path; it no longer responds to tags.
@@ -93,7 +94,7 @@ App Store Connect credentials in the repository or local release configuration.
 
 ## Testing Expectations
 
-- Run `go test ./...` before opening a PR.
+- Run `make check` before opening a PR.
 - Add targeted tests when changing parsing, normalization, config loading, store behavior, or CLI output.
 - If a known failing test blocks your branch, call that out clearly in the PR description.
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,75 @@
 BINARY ?= bin/slacrawl
 COMPLETION_DIR ?= dist/completions
 
-.PHONY: build test fmt run generate-sqlc completion completion-bash completion-zsh release release-snapshot clean
+.DEFAULT_GOAL := help
+
+.PHONY: help build test fmt fmt-check lint tidy-check smoke check run generate-sqlc completion completion-bash completion-zsh snapshot release release-snapshot clean
+
+help:
+	@printf '%s\n' \
+		'Available targets:' \
+		'  help              Print available targets (default).' \
+		'  build             Build the CLI into $(BINARY).' \
+		'  test              Run the full Go test suite.' \
+		'  fmt               Apply Go formatting.' \
+		'  lint              Run vet, vulnerability, and dead-code checks.' \
+		'  check             Run every local gate enforced by CI.' \
+		'  snapshot          Build credential-free release artifacts.' \
+		'  release           Refuse local publishing and print the official CI command.' \
+		'  run               Run the CLI (ARGS=...).' \
+		'  generate-sqlc     Regenerate sqlc output.' \
+		'  completion        Generate bash and zsh completions.' \
+		'  clean             Remove local build output.' \
+		'  release-snapshot  Alias for snapshot.'
 
 build:
 	binary="$(BINARY)"; mkdir -p "$$(dirname -- "$$binary")"; go build -o "$$binary" ./cmd/slacrawl
 
 test:
-	go test ./...
+	GOWORK=off go test -count=1 ./...
 
 fmt:
 	gofmt -w cmd internal
+
+fmt-check:
+	@set -e; \
+	changed="$$(gofmt -l .)"; \
+	if [ -n "$$changed" ]; then printf 'gofmt wants changes in:\n%s\n' "$$changed"; exit 1; fi
+
+lint:
+	GOWORK=off go vet ./...
+	GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
+	@set -e; \
+	output_file="$$(mktemp)"; \
+	trap 'rm -f "$$output_file"' EXIT; \
+	if ! GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$$output_file"; then cat "$$output_file"; exit 1; fi; \
+	if [ -s "$$output_file" ]; then cat "$$output_file"; exit 1; fi
+
+tidy-check:
+	GOWORK=off go mod verify
+	GOWORK=off go mod tidy -diff
+
+smoke:
+	@set -e; \
+	tmpdir="$$(mktemp -d)"; \
+	binary="$$tmpdir/slacrawl"; \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	GOWORK=off go build -ldflags "-X github.com/openclaw/slacrawl/internal/cli.version=ci" -o "$$binary" ./cmd/slacrawl; \
+	output="$$("$$binary" --help 2>&1 || true)"; \
+	printf '%s\n' "$$output"; \
+	printf '%s' "$$output" | grep -q 'Usage of slacrawl:'; \
+	printf '%s' "$$output" | grep -q metadata; \
+	printf '%s' "$$output" | grep -q tui; \
+	test "$$("$$binary" --version)" = ci; \
+	metadata="$$("$$binary" metadata --json)"; \
+	printf '%s' "$$metadata" | grep -q '"schema_version"'; \
+	"$$binary" --config "$$tmpdir/slacrawl.toml" init --db "$$tmpdir/slacrawl.db"; \
+	status_output="$$("$$binary" --config "$$tmpdir/slacrawl.toml" status --json)"; \
+	printf '%s' "$$status_output" | grep -q '"databases"'; \
+	tui_output="$$("$$binary" --config "$$tmpdir/slacrawl.toml" tui --json --limit 1)"; \
+	printf '%s' "$$tui_output" | grep -q '^\['
+
+check: tidy-check fmt-check lint test smoke snapshot
 
 run:
 	go run ./cmd/slacrawl $(ARGS)
@@ -31,8 +90,10 @@ completion-zsh:
 release:
 	@./scripts/release.sh
 
-release-snapshot:
+snapshot:
 	$${GORELEASER:-goreleaser} release --snapshot --clean --skip=publish
+
+release-snapshot: snapshot
 
 clean:
 	rm -f -- "$(BINARY)"

--- a/README.md
+++ b/README.md
@@ -278,8 +278,10 @@ Color is disabled automatically when stdout is not a TTY. You can also force pla
 ## Make Targets
 
 ```bash
+make help
 make build
 make test
+make check
 make run ARGS="status"
 make generate-sqlc
 make completion


### PR DESCRIPTION
Add the shared help, check, and snapshot targets while preserving the release-snapshot alias. Keep publishing CI-only and fail closed to release-unified.
