### PR TITLE
fix(ci): provision Node for Crabbox decoding tests

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - Increased the AWS Crabbox root volume to match the current developer image
   snapshot size.
+- Provisioned Node.js 24 in Crabbox hydration and made Node-dependent Redux
+  decoder tests declare their runtime prerequisite.
 - Require explicit workspace, channel, and timestamp scope for live local
   validation instead of embedding workspace-specific defaults.
 - Updated govulncheck to 1.6.0 and deadcode to 0.48.0 across local and CI validation.

--- a/internal/slackdesktop/redux_decode_test.go
+++ b/internal/slackdesktop/redux_decode_test.go
@@ -306,6 +306,7 @@ func TestExtractIndexedDBStatesNodeUnavailable(t *testing.T) {
 }
 
 func TestInspectReportsAllCandidateFailureWithoutError(t *testing.T) {
+	requireNode(t)
 	root := t.TempDir()
 	writeBlob(t, root, "truncated", []byte{0xff, v8WireFormatV15, 0x6f})
 
@@ -321,6 +322,7 @@ func TestInspectReportsAllCandidateFailureWithoutError(t *testing.T) {
 }
 
 func TestIngestFailsWhenEveryCandidateFails(t *testing.T) {
+	requireNode(t)
 	root := t.TempDir()
 	writeBlob(t, root, "truncated", []byte{0xff, v8WireFormatV15, 0x6f})
 


### PR DESCRIPTION
## What Problem This Solves

Native arm64 Crabbox validation failed because the hydrated runner had Go but not the Node.js runtime required by Slack Desktop Redux decoding. Two Node-dependent tests also assumed Node was installed instead of declaring that prerequisite.

## Why This Change Was Made

Pins Node.js 24 in the Crabbox hydration workflow and applies the existing `requireNode` helper to the two decoder-failure tests. This keeps the tests deterministic on minimal machines while ensuring hydrated Crabbox hosts exercise the decoder.

## User Impact

Crabbox validation now matches Slacrawl's wiretap runtime requirements on both amd64 and arm64. Developers without Node can still run the Go suite; only the explicitly Node-dependent checks skip.

## Evidence

- Focused decoder-failure tests pass with Node available.
- The same compiled tests skip cleanly with an empty `PATH`.
- `GOWORK=off go test -count=1 ./...` passes.
- Workflow YAML parses successfully.
- Native AWS arm64 reproduction: the pre-fix hydrated run failed only the two undeclared Node-dependent tests.
