### PR TITLE
fix(api): use 60s default HTTP client when none is injected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Use a 60-second default HTTP client when none is injected so stalled Slack API peers cannot hang the CLI forever. Thanks @SebTardif.
+
 ### Documentation
 
 - Rewrote the README around installation and a verified quick start, with detailed command and Git archive references moved to `docs/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Added a 60-second default Slack API timeout so stalled requests cannot hang the CLI indefinitely. Thanks @SebTardif.
+
 ### Documentation
 
 - Rewrote the README around installation and a verified quick start, with detailed command and Git archive references moved to `docs/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixes
-
-- Use a 60-second default HTTP client when none is injected so stalled Slack API peers cannot hang the CLI forever. Thanks @SebTardif.
-
 ### Documentation
 
 - Rewrote the README around installation and a verified quick start, with detailed command and Git archive references moved to `docs/`.

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -29,7 +29,14 @@ import (
 const (
 	SourceUser = "api-user"
 	SourceBot  = "api-bot"
+
+	// defaultHTTPTimeout bounds Slack API HTTP when NewWithOptions gets a nil client.
+	defaultHTTPTimeout = 60 * time.Second
 )
+
+func defaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultHTTPTimeout}
+}
 
 type Diagnostics struct {
 	BotConfigured     bool   `json:"bot_configured"`
@@ -76,11 +83,14 @@ func New(tokens config.Tokens) *Client {
 }
 
 func NewWithOptions(tokens config.Tokens, apiURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = defaultHTTPClient()
+	}
 	client := &Client{
 		tokens:     tokens,
 		appToken:   tokens.App,
 		apiURL:     slack.APIURL,
-		httpClient: http.DefaultClient,
+		httpClient: httpClient,
 		includeDMs: tokens.User != "",
 		sleep:      sleepContext,
 		now:        func() time.Time { return time.Now().UTC() },
@@ -88,18 +98,13 @@ func NewWithOptions(tokens config.Tokens, apiURL string, httpClient *http.Client
 	if apiURL != "" {
 		client.apiURL = apiURL
 	}
-	if httpClient != nil {
-		client.httpClient = httpClient
-	}
 
 	buildOptions := func(includeAppToken bool) []slack.Option {
 		var options []slack.Option
 		if apiURL != "" {
 			options = append(options, slack.OptionAPIURL(apiURL))
 		}
-		if httpClient != nil {
-			options = append(options, slack.OptionHTTPClient(httpClient))
-		}
+		options = append(options, slack.OptionHTTPClient(httpClient))
 		if includeAppToken && tokens.App != "" {
 			options = append(options, slack.OptionAppLevelToken(tokens.App))
 		}

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -1695,3 +1695,23 @@ func testProgressLogger(out *bytes.Buffer) *slog.Logger {
 		},
 	}))
 }
+
+func TestNewWithOptionsDefaultsTimedHTTPClient(t *testing.T) {
+	client := NewWithOptions(config.Tokens{Bot: "xoxb-test"}, "", nil)
+	if client.httpClient == nil {
+		t.Fatal("httpClient is nil")
+	}
+	if client.httpClient == http.DefaultClient {
+		t.Fatal("httpClient must not be http.DefaultClient")
+	}
+	if client.httpClient.Timeout != defaultHTTPTimeout {
+		t.Fatalf("httpClient.Timeout = %s, want %s", client.httpClient.Timeout, defaultHTTPTimeout)
+	}
+}
+
+func TestNewUsesDefaultHTTPClient(t *testing.T) {
+	client := New(config.Tokens{Bot: "xoxb-test"})
+	if client.httpClient.Timeout != defaultHTTPTimeout {
+		t.Fatalf("New() httpClient.Timeout = %s, want %s", client.httpClient.Timeout, defaultHTTPTimeout)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`slackapi.New` / `NewWithOptions` used `http.DefaultClient` when the caller passed a nil HTTP client, and only forwarded a custom client into slack-go when non-nil. `http.DefaultClient` has no overall `Timeout`, so a stalled Slack API peer can hang CLI sync/doctor/tail forever when the ambient context has no deadline.

## Evidence

- Production path: `slackapi.New(tokens)` and `NewWithOptions(..., nil)` from CLI/syncer.
- Before: `httpClient: http.DefaultClient` and `OptionHTTPClient` only when the caller supplied a client.
- After: nil → `defaultHTTPClient()` (60s Timeout) used for both the package's `Do` path and `slack.OptionHTTPClient`.
- Explicit non-nil clients (tests with `httptest.Server.Client()`) are unchanged.

## Real behavior proof

**Environment:** Go 1.26, macOS; branch `fix/default-http-client-timeout`

**Setup:** none

**Command:**
```bash
# RED: defaultHTTPClient returns http.DefaultClient
go test ./internal/slackapi/ -count=1 -run 'TestNewWithOptionsDefaultsTimed|TestNewUsesDefault'
# GREEN:
go test ./internal/slackapi/ -count=1 -run 'TestNewWithOptionsDefaultsTimed|TestNewUsesDefault'
go test ./internal/slackapi/ ./internal/cli/ -count=1
```

**Output:**
```
# RED
--- FAIL: TestNewWithOptionsDefaultsTimedHTTPClient
    httpClient must not be http.DefaultClient
# GREEN
ok  github.com/openclaw/slacrawl/internal/slackapi
ok  github.com/openclaw/slacrawl/internal/cli
```

**Why this proves it:** Unit tests assert `New`/`NewWithOptions(nil)` install a non-DefaultClient with Timeout 60s. Package and CLI tests stay green.

**Limits:** Does not hit live Slack API; bounds client construction and unit/integration tests only.

## Test plan

- [x] Red/green on default client timeout
- [x] `go test ./internal/slackapi/ ./internal/cli/`

## Review follow-up (changelog)

Claw P3: removed the release-owned Unreleased changelog entry. Functional default HTTP client change unchanged.
