### PR TITLE
fix: skip cross-workspace channel collisions during bot sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Slack Connect shared channels no longer abort workspace syncs: when a channel already belongs to another workspace in the archive, the bot sync skips it with a warning and keeps syncing the remaining channels instead of failing the whole run.
+
 ## v0.8.1 - 2026-08-02
 
 ### Fixes

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -1151,6 +1151,33 @@ func normalizeChannelName(value string) string {
 	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(value), "#"))
 }
 
+// skipChannelCollision upserts the channel and reports whether it must be
+// skipped because another workspace already owns it. Slack Connect shared
+// channels legitimately appear under multiple workspaces, so a collision must
+// not abort the whole sync — the workspace that recorded the channel first
+// keeps it, and the channel is skipped here with a warning. Any other upsert
+// error is returned for the caller's fatal path.
+func (c *Client) skipChannelCollision(ctx context.Context, st *store.Store, workspaceID string, channel slack.Channel, now time.Time) (bool, error) {
+	err := st.UpsertChannel(ctx, toStoreChannel(workspaceID, channel, now))
+	if err == nil {
+		return false, nil
+	}
+	if store.IsWorkspaceCollision(err, "channel") {
+		logger := c.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("skipping channel owned by another workspace",
+			"workspace_id", workspaceID,
+			"channel_id", channel.ID,
+			"channel_name", channel.Name,
+			"err", err,
+		)
+		return true, nil
+	}
+	return false, err
+}
+
 func (c *Client) syncChannelsWithSource(ctx context.Context, st *store.Store, workspaceID string, channels []slack.Channel, opts SyncOptions, now time.Time, userRepliesAvailable bool, source channelSyncSource) error {
 	if len(channels) == 0 {
 		return nil
@@ -1178,9 +1205,13 @@ func (c *Client) syncChannelsWithSource(ctx context.Context, st *store.Store, wo
 	})
 	if workerCount == 1 {
 		for _, channel := range channels {
-			if err := st.UpsertChannel(ctx, toStoreChannel(workspaceID, channel, now)); err != nil {
+			skip, err := c.skipChannelCollision(ctx, st, workspaceID, channel, now)
+			if err != nil {
 				tracker.Finish(err)
 				return err
+			}
+			if skip {
+				continue
 			}
 			if err := c.syncChannelMessagesWithSource(ctx, st, workspaceID, channel, oldestByChannel[channel.ID], restoreRequested, now, userRepliesAvailable, source); err != nil {
 				tracker.Finish(err)
@@ -1201,13 +1232,17 @@ func (c *Client) syncChannelsWithSource(ctx context.Context, st *store.Store, wo
 	worker := func() {
 		defer wg.Done()
 		for channel := range workCh {
-			if err := st.UpsertChannel(ctx, toStoreChannel(workspaceID, channel, now)); err != nil {
+			skip, err := c.skipChannelCollision(ctx, st, workspaceID, channel, now)
+			if err != nil {
 				select {
 				case errCh <- err:
 				default:
 				}
 				cancel()
 				return
+			}
+			if skip {
+				continue
 			}
 			if err := c.syncChannelMessagesWithSource(ctx, st, workspaceID, channel, oldestByChannel[channel.ID], restoreRequested, now, userRepliesAvailable, source); err != nil {
 				select {

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -1624,6 +1624,38 @@ func TestExplicitSinceDoesNotScanRetainedThreadRoots(t *testing.T) {
 	require.Empty(t, rows)
 }
 
+func TestSyncSkipsChannelOwnedByAnotherWorkspace(t *testing.T) {
+	server := newSkipChannelSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot: "xoxb-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	now := time.Now().UTC()
+	// Slack Connect shared channels surface in multiple workspaces. Seed the
+	// channel as owned by a different workspace, the state a multi-workspace
+	// archive can legitimately reach; the sync for T123 must not abort.
+	require.NoError(t, st.UpsertWorkspace(context.Background(), store.Workspace{ID: "Tother", Name: "other", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(context.Background(), store.Channel{ID: "C111", WorkspaceID: "Tother", Name: "private-ish", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+
+	err := client.Sync(context.Background(), st, SyncOptions{})
+	require.NoError(t, err, "one cross-workspace channel must not abort the sync")
+
+	rows, err := st.Messages(context.Background(), "", "C222", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "other channels must still sync")
+	require.Equal(t, "accessible message", rows[0].Text)
+
+	owner, err := st.ChannelWorkspaceID(context.Background(), "C111")
+	require.NoError(t, err)
+	require.Equal(t, "Tother", owner, "the original workspace keeps the shared channel")
+}
+
 func TestSyncSkipsExcludedChannels(t *testing.T) {
 	server := newExcludeChannelSlackServer(t)
 	defer server.Close()


### PR DESCRIPTION
## Problem

`slacrawl sync` (bot source) aborts the entire run as soon as it meets a channel that already belongs to a different workspace in the archive:

```
error: channel "C0HKT7BFH" already belongs to workspace "T0ASS4K1HT5", not "T0BQTNSUF"
```

Slack Connect shared channels legitimately surface in multiple workspaces. Whichever workspace records the channel first "owns" it in the single-workspace `channels` table, and every later sync of the other workspace then hits `WorkspaceCollisionError` and dies — on a real 11-workspace archive this killed a 20,304-channel sync at channel 0.

## Fix

The store's collision guard stays intact — it's the right integrity check for message/batch writes, and the desktop import path (`redux.go`) already skips the same collision class. This change demotes the collision only at the API sync boundary: `syncChannelsWithSource` now skips a channel owned by another workspace with a warning and continues, in both the serial and concurrent worker paths. Any other upsert error stays fatal.

## Test

- New `TestSyncSkipsChannelOwnedByAnotherWorkspace`: seeds the colliding channel under a different workspace, runs a full bot sync against the mock server, and asserts the sync succeeds, unaffected channels still sync, and the original workspace keeps ownership.
- Full `make check` green (tidy/fmt/lint/test/smoke/snapshot).
- Codex autoreview clean, no accepted/actionable findings.
