### PR TITLE
fix(cli): allow larger user and channel listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Made command help independent of local configuration and consistently successful for `--help` and `-h`.
+- Added configurable positive row limits to `users` and `channels` while preserving the existing 100-row default.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ Choose the path that matches your setup:
 - `messages` lists stored messages with filters
 - `mentions` lists structured mention records
 - `sql` runs read-only SQL against the local database
-- `users` lists synced users
-- `channels` lists synced channels
+- `users` lists synced users, with `--limit <n>` overriding the 100-row default
+- `channels` lists synced channels, with `--limit <n>` overriding the 100-row default
 - `status` prints workspace and sync status
 - `metadata --json`, `status --json`, and `doctor --json` expose crawlkit
   control/status payloads for launchers, automation, and CI
@@ -586,7 +586,8 @@ go run ./cmd/slacrawl sync --source bot
 go run ./cmd/slacrawl status
 go run ./cmd/slacrawl report
 go run ./cmd/slacrawl digest --since 7d
-go run ./cmd/slacrawl channels
+go run ./cmd/slacrawl channels --limit 200
+go run ./cmd/slacrawl users --limit 200
 go run ./cmd/slacrawl messages --channel C12345678 --limit 20
 go run ./cmd/slacrawl mentions --limit 20
 go run ./cmd/slacrawl sql 'select channel_id, count(*) as messages from messages group by channel_id order by messages desc limit 10;'

--- a/SPEC.md
+++ b/SPEC.md
@@ -217,6 +217,20 @@ Must include:
 - sync metadata such as first / last timestamps
 - configured git-share repo plus last import / stale state when share mode is enabled
 
+### `users`
+
+Purpose:
+
+- list synced users, optionally filtered by workspace and a positional text query
+- return up to 100 rows by default, with `--limit <n>` accepting positive overrides
+
+### `channels`
+
+Purpose:
+
+- list synced channels, optionally filtered by workspace, channel kind, and a positional text query
+- return up to 100 rows by default, with `--limit <n>` accepting positive overrides
+
 ### `report`
 
 Purpose:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,7 @@ Behavior:
 - `sync --source bot` without `--workspace` runs against every configured `[[workspaces]]` entry
 - `tail` without `--workspace` starts one live tail per configured `[[workspaces]]` entry
 - `search`, `messages`, `mentions`, `users`, and `channels` accept `--workspace` to filter the shared SQLite database
+- `users` and `channels` return 100 rows by default and accept a positive `--limit` override
 - if `[[workspaces]]` is empty, the legacy top-level `[slack.*]` token config is used
 
 ## Visibility Boundaries

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1278,11 +1278,15 @@ func (a *App) runUsers(ctx context.Context, configPath string, args []string, fo
 	}
 	fs := flag.NewFlagSet("users", flag.ContinueOnError)
 	workspaceID := fs.String("workspace", "", "workspace id")
