### PR TITLE
chore(release): prepare v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.1 - 2026-08-02
 
 ### Fixes
 


### PR DESCRIPTION
## Summary

Close the verified Unreleased section as `v0.8.1` dated 2026-08-02 before dispatching the repository's unified release workflow.

## Release gate

- non-parked issue and PR queue is zero
- patch release: bounded Slack API requests, documentation restructuring, and dependency maintenance
- `make check` passed, including all CI-equivalent gates and a four-platform GoReleaser snapshot
- Codex autoreview clean with no accepted/actionable findings

This PR contains only the frozen changelog heading change required by the documented release process.
