### PR TITLE
chore(ci): refresh validation tool pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           git diff --exit-code -- go.mod go.sum
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
 
       - name: Run govulncheck
         run: '"$(go env GOPATH)/bin/govulncheck" ./...'
@@ -68,7 +68,7 @@ jobs:
         run: go vet ./...
 
       - name: Install deadcode
-        run: go install golang.org/x/tools/cmd/deadcode@v0.45.0
+        run: go install golang.org/x/tools/cmd/deadcode@v0.48.0
 
       - name: Deadcode
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Require explicit workspace, channel, and timestamp scope for live local
   validation instead of embedding workspace-specific defaults.
+- Updated govulncheck to 1.6.0 and deadcode to 0.48.0 across local and CI validation.
 - Standardized the Makefile's build, check, snapshot, and fail-closed release targets across the crawler repositories.
 - Refreshed terminal detection and Unicode display-width dependencies.
 - Updated CrawlKit to 0.14.4, SQLite to 1.55.0, `golang.org/x/net` to 0.57.0, and replaced the retracted libc 1.74.3 with 1.74.4.

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,11 @@ fmt-check:
 
 lint:
 	GOWORK=off go vet ./...
-	GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
+	GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 	@set -e; \
 	output_file="$$(mktemp)"; \
 	trap 'rm -f "$$output_file"' EXIT; \
-	if ! GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$$output_file"; then cat "$$output_file"; exit 1; fi; \
+	if ! GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.48.0 -test ./... > "$$output_file"; then cat "$$output_file"; exit 1; fi; \
 	if [ -s "$$output_file" ]; then cat "$$output_file"; exit 1; fi
 
 tidy-check:


### PR DESCRIPTION
## What Problem This Solves

The local and CI validation paths were pinned to older govulncheck and deadcode releases, leaving dependency and static-analysis checks behind the current stable toolchain.

## Why This Change Was Made

Update both validation paths to the latest published stable module versions: `golang.org/x/vuln` 1.6.0 and `golang.org/x/tools` 0.48.0. The requested govulncheck 1.6.1 version is not published, so this deliberately uses the current module release instead.

## User Impact

There is no runtime behavior change. Contributors and CI receive current vulnerability and dead-code analysis with identical local and hosted pins.

## Evidence

- `go mod verify`
- `go mod tidy -diff`
- `go vet ./...`
- `go test -count=1 ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.48.0 -test ./...`
- `make check` passed through lint, tests, and CLI smoke; the snapshot stage could not run because GoReleaser is not installed in the local environment.