+	limit := fs.Int("limit", 100, "row limit")
 	if err := a.parseCommandFlags(fs, args); err != nil {
 		return err
 	}
 	if configErr != nil {
 		return configErr
+	}
+	if *limit <= 0 {
+		return errors.New("users --limit must be positive")
 	}
 	query := ""
 	if fs.NArg() > 0 {
@@ -1293,7 +1297,7 @@ func (a *App) runUsers(ctx context.Context, configPath string, args []string, fo
 		return err
 	}
 	defer func() { _ = st.Close() }()
-	results, err := st.Users(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, 100)
+	results, err := st.Users(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, *limit)
 	if err != nil {
 		return err
 	}
@@ -1308,11 +1312,15 @@ func (a *App) runChannels(ctx context.Context, configPath string, args []string,
 	fs := flag.NewFlagSet("channels", flag.ContinueOnError)
 	workspaceID := fs.String("workspace", "", "workspace id")
 	kind := fs.String("kind", "", "channel kind")
+	limit := fs.Int("limit", 100, "row limit")
 	if err := a.parseCommandFlags(fs, args); err != nil {
 		return err
 	}
 	if configErr != nil {
 		return configErr
+	}
+	if *limit <= 0 {
+		return errors.New("channels --limit must be positive")
 	}
 	resolvedKind := normalizeChannelKind(*kind)
 	if resolvedKind != "" && !isValidChannelKind(resolvedKind) {
@@ -1327,7 +1335,7 @@ func (a *App) runChannels(ctx context.Context, configPath string, args []string,
 		return err
 	}
 	defer func() { _ = st.Close() }()
-	results, err := st.ChannelsByKind(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, resolvedKind, 100)
+	results, err := st.ChannelsByKind(ctx, coalesce(*workspaceID, cfg.WorkspaceID), query, resolvedKind, *limit)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -503,6 +503,68 @@ func TestWorkspaceFilteredReadCommands(t *testing.T) {
 	require.ErrorContains(t, err, "invalid channel kind")
 }
 
+func TestUsersAndChannelsLimits(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	dbPath := filepath.Join(tmp, "slacrawl.db")
+
+	cfg := config.Default()
+	cfg.DBPath = dbPath
+	require.NoError(t, cfg.Save(configPath))
+
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	now := mustTime(t, "2026-03-08T18:20:43Z")
+	require.NoError(t, st.UpsertWorkspace(context.Background(), store.Workspace{
+		ID:        "T1",
+		Name:      "one",
+		RawJSON:   "{}",
+		UpdatedAt: now,
+	}))
+	for i := range 105 {
+		suffix := fmt.Sprintf("%03d", i)
+		require.NoError(t, st.UpsertUser(context.Background(), store.User{
+			ID:          "U" + suffix,
+			WorkspaceID: "T1",
+			Name:        "user-" + suffix,
+			RawJSON:     "{}",
+			UpdatedAt:   now,
+		}))
+		require.NoError(t, st.UpsertChannel(context.Background(), store.Channel{
+			ID:          "C" + suffix,
+			WorkspaceID: "T1",
+			Name:        "channel-" + suffix,
+			Kind:        "public_channel",
+			RawJSON:     "{}",
+			UpdatedAt:   now,
+		}))
+	}
+	require.NoError(t, st.Close())
+
+	for _, command := range []string{"users", "channels"} {
+		t.Run(command, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			app := &App{Stdout: &stdout, Stderr: &stderr}
+
+			require.NoError(t, app.Run(context.Background(), []string{"--config", configPath, "--json", command}))
+			var rows []map[string]any
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &rows))
+			require.Len(t, rows, 100)
+			require.Empty(t, stderr.String())
+
+			stdout.Reset()
+			require.NoError(t, app.Run(context.Background(), []string{"--config", configPath, "--json", command, "--limit", "105"}))
+			rows = nil
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &rows))
+			require.Len(t, rows, 105)
+
+			stdout.Reset()
+			err := app.Run(context.Background(), []string{"--config", configPath, "--json", command, "--limit", "0"})
+			require.ErrorContains(t, err, command+" --limit must be positive")
+		})
+	}
+}
+
 func TestHelpIncludesBannerAndUsage(t *testing.T) {
 	var stdout bytes.Buffer
 	app := &App{
@@ -828,6 +890,8 @@ func TestCompletionBashOutput(t *testing.T) {
 	require.Contains(t, out, "--max-bytes")
 	require.Contains(t, out, "--desktop-every --workspace")
 	require.Contains(t, out, "--keep-message-events")
+	require.Contains(t, out, "--workspace --limit --help")
+	require.Contains(t, out, "--workspace --kind --limit --help")
 }
 
 func TestCompletionZshOutput(t *testing.T) {
@@ -859,6 +923,7 @@ func TestCompletionZshOutput(t *testing.T) {
 	require.Contains(t, out, "--ref[historical Git ref to import; requires --restore]")
 	require.Contains(t, out, "--restore[exactly replace snapshot tables instead of merging]")
 	require.Contains(t, out, "--workspace[workspace id]")
+	require.Contains(t, out, "'--limit[row limit]:limit:'")
 }
 
 func TestReportIncludesArchiveAndShareState(t *testing.T) {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -217,10 +217,10 @@ _slacrawl()
             COMPREPLY=( $(compgen -W "--workspace --target --limit --help -h ${global_flags}" -- "${cur}") )
             ;;
         users)
-            COMPREPLY=( $(compgen -W "--workspace --help -h ${global_flags}" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "--workspace --limit --help -h ${global_flags}" -- "${cur}") )
             ;;
 		channels)
-			COMPREPLY=( $(compgen -W "--workspace --kind --help -h ${global_flags}" -- "${cur}") )
+			COMPREPLY=( $(compgen -W "--workspace --kind --limit --help -h ${global_flags}" -- "${cur}") )
 			;;
         completion)
             COMPREPLY=( $(compgen -W "bash zsh --help -h ${global_flags}" -- "${cur}") )
@@ -348,10 +348,10 @@ _slacrawl() {
           _arguments '--workspace[workspace id]:workspace id:' '--target[target id or label]:target:' '--limit[row limit]:limit:'
           ;;
         users)
-          _arguments '--workspace[workspace id]:workspace id:'
+          _arguments '--workspace[workspace id]:workspace id:' '--limit[row limit]:limit:'
           ;;
 		channels)
-		  _arguments '--workspace[workspace id]:workspace id:' '--kind[channel kind]:kind:(im mpim public_channel private_channel)'
+		  _arguments '--workspace[workspace id]:workspace id:' '--kind[channel kind]:kind:(im mpim public_channel private_channel)' '--limit[row limit]:limit:'
 		  ;;
         completion)
           _values 'shell' bash zsh


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting larger Slack archives could only retrieve the first 100 users or channels, with no way to request more rows.

## Why This Change Was Made

Adds a positive `--limit` option to `users` and `channels` while preserving the existing 100-row default. Shell completions, command documentation, the specification, and release notes now describe the option.

## User Impact

Operators can request larger user and channel listings without changing existing scripts or default JSON output.

## Evidence

- Added focused CLI coverage proving the 100-row default, a larger override, and rejection of non-positive limits.
- Verified both commands against a redacted temporary archive larger than the default; default and overridden row counts matched expectations with clean stderr.
- `go mod verify`, `go mod tidy -diff`, `go vet ./...`, `govulncheck`, dead-code checks, the full Go test suite, and smoke tests passed.
- GoReleaser v2.17.1 snapshot passed for Darwin/Linux on amd64/arm64, including archives, checksums, DEB, and RPM artifacts.
