### PR TITLE
test: require explicit live validation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Maintenance
 
+- Require explicit workspace, channel, and timestamp scope for live local
+  validation instead of embedding workspace-specific defaults.
 - Standardized the Makefile's build, check, snapshot, and fail-closed release targets across the crawler repositories.
 - Refreshed terminal detection and Unicode display-width dependencies.
 - Updated CrawlKit to 0.14.4, SQLite to 1.55.0, `golang.org/x/net` to 0.57.0, and replaced the retracted libc 1.74.3 with 1.74.4.

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -16,9 +16,9 @@ if [[ -z "${SLACK_BOT_TOKEN:-}" ]]; then
   exit 1
 fi
 
-workspace_id="${SLACRAWL_WORKSPACE_ID:-T7HML1FG9}"
-channel_id="${SLACRAWL_CHANNEL_ID:-C06DHKFEHGR}"
-since_ts="${SLACRAWL_SINCE_TS:-1772800000.000000}"
+workspace_id="${SLACRAWL_WORKSPACE_ID:?SLACRAWL_WORKSPACE_ID is required}"
+channel_id="${SLACRAWL_CHANNEL_ID:?SLACRAWL_CHANNEL_ID is required}"
+since_ts="${SLACRAWL_SINCE_TS:?SLACRAWL_SINCE_TS is required}"
 
 go test ./...
 go build -o "$tmpdir/slacrawl" ./cmd/slacrawl


### PR DESCRIPTION
## Summary

- remove workspace-specific defaults from the live validation script
- require callers to provide the workspace, channel, and lower-bound timestamp explicitly
- document the maintenance change in the unreleased changelog

## Verification

- `bash -n scripts/validate-local.sh`
- missing-scope failure smoke with a redacted dummy token
- `GOWORK=off go test -count=1 ./...`