### PR TITLE
fix(ci): restore AWS Crabbox provisioning

### DIFF
--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -24,7 +24,7 @@ actions:
   ephemeral: true
 aws:
   region: eu-west-1
-  rootGB: 160
+  rootGB: 400
 sync:
   delete: true
   checksum: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Maintenance
 
+- Increased the AWS Crabbox root volume to match the current developer image
+  snapshot size.
 - Require explicit workspace, channel, and timestamp scope for live local
   validation instead of embedding workspace-specific defaults.
 - Updated govulncheck to 1.6.0 and deadcode to 0.48.0 across local and CI validation.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running AWS Crabbox validation would fail before provisioning because the configured root volume was smaller than the current developer-image snapshot.

## Why This Change Was Made

Raises the Slacrawl AWS Crabbox root volume from 160 GB to 400 GB, matching the minimum size required by the current snapshot. No runtime or product behavior changes.

## User Impact

Maintainers can provision the repository's direct AWS Crabbox profile and run remote Linux validation again.

## Evidence

- Before: AWS rejected provisioning with `InvalidBlockDeviceMapping` because 160 GB was smaller than the snapshot requirement.
- After: direct AWS Crabbox provisioning and Actions hydration succeeded on lease `cbx_c938c906491c`.
- Hydration run: https://github.com/openclaw/slacrawl/actions/runs/30756552705
- Remote run `run_35d61c0242f3` passed `go mod verify`, tidy diff, `go vet ./...`, `go test -count=1 ./...`, versioned build, and metadata JSON smoke.