### PR TITLE
fix: triage pass — cross-workspace collisions, attachment loss, and text width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
 - `search` and `messages` no longer emit invalid UTF-8 when a message containing emoji or CJK is truncated, and wide characters now count as their display width rather than their byte length.
 - Table output stays aligned when cells are empty, `null`, boolean, or non-ASCII; column widths were measured on the ANSI-colorized bytes.
 - Cached attachments with fully non-Latin filenames keep their extension, so a published `media/` tree serves them with the right content type.
+- Messages that merely quote mention syntax (`&lt;@U…&gt;` in escaped form) are no longer recorded as real mentions in the archive or the `mentions` command.
+- Ctrl-C and SIGTERM now cancel long-running commands cleanly instead of hard-killing the process mid-sync.
+- `slacrawl tail` survives transient network failures during its periodic repair sweep instead of exiting, its websocket now honors cancellation, and a failing workspace reports its real error instead of an occasional bare `context canceled`.
+- `sync --since` accepts RFC3339 timestamps on every backend as documented; previously only the MCP source normalized them and junk values were passed through silently.
+- `analytics trends --weeks` rejects absurd values that previously attempted multi-gigabyte allocations.
+- MCP stdio responses written just before server exit are no longer occasionally reported as decode errors, and provider subprocesses that die at startup now surface their stderr instead of a bare broken-pipe error.
+
+### Performance
+
+- Thread synchronization no longer scans whole channels per message: a new schema v7 index makes the thread-root lookup O(log n); a 50k-message channel dropped from minutes to milliseconds. Message-event deletes and rendered mention replacement also stopped doing redundant work.
 
 ## v0.8.1 - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Fixes
 
 - Slack Connect shared channels no longer abort workspace syncs: when a channel already belongs to another workspace in the archive, the bot sync skips it with a warning and keeps syncing the remaining channels instead of failing the whole run.
+- Cross-workspace collisions are now skipped for users and messages too, not just channels: an Enterprise Grid user shared between workspaces no longer aborts the sync after every message has already committed, and a shared-channel message no longer terminates `slacrawl tail`.
+- `files fetch` no longer discards every attachment when `--max-bytes`/`sync.max_file_bytes` is set to the maximum int64 value: the over-limit probe used to overflow negative and record each file as a fetched empty file.
+- `purge` and `publish` now work with a media cache whose root is a symlink, a common setup for large attachment caches on a separate volume. The fetch path always wrote through such a symlink while every read path rejected it, so cleanup failed permanently; symlinks inside the cache tree are still refused.
+- `publish` now fails loudly on an unreadable media cache instead of emitting a manifest that claims the archive has no attachments, which silently wiped media for subscribers on their next import.
+- `search` and `messages` no longer emit invalid UTF-8 when a message containing emoji or CJK is truncated, and wide characters now count as their display width rather than their byte length.
+- Table output stays aligned when cells are empty, `null`, boolean, or non-ASCII; column widths were measured on the ANSI-colorized bytes.
+- Cached attachments with fully non-Latin filenames keep their extension, so a published `media/` tree serves them with the right content type.
 
 ## v0.8.1 - 2026-08-02
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/slacrawl ./cmd/slacrawl
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w -X github.com/openclaw/slacrawl/internal/cli.version=${VERSION}" -o /out/slacrawl ./cmd/slacrawl
 
 FROM alpine:${ALPINE_VERSION}
 RUN apk add --no-cache ca-certificates git nodejs npm openssh-client tzdata \

--- a/cmd/slacrawl/main.go
+++ b/cmd/slacrawl/main.go
@@ -2,16 +2,27 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/openclaw/slacrawl/internal/cli"
 )
 
 func main() {
-	ctx := context.Background()
+	// Ctrl-C and SIGTERM cancel the context so long-running commands (sync,
+	// tail, watch) unwind through their normal cleanup paths instead of being
+	// hard-killed; a second signal falls through to the default handler.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	app := cli.New()
 	if err := app.Run(ctx, os.Args[1:]); err != nil {
+		stop()
+		if errors.Is(err, context.Canceled) {
+			os.Exit(130)
+		}
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/golang/snappy v1.0.0
+	github.com/mattn/go-runewidth v0.0.27
 	github.com/openclaw/crawlkit v0.14.5
 	github.com/slack-go/slack v0.27.0
 	github.com/stretchr/testify v1.11.1
@@ -32,7 +33,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.27 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect

--- a/internal/cli/analytics.go
+++ b/internal/cli/analytics.go
@@ -108,6 +108,13 @@ func (a *App) runAnalyticsTrends(ctx context.Context, configPath string, args []
 	if *weeks < 0 {
 		return errors.New("--weeks must be zero or greater")
 	}
+	// Every channel row materializes one WeeklyCount per week, so an absurd
+	// count is an OOM, not a long report. A decade of weekly buckets is more
+	// than any digest needs.
+	const maxTrendWeeks = 520
+	if *weeks > maxTrendWeeks {
+		return fmt.Errorf("--weeks must be %d or fewer", maxTrendWeeks)
+	}
 	outputFormat, err := resolveOutputFormat(*formatFlag, *jsonOut)
 	if err != nil {
 		return err

--- a/internal/cli/analytics_test.go
+++ b/internal/cli/analytics_test.go
@@ -131,6 +131,16 @@ func TestAnalyticsQuietCommand(t *testing.T) {
 	require.False(t, ids["C3"])
 }
 
+func TestAnalyticsTrendsRejectsAbsurdWeeks(t *testing.T) {
+	ctx := context.Background()
+	app, configPath, _, _ := setupAnalyticsApp(t)
+
+	// Each channel row materializes one bucket per week, so an unbounded
+	// count was a multi-gigabyte allocation, not a long report.
+	err := app.Run(ctx, []string{"--config", configPath, "analytics", "trends", "--weeks", "2000000000"})
+	require.ErrorContains(t, err, "--weeks must be 520 or fewer")
+}
+
 func TestAnalyticsTrendsCommand(t *testing.T) {
 	ctx := context.Background()
 	app, configPath, dbPath, stdout := setupAnalyticsApp(t)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -547,6 +547,10 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	}
 	workspaceSet := flagWasSet(fs, "workspace")
 	resolvedWorkspaceID := resolveSyncWorkspaceID(*workspaceID, workspaceSet)
+	normalizedSince, err := normalizeSinceTimestamp(*since)
+	if err != nil {
+		return err
+	}
 	runOptions := syncer.Options{
 		Source:       resolvedSource,
 		WorkspaceID:  resolvedWorkspaceID,
@@ -556,7 +560,7 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 			cfg.Sync.ExcludeChannels,
 			csv(*excludeChannels),
 		),
-		Since:       *since,
+		Since:       normalizedSince,
 		Full:        *full,
 		LatestOnly:  *latestOnly,
 		Limit:       *limit,
@@ -1608,6 +1612,24 @@ func mergeStringSlices(values ...[]string) []string {
 	return out
 }
 
+// normalizeSinceTimestamp converts the documented "slack ts or RFC3339" flag
+// contract into a slack ts for every backend. Only the MCP path used to
+// normalize RFC3339, so the API and desktop paths silently passed the raw
+// string through to Slack's `oldest` parameter.
+func normalizeSinceTimestamp(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	if _, err := strconv.ParseFloat(value, 64); err == nil {
+		return value, nil
+	}
+	if parsed, err := time.Parse(time.RFC3339, value); err == nil {
+		return fmt.Sprintf("%d.%06d", parsed.Unix(), parsed.Nanosecond()/1000), nil
+	}
+	return "", fmt.Errorf("--since must be a slack timestamp or an RFC3339 time, got %q", value)
+}
+
 func flagWasSet(fs *flag.FlagSet, name string) bool {
 	wasSet := false
 	fs.Visit(func(candidate *flag.Flag) {
@@ -1785,8 +1807,17 @@ func (a *App) runTailTargets(ctx context.Context, st *store.Store, cfg config.Co
 	case err := <-errCh:
 		return err
 	case <-done:
-		return ctx.Err()
 	case <-ctx.Done():
+		<-done
+	}
+	// A failing tail sends its error and then cancels the others, so by the
+	// time done closes, errCh and ctx.Done() are both ready and a bare select
+	// would pick randomly — returning "context canceled" instead of the real
+	// error for a measurable fraction of failures. Drain the error first.
+	select {
+	case err := <-errCh:
+		return err
+	default:
 		return ctx.Err()
 	}
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1361,3 +1361,22 @@ func cliSlackForm(r *http.Request) url.Values {
 	_ = r.ParseForm()
 	return r.Form
 }
+
+func TestNormalizeSinceTimestamp(t *testing.T) {
+	// The --since contract is "slack ts or RFC3339", but only the MCP backend
+	// normalized RFC3339; the API path passed it raw to Slack's oldest param.
+	normalized, err := normalizeSinceTimestamp("2026-08-01T00:00:00Z")
+	require.NoError(t, err)
+	require.Equal(t, "1785542400.000000", normalized)
+
+	normalized, err = normalizeSinceTimestamp("1710000000.000100")
+	require.NoError(t, err)
+	require.Equal(t, "1710000000.000100", normalized)
+
+	normalized, err = normalizeSinceTimestamp("  ")
+	require.NoError(t, err)
+	require.Empty(t, normalized)
+
+	_, err = normalizeSinceTimestamp("7d")
+	require.ErrorContains(t, err, "--since must be a slack timestamp or an RFC3339 time")
+}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openclaw/slacrawl/internal/config"
 	"github.com/openclaw/slacrawl/internal/importer"
 	"github.com/openclaw/slacrawl/internal/search"
+	"github.com/openclaw/slacrawl/internal/slackapi"
 	"github.com/openclaw/slacrawl/internal/store"
 )
 
@@ -160,7 +161,7 @@ func runImportExecution(ctx context.Context, st *store.Store, ex *importer.Expor
 			return ImportReport{}, nil, err
 		}
 		for _, user := range users {
-			if err := st.UpsertUser(ctx, toStoreUser(workspaceID, user, now)); err != nil {
+			if err := st.UpsertUser(ctx, slackapi.ToStoreUser(workspaceID, user, now)); err != nil {
 				return ImportReport{}, nil, err
 			}
 		}
@@ -314,21 +315,6 @@ where workspace_id = ? and channel_id = ? and ts = ?
 		return 0, "", false, err
 	}
 	return rank, source, true, nil
-}
-
-func toStoreUser(workspaceID string, user slack.User, now time.Time) store.User {
-	return store.User{
-		ID:          user.ID,
-		WorkspaceID: workspaceID,
-		Name:        user.Name,
-		RealName:    user.RealName,
-		DisplayName: user.Profile.DisplayName,
-		Title:       user.Profile.Title,
-		IsBot:       user.IsBot,
-		IsDeleted:   user.Deleted,
-		RawJSON:     store.MarshalRaw(user),
-		UpdatedAt:   now,
-	}
 }
 
 func toStoreChannel(workspaceID string, channel importer.ChannelInfo, now time.Time) store.Channel {

--- a/internal/cli/purge_test.go
+++ b/internal/cli/purge_test.go
@@ -368,7 +368,13 @@ func TestPurgeCommandReportsPostCommitCleanupFailure(t *testing.T) {
 	cfg.CacheDir = cacheDir
 	require.NoError(t, cfg.Save(configPath))
 	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
-	require.NoError(t, os.Symlink(t.TempDir(), filepath.Join(cacheDir, "media")))
+	// A media root symlinked to a directory is a supported setup, so it no
+	// longer fails cleanup. Point it at a regular file instead: that is a
+	// genuinely broken cache, and the purge must still report the failure
+	// after the database transaction has already committed.
+	brokenRoot := filepath.Join(dir, "not-a-directory")
+	require.NoError(t, os.WriteFile(brokenRoot, []byte("not a media root"), 0o600))
+	require.NoError(t, os.Symlink(brokenRoot, filepath.Join(cacheDir, "media")))
 
 	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 	oldTime := now.Add(-120 * 24 * time.Hour)
@@ -389,6 +395,46 @@ func TestPurgeCommandReportsPostCommitCleanupFailure(t *testing.T) {
 	var response purgeResponse
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &response))
 	require.False(t, response.DryRun)
+	require.Equal(t, int64(1), response.Messages)
+	require.Zero(t, purgeTestMessageCount(t, dbPath))
+}
+
+func TestPurgeCommandSucceedsWithSymlinkedMediaRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires additional privileges on Windows")
+	}
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "slacrawl.db")
+	cacheDir := filepath.Join(dir, "cache")
+	cfg := config.Default()
+	cfg.DBPath = dbPath
+	cfg.CacheDir = cacheDir
+	require.NoError(t, cfg.Save(configPath))
+	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+	// Attachment caches are routinely parked on another volume. files fetch
+	// has always written through such a symlink, but every read path rejected
+	// it, so purge failed permanently on a cache slacrawl itself filled.
+	require.NoError(t, os.Symlink(t.TempDir(), filepath.Join(cacheDir, "media")))
+
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	oldTime := now.Add(-120 * 24 * time.Hour)
+	st, err := store.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, st.UpsertMessage(context.Background(), store.Message{
+		WorkspaceID: "T1", ChannelID: "C1", TS: purgeTestSlackTS(oldTime),
+		Text: "old", NormalizedText: "old", SourceRank: 2, SourceName: "api-bot", RawJSON: "{}", UpdatedAt: oldTime,
+	}, nil))
+	require.NoError(t, st.Close())
+
+	var stdout bytes.Buffer
+	app := &App{Stdout: &stdout, Stderr: &stdout, now: func() time.Time { return now }}
+	require.NoError(t, app.Run(context.Background(), []string{
+		"--config", configPath, "--json", "purge", "--older-than", "90d", "--force",
+	}), "a symlinked media root must not fail the purge")
+
+	var response purgeResponse
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &response))
 	require.Equal(t, int64(1), response.Messages)
 	require.Zero(t, purgeTestMessageCount(t, dbPath))
 }

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mattn/go-runewidth"
 )
 
 const banner = `
@@ -287,11 +289,14 @@ func renderTable(w *strings.Builder, rows []map[string]any, depth int) {
 	columns := orderedColumns(rows)
 	widths := make(map[string]int, len(columns))
 	for _, col := range columns {
-		widths[col] = len(humanize(col))
+		widths[col] = displayWidth(humanize(col))
 	}
 	for _, row := range rows {
 		for _, col := range columns {
-			if n := len(formatScalar(row[col])); n > widths[col] {
+			// Measure the uncolored text: formatScalar wraps empty, nil and
+			// bool cells in ANSI codes, whose bytes are invisible but would
+			// otherwise pad the column by roughly eight characters.
+			if n := displayWidth(plainScalar(row[col])); n > widths[col] {
 				widths[col] = n
 			}
 		}
@@ -305,7 +310,7 @@ func renderTable(w *strings.Builder, rows []map[string]any, depth int) {
 		header := humanize(col)
 		w.WriteString(prefixIfFirst(prefix, i))
 		w.WriteString(colorize(ansiDim, header))
-		w.WriteString(strings.Repeat(" ", widths[col]-len(header)))
+		w.WriteString(strings.Repeat(" ", widths[col]-displayWidth(header)))
 	}
 	w.WriteByte('\n')
 	for i, col := range columns {
@@ -322,9 +327,8 @@ func renderTable(w *strings.Builder, rows []map[string]any, depth int) {
 				w.WriteString("  ")
 			}
 			w.WriteString(prefixIfFirst(prefix, i))
-			cell := formatScalar(row[col])
-			w.WriteString(cell)
-			w.WriteString(strings.Repeat(" ", widths[col]-len(cell)))
+			w.WriteString(formatScalar(row[col]))
+			w.WriteString(strings.Repeat(" ", widths[col]-displayWidth(plainScalar(row[col]))))
 		}
 		w.WriteByte('\n')
 	}
@@ -1303,21 +1307,44 @@ func ternary(ok bool, a string, b string) string {
 	return b
 }
 
+// trimTo clips value to limit display columns. It counts width rather than
+// bytes so a message containing emoji or CJK is neither cut mid-rune into
+// invalid UTF-8 nor truncated far earlier than intended.
 func trimTo(value string, limit int) string {
-	if limit <= 0 || len(value) <= limit {
+	if limit <= 0 || displayWidth(value) <= limit {
 		return value
 	}
 	if limit <= 3 {
-		return value[:limit]
+		return truncateToWidth(value, limit)
 	}
-	return value[:limit-3] + "..."
+	return truncateToWidth(value, limit-3) + "..."
+}
+
+func truncateToWidth(value string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	used := 0
+	for i, r := range value {
+		w := runewidth.RuneWidth(r)
+		if used+w > width {
+			return value[:i]
+		}
+		used += w
+	}
+	return value
+}
+
+func displayWidth(value string) int {
+	return runewidth.StringWidth(value)
 }
 
 func padRight(value string, width int) string {
-	if len(value) >= width {
+	pad := width - displayWidth(value)
+	if pad <= 0 {
 		return value
 	}
-	return value + strings.Repeat(" ", width-len(value))
+	return value + strings.Repeat(" ", pad)
 }
 
 func colorize(code string, value string) string {

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 )
@@ -22,4 +25,45 @@ func TestNormalizeValueHandlesTimePointers(t *testing.T) {
 	row := value.(map[string]any)
 	require.Equal(t, now, row["at"])
 	require.Nil(t, row["missing"])
+}
+
+func TestTrimToKeepsValidUTF8(t *testing.T) {
+	// Byte slicing cut multi-byte runes in half, so search and messages output
+	// could emit text that is not valid UTF-8 at all.
+	trimmed := trimTo(strings.Repeat("a", 108)+"🎉🎉", 110)
+	require.True(t, utf8.ValidString(trimmed), "trimTo must cut on a rune boundary")
+	require.LessOrEqual(t, displayWidth(trimmed), 110)
+
+	require.Equal(t, "short", trimTo("short", 110))
+	require.True(t, utf8.ValidString(trimTo(strings.Repeat("世界", 200), 110)))
+}
+
+func TestRenderTableAlignsColorizedAndWideCells(t *testing.T) {
+	previous := ansiEnabled
+	ansiEnabled = true
+	defer func() { ansiEnabled = previous }()
+
+	var w strings.Builder
+	// The empty "title" cell gets wrapped in ANSI codes, whose bytes are
+	// invisible but used to widen the column; "Ålice" is 6 bytes across 5
+	// columns. Both used to shift every following column.
+	renderTable(&w, []map[string]any{
+		{"name": "Ålice", "title": ""},
+		{"name": "bob", "title": "eng"},
+	}, 0)
+
+	lines := strings.Split(strings.TrimRight(w.String(), "\n"), "\n")
+	require.Len(t, lines, 4)
+
+	gap := regexp.MustCompile(` {2,}`)
+	offsets := make([]int, 0, len(lines))
+	for _, line := range lines {
+		plain := strings.TrimRight(stripANSI(line), " ")
+		loc := gap.FindStringIndex(plain)
+		require.NotNil(t, loc, "line %q must have two columns", plain)
+		offsets = append(offsets, displayWidth(plain[:loc[1]]))
+	}
+	for i, offset := range offsets[1:] {
+		require.Equal(t, offsets[0], offset, "line %d starts its second column at a different display offset", i+1)
+	}
 }

--- a/internal/mcpclient/stdio.go
+++ b/internal/mcpclient/stdio.go
@@ -90,8 +90,16 @@ func NewStdio(_ context.Context, opts StdioOptions) (*StdioClient, error) {
 		pending: make(map[int64]chan stdioResult), waitCh: make(chan error, 1),
 	}
 	go func() { _, _ = io.Copy(io.Discard, stderr) }()
-	go client.readLoop(stdout)
+	readDone := make(chan struct{})
 	go func() {
+		defer close(readDone)
+		client.readLoop(stdout)
+	}()
+	go func() {
+		// cmd.Wait closes the stdout pipe, so let the read loop drain it
+		// first: a server that writes its final response and exits at once
+		// would otherwise have that response turned into a decode error.
+		<-readDone
 		err := cmd.Wait()
 		processErr := errors.New("MCP stdio process exited")
 		if err != nil {
@@ -322,7 +330,14 @@ func (c *StdioClient) Close() error {
 			if c.cmd.Process != nil {
 				_ = c.cmd.Process.Kill()
 			}
-			c.waitErr = <-c.waitCh
+			// A killed server normally reaches waitCh via stdout EOF, but a
+			// grandchild that inherited the pipe can hold it open forever;
+			// give up after a bound instead of hanging Close.
+			select {
+			case c.waitErr = <-c.waitCh:
+			case <-time.After(5 * time.Second):
+				c.waitErr = errors.New("MCP stdio process did not exit after kill")
+			}
 		}
 	})
 	return c.waitErr

--- a/internal/media/cache.go
+++ b/internal/media/cache.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"net/http"
 	"net/url"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/openclaw/slacrawl/internal/store"
 )
@@ -208,7 +210,7 @@ func fetchURL(ctx context.Context, opts FetchOptions, file store.FileRow, url st
 	if resp.ContentLength > opts.MaxBytes {
 		return fetchResult{status: "skipped", reason: "too_large"}, nil
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, opts.MaxBytes+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, readLimit(opts.MaxBytes)))
 	if err != nil {
 		return fetchResult{}, err
 	}
@@ -253,6 +255,17 @@ func fetchURL(ctx context.Context, opts FetchOptions, file store.FileRow, url st
 		}
 	}
 	return fetchResult{mediaPath: mediaPath, sha256: hash, size: int64(len(body))}, nil
+}
+
+// readLimit returns the byte budget for a download: one past the cap so an
+// oversized body is detectable. math.MaxInt64 is the natural "no cap" value, and
+// incrementing it wraps negative, which makes io.LimitReader return EOF at once
+// and every attachment look like a successfully fetched empty file.
+func readLimit(maxBytes int64) int64 {
+	if maxBytes >= math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return maxBytes + 1
 }
 
 func httpClientWithRedirectValidation(client *http.Client, withToken bool) *http.Client {
@@ -327,8 +340,14 @@ func mediaTargetNeedsWrite(target, hash string) (bool, error) {
 
 func fileMediaPath(hash, filename, contentType string) string {
 	name := safeFilename(filename)
-	if name == "" {
+	switch {
+	case name == "":
 		name = "file" + extensionForContentType(contentType)
+	case filepath.Ext(name) == "":
+		// safeFilename drops non-ASCII runes, so a fully non-Latin name such as
+		// "写真.png" survives only as "png" and loses its extension. Anything
+		// that types by extension would then mis-serve the cached file.
+		name += extensionForContentType(contentType)
 	}
 	name = truncateFilename(name, 190)
 	return filepath.ToSlash(filepath.Join("files", hash[:2], hash+"-"+name))
@@ -394,6 +413,28 @@ func fileSHA256(path string) (string, error) {
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
+// ResolveRoot returns the media root with its own symlinks resolved. Parking a
+// large attachment cache on another volume behind a symlink is a supported
+// setup, and the fetch path has always written through one, so the read paths
+// must not reject it — otherwise purge and publish wedge on a cache that
+// slacrawl itself keeps filling. Symlinks *inside* the tree stay rejected by
+// the per-component checks, which is where an escape could actually come from.
+func ResolveRoot(root string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", err
+	}
+	resolved = filepath.Clean(resolved)
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("unsafe media root %q", root)
+	}
+	return resolved, nil
+}
+
 func LocalPath(cacheDir, mediaPath string) (string, error) {
 	root := filepath.Clean(filepath.Join(cacheDir, cacheSubdir))
 	clean := filepath.Clean(filepath.FromSlash(strings.TrimSpace(mediaPath)))
@@ -425,5 +466,11 @@ func clampError(message string) string {
 	if len(message) <= 512 {
 		return message
 	}
-	return message[:512]
+	// Cut on a rune boundary so a non-ASCII error does not leave invalid UTF-8
+	// in message_files.fetch_error, which surfaces as U+FFFD downstream.
+	clamped := message[:512]
+	for len(clamped) > 0 && !utf8.ValidString(clamped) {
+		clamped = clamped[:len(clamped)-1]
+	}
+	return clamped
 }

--- a/internal/media/cache.go
+++ b/internal/media/cache.go
@@ -262,7 +262,7 @@ func fetchURL(ctx context.Context, opts FetchOptions, file store.FileRow, url st
 // incrementing it wraps negative, which makes io.LimitReader return EOF at once
 // and every attachment look like a successfully fetched empty file.
 func readLimit(maxBytes int64) int64 {
-	if maxBytes >= math.MaxInt64 {
+	if maxBytes == math.MaxInt64 {
 		return math.MaxInt64
 	}
 	return maxBytes + 1
@@ -436,27 +436,25 @@ func ResolveRoot(root string) (string, error) {
 }
 
 func LocalPath(cacheDir, mediaPath string) (string, error) {
-	root := filepath.Clean(filepath.Join(cacheDir, cacheSubdir))
-	clean := filepath.Clean(filepath.FromSlash(strings.TrimSpace(mediaPath)))
-	if clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("invalid media path %q", mediaPath)
-	}
-	full := filepath.Clean(filepath.Join(root, clean))
-	if full != root && !strings.HasPrefix(full, root+string(filepath.Separator)) {
-		return "", fmt.Errorf("media path escapes cache: %q", mediaPath)
-	}
-	return full, nil
+	return containedJoin(cacheDir, mediaPath, "cache")
 }
 
 func RepoPath(repoPath, mediaPath string) (string, error) {
-	root := filepath.Clean(filepath.Join(repoPath, cacheSubdir))
+	return containedJoin(repoPath, mediaPath, "repo")
+}
+
+// containedJoin is the single lexical-containment check for media paths: the
+// joined result must stay under <base>/media. Both the cache and the share
+// repo enforce the same invariant, so they share one implementation.
+func containedJoin(base, mediaPath, label string) (string, error) {
+	root := filepath.Clean(filepath.Join(base, cacheSubdir))
 	clean := filepath.Clean(filepath.FromSlash(strings.TrimSpace(mediaPath)))
 	if clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("invalid media path %q", mediaPath)
 	}
 	full := filepath.Clean(filepath.Join(root, clean))
 	if full != root && !strings.HasPrefix(full, root+string(filepath.Separator)) {
-		return "", fmt.Errorf("media path escapes repo: %q", mediaPath)
+		return "", fmt.Errorf("media path escapes %s: %q", label, mediaPath)
 	}
 	return full, nil
 }

--- a/internal/media/cache_test.go
+++ b/internal/media/cache_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"math"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
@@ -66,6 +68,56 @@ func TestFetchSkipsTooLargeFile(t *testing.T) {
 	rows, err := st.Files(ctx, store.FileListOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "too_large", rows[0].FetchStatus)
+}
+
+func TestFetchStoresFileWhenMaxBytesIsUnbounded(t *testing.T) {
+	ctx := context.Background()
+	body := []byte("file bytes")
+	st := seedFileStore(t, "https://files.example/file.png")
+	defer func() { require.NoError(t, st.Close()) }()
+
+	// math.MaxInt64 is the natural way to ask for "no cap". Incrementing it for
+	// the over-limit probe wrapped negative, so io.LimitReader returned EOF
+	// immediately and every attachment was recorded as a fetched empty file.
+	stats, err := Fetch(ctx, st, FetchOptions{
+		CacheDir: t.TempDir(),
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return testHTTPResponse(r, body, int64(len(body))), nil
+		})},
+		MaxBytes:     math.MaxInt64,
+		StatusUpdate: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Fetched)
+
+	rows, err := st.Files(ctx, store.FileListOptions{})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "fetched", rows[0].FetchStatus)
+	require.Equal(t, int64(len(body)), rows[0].ContentSize, "the body must not be truncated to zero")
+	sum := sha256.Sum256(body)
+	require.Equal(t, hex.EncodeToString(sum[:]), rows[0].ContentSHA256)
+}
+
+func TestReadLimitDoesNotOverflow(t *testing.T) {
+	require.Equal(t, int64(5), readLimit(4))
+	require.Equal(t, int64(math.MaxInt64), readLimit(math.MaxInt64))
+	require.Positive(t, readLimit(math.MaxInt64))
+}
+
+func TestFileMediaPathKeepsExtensionForNonLatinNames(t *testing.T) {
+	hash := strings.Repeat("a", 64)
+	// safeFilename strips non-ASCII runes, so "写真.png" survived only as "png"
+	// and the cached file lost the extension anything content-types by.
+	require.Equal(t, ".png", filepath.Ext(fileMediaPath(hash, "写真.png", "image/png")))
+	require.Equal(t, ".pdf", filepath.Ext(fileMediaPath(hash, "отчёт.pdf", "application/pdf")))
+	require.Equal(t, ".png", filepath.Ext(fileMediaPath(hash, "photo.png", "image/png")), "ASCII names keep working")
+}
+
+func TestClampErrorKeepsValidUTF8(t *testing.T) {
+	clamped := clampError(strings.Repeat("é", 400))
+	require.LessOrEqual(t, len(clamped), 512)
+	require.True(t, utf8.ValidString(clamped), "a clamped error must not be cut mid-rune")
 }
 
 func TestFetchRefusesTokenOnNonSlackURL(t *testing.T) {

--- a/internal/media/list.go
+++ b/internal/media/list.go
@@ -2,7 +2,6 @@ package media
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -19,16 +18,12 @@ func ListCachedFiles(cacheDir string) ([]CachedFile, error) {
 	if strings.TrimSpace(cacheDir) == "" {
 		return nil, errors.New("cache dir is required")
 	}
-	root := filepath.Clean(filepath.Join(cacheDir, cacheSubdir))
-	info, err := os.Lstat(root)
+	root, err := ResolveRoot(filepath.Clean(filepath.Join(cacheDir, cacheSubdir)))
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-		return nil, fmt.Errorf("unsafe media root %q", root)
 	}
 
 	var files []CachedFile

--- a/internal/media/remove.go
+++ b/internal/media/remove.go
@@ -39,18 +39,15 @@ func cachedRegularFile(cacheDir, mediaPath string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	root := filepath.Clean(filepath.Join(cacheDir, cacheSubdir))
-	rootInfo, err := os.Lstat(root)
+	relative, err := filepath.Rel(filepath.Clean(filepath.Join(cacheDir, cacheSubdir)), target)
 	if err != nil {
 		return "", "", err
 	}
-	if rootInfo.Mode()&os.ModeSymlink != 0 || !rootInfo.IsDir() {
-		return "", "", fmt.Errorf("unsafe media root %q", root)
-	}
-	relative, err := filepath.Rel(root, target)
+	root, err := ResolveRoot(filepath.Clean(filepath.Join(cacheDir, cacheSubdir)))
 	if err != nil {
 		return "", "", err
 	}
+	target = filepath.Join(root, relative)
 	current := root
 	parts := splitPath(relative)
 	for _, part := range parts[:len(parts)-1] {

--- a/internal/media/remove.go
+++ b/internal/media/remove.go
@@ -32,20 +32,36 @@ func RemoveCachedFile(cacheDir, mediaPath string) (bool, error) {
 }
 
 func cachedRegularFile(cacheDir, mediaPath string) (string, string, error) {
-	if strings.TrimSpace(cacheDir) == "" {
-		return "", "", errors.New("cache dir is required")
+	root, target, _, err := verifiedFile(cacheDir, mediaPath)
+	return root, target, err
+}
+
+// VerifiedFile returns the resolved on-disk path and FileInfo for mediaPath
+// under base's media root, enforcing the containment invariant on the real
+// filesystem: the root itself may be a symlink (resolved once), every
+// directory component below it must be a real directory — never a symlink —
+// and the target must be a regular file. This is the single owner of that
+// walk; the share export/import paths and the cache read paths all use it.
+func VerifiedFile(base, mediaPath string) (string, os.FileInfo, error) {
+	_, target, info, err := verifiedFile(base, mediaPath)
+	return target, info, err
+}
+
+func verifiedFile(base, mediaPath string) (string, string, os.FileInfo, error) {
+	if strings.TrimSpace(base) == "" {
+		return "", "", nil, errors.New("media base dir is required")
 	}
-	target, err := LocalPath(cacheDir, mediaPath)
+	target, err := LocalPath(base, mediaPath)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
-	relative, err := filepath.Rel(filepath.Clean(filepath.Join(cacheDir, cacheSubdir)), target)
+	relative, err := filepath.Rel(filepath.Clean(filepath.Join(base, cacheSubdir)), target)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
-	root, err := ResolveRoot(filepath.Clean(filepath.Join(cacheDir, cacheSubdir)))
+	root, err := ResolveRoot(filepath.Clean(filepath.Join(base, cacheSubdir)))
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 	target = filepath.Join(root, relative)
 	current := root
@@ -54,20 +70,20 @@ func cachedRegularFile(cacheDir, mediaPath string) (string, string, error) {
 		current = filepath.Join(current, part)
 		info, err := os.Lstat(current)
 		if err != nil {
-			return "", "", err
+			return "", "", nil, err
 		}
 		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-			return "", "", fmt.Errorf("unsafe media path component %q", current)
+			return "", "", nil, fmt.Errorf("unsafe media path component %q", current)
 		}
 	}
 	info, err := os.Lstat(target)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 	if !info.Mode().IsRegular() {
-		return "", "", fmt.Errorf("cached media %q is not a regular file", mediaPath)
+		return "", "", nil, fmt.Errorf("cached media %q is not a regular file", mediaPath)
 	}
-	return root, target, nil
+	return root, target, info, nil
 }
 
 func splitPath(path string) []string {

--- a/internal/media/remove_test.go
+++ b/internal/media/remove_test.go
@@ -30,7 +30,7 @@ func TestRemoveCachedFile(t *testing.T) {
 
 func TestValidateCachedFileRequiresCacheDir(t *testing.T) {
 	err := ValidateCachedFile("", "files/aa/file.txt")
-	require.ErrorContains(t, err, "cache dir is required")
+	require.ErrorContains(t, err, "media base dir is required")
 }
 
 func TestRemoveCachedFileRejectsSymlinkedParent(t *testing.T) {

--- a/internal/media/remove_test.go
+++ b/internal/media/remove_test.go
@@ -50,3 +50,33 @@ func TestRemoveCachedFileRejectsSymlinkedParent(t *testing.T) {
 	require.ErrorContains(t, err, "unsafe media path component")
 	require.FileExists(t, filepath.Join(outside, "file.txt"))
 }
+
+func TestCachedFileAllowsSymlinkedMediaRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires additional privileges on Windows")
+	}
+	// A large attachment cache is often parked on another volume behind a
+	// symlinked media root. Fetch has always written through one, so rejecting
+	// it on the read side left purge failing forever on a cache slacrawl
+	// itself keeps filling.
+	cacheDir := t.TempDir()
+	storage := t.TempDir()
+	require.NoError(t, os.Symlink(storage, filepath.Join(cacheDir, cacheSubdir)))
+
+	mediaPath := "files/aa/file.txt"
+	target, err := LocalPath(cacheDir, mediaPath)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+	require.NoError(t, os.WriteFile(target, []byte("cached"), 0o600))
+
+	listed, err := ListCachedFiles(cacheDir)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	require.Equal(t, mediaPath, listed[0].Path)
+
+	require.NoError(t, ValidateCachedFile(cacheDir, mediaPath))
+	deleted, err := RemoveCachedFile(cacheDir, mediaPath)
+	require.NoError(t, err)
+	require.True(t, deleted)
+	require.NoFileExists(t, filepath.Join(storage, "files", "aa", "file.txt"))
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -178,17 +178,18 @@ func Sync(ctx context.Context, st *store.Store, providerConfig config.Provider, 
 		_ = stdin.Close()
 		return Summary{}, fmt.Errorf("start provider %q: %w", providerConfig.Name, err)
 	}
-	if err := json.NewEncoder(stdin).Encode(providerRequest); err != nil {
-		_ = stdin.Close()
-		cancel()
-		_ = cmd.Wait()
-		return Summary{}, fmt.Errorf("write provider request: %w", err)
-	}
-	if err := stdin.Close(); err != nil {
-		cancel()
-		_ = cmd.Wait()
-		return Summary{}, fmt.Errorf("close provider request: %w", err)
-	}
+	// Write the request from a goroutine so a provider that emits more than a
+	// pipe buffer of output before draining stdin cannot deadlock against a
+	// request larger than a pipe buffer — the consumer below reads while the
+	// request is still being written.
+	writeErrCh := make(chan error, 1)
+	go func() {
+		err := json.NewEncoder(stdin).Encode(providerRequest)
+		if closeErr := stdin.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close provider request: %w", closeErr)
+		}
+		writeErrCh <- err
+	}()
 
 	consumer := consumer{
 		store:         st,
@@ -210,9 +211,15 @@ func Sync(ctx context.Context, st *store.Store, providerConfig config.Provider, 
 	if consumeErr != nil {
 		cancel()
 	}
+	writeErr := <-writeErrCh
 	waitErr := cmd.Wait()
 	if consumeErr != nil {
 		return consumer.summary, withStderr(fmt.Errorf("consume provider %q: %w", providerConfig.Name, consumeErr), stderr.String())
+	}
+	// A provider that died before reading its request breaks the write with
+	// EPIPE; its stderr explains why, so keep it attached here too.
+	if writeErr != nil {
+		return consumer.summary, withStderr(fmt.Errorf("write provider request: %w", writeErr), stderr.String())
 	}
 	if waitErr != nil {
 		return consumer.summary, withStderr(fmt.Errorf("provider %q exited: %w", providerConfig.Name, waitErr), stderr.String())

--- a/internal/search/normalize.go
+++ b/internal/search/normalize.go
@@ -700,20 +700,25 @@ func renderSlackToken(target string, label string) string {
 }
 
 func ExtractMentions(text string) []Mention {
-	text = sanitizeDisplayText(text)
+	// Match against the still-escaped text, exactly like normalizeMessageText:
+	// Slack escapes literal <, >, & in message bodies, so a user *talking
+	// about* mention syntax arrives as &lt;@U…&gt;. Unescaping first made that
+	// indistinguishable from a real mention token; only the display label may
+	// be unescaped.
+	text = sanitizeText(text)
 	var mentions []Mention
 	for _, match := range userMentionRe.FindAllStringSubmatch(text, -1) {
 		mentions = append(mentions, Mention{
 			Type:        "user",
 			TargetID:    match[1],
-			DisplayText: display(match[2], match[1]),
+			DisplayText: display(sanitizeDisplayText(match[2]), match[1]),
 		})
 	}
 	for _, match := range channelMentionRe.FindAllStringSubmatch(text, -1) {
 		mentions = append(mentions, Mention{
 			Type:        "channel",
 			TargetID:    match[1],
-			DisplayText: display(match[2], match[1]),
+			DisplayText: display(sanitizeDisplayText(match[2]), match[1]),
 		})
 	}
 	return mentions

--- a/internal/search/normalize_test.go
+++ b/internal/search/normalize_test.go
@@ -271,9 +271,19 @@ func TestExtractMentionsSanitizesNoisyText(t *testing.T) {
 	require.Equal(t, "eng", mentions[1].DisplayText)
 }
 
-func TestExtractMentionsUnescapesSlackEntities(t *testing.T) {
-	mentions := ExtractMentions("hello &lt;@U123|alice&gt; and &lt;#C123|eng&gt;")
+func TestExtractMentionsIgnoresEscapedLiterals(t *testing.T) {
+	// Slack escapes literal <, >, & in message bodies and never escapes real
+	// mention tokens, so &lt;@U123&gt; is a user talking *about* mention
+	// syntax, not a mention. Unescaping before matching used to record these
+	// as real mentions. Mirrors normalizeMessageText, which parses tokens
+	// before entity decoding for the same reason.
+	mentions := ExtractMentions("how do I write &lt;@U123|alice&gt; or &lt;#C123|eng&gt; in a message?")
+	require.Empty(t, mentions)
+}
+
+func TestExtractMentionsUnescapesDisplayLabels(t *testing.T) {
+	mentions := ExtractMentions("ping <@U123|R&amp;D lead> in <#C123|r&amp;d>")
 	require.Len(t, mentions, 2)
-	require.Equal(t, "alice", mentions[0].DisplayText)
-	require.Equal(t, "eng", mentions[1].DisplayText)
+	require.Equal(t, "R&D lead", mentions[0].DisplayText)
+	require.Equal(t, "r&d", mentions[1].DisplayText)
 }

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -37,8 +37,6 @@ const (
 
 var ErrNoManifest = errors.New("share manifest not found")
 
-var errUnsafeMediaPath = errors.New("unsafe media path")
-
 var maxShardBytes = defaultMaxShardBytes
 
 var SnapshotTables = []string{
@@ -287,7 +285,7 @@ func importLocked(ctx context.Context, s *store.Store, opts Options, restore boo
 			return Manifest{}, fmt.Errorf("manifest table %s row count mismatch: imported %d, expected %d", table.Name, rows, table.Rows)
 		}
 	}
-	if err := backfillDeletedMessageSubordinates(ctx, tx); err != nil {
+	if err := store.BackfillDeletedSubordinates(ctx, tx); err != nil {
 		return Manifest{}, err
 	}
 	if err := rebuildMessageFTS(ctx, tx); err != nil {
@@ -345,53 +343,6 @@ select m.channel_id || '|' || m.ts,
 from messages m;
 `); err != nil {
 		return fmt.Errorf("rebuild message_fts: %w", err)
-	}
-	return nil
-}
-
-func backfillDeletedMessageSubordinates(ctx context.Context, tx *sql.Tx) error {
-	if _, err := tx.ExecContext(ctx, `
-update message_files
-set deleted_at = coalesce(nullif(deleted_at, ''), (
-      select m.updated_at from messages m
-      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
-    )),
-    deletion_source = coalesce(nullif(deletion_source, ''), (
-      select m.source_name from messages m
-      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
-    )),
-    deletion_reason = coalesce(nullif(deletion_reason, ''), 'parent_message_deleted'),
-    updated_at = coalesce((
-      select m.updated_at from messages m
-      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
-    ), updated_at)
-where exists (
-  select 1 from messages m
-  where m.channel_id = message_files.channel_id and m.ts = message_files.ts
-    and trim(coalesce(m.deleted_ts, '')) <> ''
-);
-
-update message_mentions
-set deleted_at = coalesce(nullif(deleted_at, ''), (
-      select m.updated_at from messages m
-      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
-    )),
-    deletion_source = coalesce(nullif(deletion_source, ''), (
-      select m.source_name from messages m
-      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
-    )),
-    deletion_reason = coalesce(nullif(deletion_reason, ''), 'parent_message_deleted'),
-    updated_at = coalesce((
-      select m.updated_at from messages m
-      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
-    ), updated_at)
-where exists (
-  select 1 from messages m
-  where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
-    and trim(coalesce(m.deleted_ts, '')) <> ''
-);
-`); err != nil {
-		return fmt.Errorf("backfill deleted message subordinates: %w", err)
 	}
 	return nil
 }
@@ -1046,11 +997,7 @@ order by f.media_path, f.channel_id, f.ts, f.file_id
 			manifest.Files++
 			continue
 		}
-		source, err := media.LocalPath(opts.CacheDir, mediaPath)
-		if err != nil {
-			return nil, err
-		}
-		info, err := regularMediaFile(filepath.Join(opts.CacheDir, "media"), source, mediaPath)
+		source, info, err := media.VerifiedFile(opts.CacheDir, mediaPath)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
@@ -1106,11 +1053,8 @@ func importMedia(ctx context.Context, opts Options, manifest *MediaManifest) (in
 		if !ok || strings.TrimSpace(mediaPath) == "" {
 			return copied, fmt.Errorf("invalid media manifest path %q", item.Path)
 		}
-		source, err := media.RepoPath(opts.RepoPath, mediaPath)
+		source, _, err := media.VerifiedFile(opts.RepoPath, mediaPath)
 		if err != nil {
-			return copied, err
-		}
-		if _, err := regularMediaFile(filepath.Join(opts.RepoPath, "media"), source, item.Path); err != nil {
 			return copied, err
 		}
 		hash, err := fileSHA256(source)
@@ -1343,51 +1287,6 @@ func nullableString(value string) any {
 		return nil
 	}
 	return value
-}
-
-func regularMediaFile(root, path, label string) (os.FileInfo, error) {
-	root = filepath.Clean(root)
-	path = filepath.Clean(path)
-	if path != root && !strings.HasPrefix(path, root+string(filepath.Separator)) {
-		return nil, fmt.Errorf("%w: media %s escapes media root", errUnsafeMediaPath, label)
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return nil, err
-	}
-	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-		return nil, fmt.Errorf("%w: invalid media path %q", errUnsafeMediaPath, label)
-	}
-	// The root itself may legitimately be a symlink — a cache or repo parked on
-	// another volume — and the fetch path writes through one, so resolve it
-	// once rather than rejecting it. Symlinked components inside the tree stay
-	// fatal below.
-	resolvedRoot, err := media.ResolveRoot(root)
-	if err != nil {
-		return nil, err
-	}
-	path = filepath.Join(resolvedRoot, rel)
-	current := resolvedRoot
-	for _, part := range strings.Split(rel, string(filepath.Separator)) {
-		current = filepath.Join(current, part)
-		info, err := os.Lstat(current)
-		if err != nil {
-			return nil, err
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return nil, fmt.Errorf("%w: media %s contains symlinked path component", errUnsafeMediaPath, label)
-		}
-		if current == path {
-			if !info.Mode().IsRegular() {
-				return nil, fmt.Errorf("%w: media %s is not a regular file", errUnsafeMediaPath, label)
-			}
-			return info, nil
-		}
-		if !info.IsDir() {
-			return nil, fmt.Errorf("%w: media %s parent is not a directory", errUnsafeMediaPath, label)
-		}
-	}
-	return nil, fmt.Errorf("%w: invalid media path %q", errUnsafeMediaPath, label)
 }
 
 func copyFile(dst, src string) error {

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -1051,9 +1051,12 @@ order by f.media_path, f.channel_id, f.ts, f.file_id
 			return nil, err
 		}
 		info, err := regularMediaFile(filepath.Join(opts.CacheDir, "media"), source, mediaPath)
-		if errors.Is(err, os.ErrNotExist) || errors.Is(err, errUnsafeMediaPath) {
+		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
+		// An unsafe path is a broken cache, not an absent file. Skipping it
+		// silently let publish emit a manifest claiming the archive has no
+		// media at all, which wipes attachments for every subscriber.
 		if err != nil {
 			return nil, fmt.Errorf("stat media %s: %w", mediaPath, err)
 		}
@@ -1278,11 +1281,14 @@ where channel_id = ? and ts = ? and file_id = ?
 select coalesce(media_path, '') from message_files
 where channel_id = ? and ts = ? and file_id = ?
 `, channelID, ts, fileID).Scan(&mediaPath)
-		if errors.Is(err, sql.ErrNoRows) || mediaPath == "" {
+		if errors.Is(err, sql.ErrNoRows) {
 			continue
 		}
 		if err != nil {
 			return err
+		}
+		if mediaPath == "" {
+			continue
 		}
 		if _, ok := manifested[mediaPath]; ok {
 			continue
@@ -1352,10 +1358,16 @@ func regularMediaFile(root, path, label string) (os.FileInfo, error) {
 	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
 		return nil, fmt.Errorf("%w: invalid media path %q", errUnsafeMediaPath, label)
 	}
-	current := root
-	if info, err := os.Lstat(current); err == nil && !info.IsDir() {
-		return nil, fmt.Errorf("%w: media root for %s is not a directory", errUnsafeMediaPath, label)
+	// The root itself may legitimately be a symlink — a cache or repo parked on
+	// another volume — and the fetch path writes through one, so resolve it
+	// once rather than rejecting it. Symlinked components inside the tree stay
+	// fatal below.
+	resolvedRoot, err := media.ResolveRoot(root)
+	if err != nil {
+		return nil, err
 	}
+	path = filepath.Join(resolvedRoot, rel)
+	current := resolvedRoot
 	for _, part := range strings.Split(rel, string(filepath.Separator)) {
 		current = filepath.Join(current, part)
 		info, err := os.Lstat(current)

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -277,7 +277,7 @@ func (c *Client) Sync(ctx context.Context, st *store.Store, opts SyncOptions) er
 		}
 	}
 	for _, user := range users {
-		if err := st.UpsertUser(ctx, toStoreUser(workspaceID, user, now)); err != nil {
+		if _, err := c.skipUserCollision(ctx, st, workspaceID, user, now); err != nil {
 			return err
 		}
 	}
@@ -361,11 +361,15 @@ func (c *Client) HandleEventsAPIEvent(ctx context.Context, st *store.Store, work
 		msg := messageFromEvent(ev)
 		stored := toStoreMessage(workspaceID, msg, SourceBot, 2, rawMessagePayload(event), now)
 		deleted := msg.SubType == "message_deleted" || msg.DeletedTimestamp != ""
+		var err error
 		if deleted {
-			_, err := st.MarkMessageDeletedWithRetention(ctx, stored, toStoreMentions(msg))
-			return err
+			_, err = st.MarkMessageDeletedWithRetention(ctx, stored, toStoreMentions(msg))
+		} else {
+			_, err = st.UpsertMessageWithRetention(ctx, stored, toStoreMentions(msg))
 		}
-		_, err := st.UpsertMessageWithRetention(ctx, stored, toStoreMentions(msg))
+		if err != nil && c.skipMessageCollision(err, workspaceID, stored.ChannelID, stored.TS) {
+			return nil
+		}
 		return err
 	case *slackevents.ChannelRenameEvent:
 		return st.RenameChannel(ctx, ev.Channel.ID, ev.Channel.Name)
@@ -516,7 +520,10 @@ func (c *Client) syncChannelMessagesWithSource(ctx context.Context, st *store.St
 				err = st.UpsertMessage(ctx, stored, toStoreMentions(msg))
 			}
 			if err != nil {
-				return err
+				if !c.skipMessageCollision(err, workspaceID, channel.ID, msg.Timestamp) {
+					return err
+				}
+				continue
 			}
 			if msg.ReplyCount > 0 && userRepliesAvailable {
 				if err := syncThreadOnce(msg.Timestamp); err != nil {
@@ -557,7 +564,10 @@ func (c *Client) syncThread(ctx context.Context, st *store.Store, workspaceID st
 				err = st.UpsertMessage(ctx, stored, toStoreMentions(msg))
 			}
 			if err != nil {
-				return err
+				if !c.skipMessageCollision(err, workspaceID, channelID, msg.Timestamp) {
+					return err
+				}
+				continue
 			}
 		}
 		if resp.NextCursor == "" {
@@ -1163,11 +1173,7 @@ func (c *Client) skipChannelCollision(ctx context.Context, st *store.Store, work
 		return false, nil
 	}
 	if store.IsWorkspaceCollision(err, "channel") {
-		logger := c.logger
-		if logger == nil {
-			logger = slog.Default()
-		}
-		logger.Warn("skipping channel owned by another workspace",
+		c.warnLogger().Warn("skipping channel owned by another workspace",
 			"workspace_id", workspaceID,
 			"channel_id", channel.ID,
 			"channel_name", channel.Name,
@@ -1176,6 +1182,54 @@ func (c *Client) skipChannelCollision(ctx context.Context, st *store.Store, work
 		return true, nil
 	}
 	return false, err
+}
+
+// skipUserCollision upserts the user and reports whether it must be skipped
+// because another workspace already owns it. Enterprise Grid shares user IDs
+// org-wide and Slack Connect surfaces external members, so the same user can be
+// listed by several workspaces. The workspace that recorded the user first
+// keeps it, and later workspaces skip with a warning instead of aborting.
+func (c *Client) skipUserCollision(ctx context.Context, st *store.Store, workspaceID string, user slack.User, now time.Time) (bool, error) {
+	err := st.UpsertUser(ctx, toStoreUser(workspaceID, user, now))
+	if err == nil {
+		return false, nil
+	}
+	if store.IsWorkspaceCollision(err, "user") {
+		c.warnLogger().Warn("skipping user owned by another workspace",
+			"workspace_id", workspaceID,
+			"user_id", user.ID,
+			"user_name", user.Name,
+			"err", err,
+		)
+		return true, nil
+	}
+	return false, err
+}
+
+// skipMessageCollision reports whether a message upsert error is a
+// cross-workspace collision the caller should skip rather than propagate.
+// A Slack Connect channel is owned by whichever workspace recorded it first, so
+// its messages keep arriving for every other member workspace — during history
+// sync that must not abort the run, and during tail it must not kill the
+// socket-mode loop.
+func (c *Client) skipMessageCollision(err error, workspaceID, channelID, ts string) bool {
+	if !store.IsWorkspaceCollision(err, "message") {
+		return false
+	}
+	c.warnLogger().Warn("skipping message owned by another workspace",
+		"workspace_id", workspaceID,
+		"channel_id", channelID,
+		"ts", ts,
+		"err", err,
+	)
+	return true
+}
+
+func (c *Client) warnLogger() *slog.Logger {
+	if c.logger != nil {
+		return c.logger
+	}
+	return slog.Default()
 }
 
 func (c *Client) syncChannelsWithSource(ctx context.Context, st *store.Store, workspaceID string, channels []slack.Channel, opts SyncOptions, now time.Time, userRepliesAvailable bool, source channelSyncSource) error {

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -324,7 +324,7 @@ func (c *Client) Tail(ctx context.Context, st *store.Store, workspaceID string, 
 	socketClient := c.socketModeFn(c.bot)
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- socketClient.Run()
+		errCh <- socketClient.Run(ctx)
 	}()
 
 	var ticker *time.Ticker
@@ -345,7 +345,18 @@ func (c *Client) Tail(ctx context.Context, st *store.Store, workspaceID string, 
 			return ctx.Err()
 		case <-tickerChan(ticker):
 			if err := c.repairWorkspace(ctx, st, workspaceID); err != nil {
-				return err
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				// Repair is a periodic reconciliation sweep; a transient
+				// network failure during one tick must not kill a long-running
+				// tail daemon. The next tick retries, and store errors surface
+				// through the event handler path regardless.
+				c.warnLogger().Warn("tail repair sweep failed; will retry next interval",
+					"workspace_id", workspaceID,
+					"err", err,
+				)
+				continue
 			}
 			if err := st.SetSyncState(ctx, "tail", "repair", workspaceID, c.now().Format(time.RFC3339)); err != nil {
 				return err
@@ -939,7 +950,9 @@ func toStoreChannel(workspaceID string, channel slack.Channel, now time.Time) st
 	}
 }
 
-func toStoreUser(workspaceID string, user slack.User, now time.Time) store.User {
+// ToStoreUser is the single slack.User -> store.User mapping; the export
+// importer reuses it so a new stored field cannot silently miss one path.
+func ToStoreUser(workspaceID string, user slack.User, now time.Time) store.User {
 	return store.User{
 		ID:          user.ID,
 		WorkspaceID: workspaceID,
@@ -1041,7 +1054,7 @@ func toStoreMentions(msg slack.Message) []store.Mention {
 }
 
 type socketModeRunner interface {
-	Run() error
+	Run(ctx context.Context) error
 	Ack(req socketmode.Request, payload ...interface{})
 	Events() <-chan socketmode.Event
 }
@@ -1050,7 +1063,7 @@ type managedSocketMode struct {
 	client *socketmode.Client
 }
 
-func (m managedSocketMode) Run() error { return m.client.Run() }
+func (m managedSocketMode) Run(ctx context.Context) error { return m.client.RunContext(ctx) }
 func (m managedSocketMode) Ack(req socketmode.Request, payload ...interface{}) {
 	_ = m.client.Ack(req, payload...)
 }
@@ -1190,7 +1203,7 @@ func (c *Client) skipChannelCollision(ctx context.Context, st *store.Store, work
 // listed by several workspaces. The workspace that recorded the user first
 // keeps it, and later workspaces skip with a warning instead of aborting.
 func (c *Client) skipUserCollision(ctx context.Context, st *store.Store, workspaceID string, user slack.User, now time.Time) (bool, error) {
-	err := st.UpsertUser(ctx, toStoreUser(workspaceID, user, now))
+	err := st.UpsertUser(ctx, ToStoreUser(workspaceID, user, now))
 	if err == nil {
 		return false, nil
 	}

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -884,7 +884,7 @@ type fakeSocketMode struct {
 	acks   int
 }
 
-func (f *fakeSocketMode) Run() error { return nil }
+func (f *fakeSocketMode) Run(context.Context) error { return nil }
 func (f *fakeSocketMode) Ack(req socketmode.Request, payload ...interface{}) {
 	f.acks++
 }

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -1028,6 +1028,32 @@ func newSkipChannelSlackServer(t *testing.T) *mockSlackServer {
 	return mock
 }
 
+func newSharedUserSlackServer(t *testing.T) *mockSlackServer {
+	t.Helper()
+	mock := &mockSlackServer{counts: map[string]int{}, lastOld: map[string]string{}}
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			_, _ = w.Write([]byte(`{"ok":true,"team":"Test Team","team_id":"T123","user":"bot","user_id":"Ubot","bot_id":"B123"}`))
+		case "/conversations.list":
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[
+				{"id":"C222","name":"general","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":true,"topic":{"value":"topic"},"purpose":{"value":"purpose"}}
+			],"response_metadata":{"next_cursor":""}}`))
+		case "/conversations.history":
+			_, _ = w.Write([]byte(`{"ok":true,"messages":[{"type":"message","channel":"C222","user":"U123","text":"accessible message","ts":"1710000000.000100"}],"response_metadata":{"next_cursor":""}}`))
+		case "/users.list":
+			_, _ = w.Write([]byte(`{"ok":true,"members":[
+				{"id":"Ushared","name":"shared","real_name":"Shared User"},
+				{"id":"Ulocal","name":"local","real_name":"Local User"}
+			],"response_metadata":{"next_cursor":""}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return mock
+}
+
 func newInvalidUserSlackServer(t *testing.T) *mockSlackServer {
 	t.Helper()
 	mock := &mockSlackServer{counts: map[string]int{}, lastOld: map[string]string{}}
@@ -1652,6 +1678,82 @@ func TestSyncSkipsChannelOwnedByAnotherWorkspace(t *testing.T) {
 	require.Equal(t, "accessible message", rows[0].Text)
 
 	owner, err := st.ChannelWorkspaceID(context.Background(), "C111")
+	require.NoError(t, err)
+	require.Equal(t, "Tother", owner, "the original workspace keeps the shared channel")
+}
+
+func TestSyncSkipsUserOwnedByAnotherWorkspace(t *testing.T) {
+	server := newSharedUserSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot: "xoxb-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	// Enterprise Grid shares user IDs org-wide, so users.list for T123 can
+	// return a member another workspace already recorded. The sync must skip
+	// that row rather than abort after every message has already committed.
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "Tother", Name: "other", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertUser(ctx, store.User{ID: "Ushared", WorkspaceID: "Tother", Name: "shared", RawJSON: "{}", UpdatedAt: now}))
+
+	require.NoError(t, client.Sync(ctx, st, SyncOptions{}), "one cross-workspace user must not abort the sync")
+
+	rows, err := st.Messages(ctx, "", "C222", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	// The checkpoint lives after the user loop, so an abort there silently
+	// discarded the whole run's progress.
+	state, err := st.GetSyncState(ctx, SourceBot, "workspace", "T123")
+	require.NoError(t, err)
+	require.NotEmpty(t, state, "the bot sync checkpoint must still be recorded")
+}
+
+func TestHandleEventsAPIEventSkipsMessageOwnedByAnotherWorkspace(t *testing.T) {
+	st := mustStore(t)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	ctx := context.Background()
+	now := time.Date(2026, 3, 8, 3, 0, 0, 0, time.UTC)
+	// A Slack Connect channel stays owned by whichever workspace recorded it
+	// first, so tail for the other workspace keeps receiving its messages.
+	// That must not terminate the socket-mode loop.
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "Tother", Name: "other", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertChannel(ctx, store.Channel{ID: "C111", WorkspaceID: "Tother", Name: "shared", Kind: "public_channel", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertMessage(ctx, store.Message{
+		ChannelID: "C111", TS: "1710000000.000100", WorkspaceID: "Tother",
+		UserID: "U123", Text: "owned elsewhere", SourceName: SourceBot, SourceRank: 2,
+		RawJSON: "{}", UpdatedAt: now,
+	}, nil))
+	require.NoError(t, st.UpsertWorkspace(ctx, store.Workspace{ID: "T123", Name: "team", RawJSON: "{}", UpdatedAt: now}))
+
+	client := New(config.Tokens{Bot: "xoxb-test", App: "xapp-test"})
+	client.now = func() time.Time { return now }
+
+	event, err := slackevents.ParseEvent([]byte(`{
+	  "token":"ignored",
+	  "team_id":"T123",
+	  "api_app_id":"A123",
+	  "type":"event_callback",
+	  "event":{
+	    "type":"message",
+	    "channel":"C111",
+	    "user":"U123",
+	    "text":"shared channel reply",
+	    "ts":"1710000000.000100",
+	    "event_ts":"1710000000.000100"
+	  }
+	}`), slackevents.OptionNoVerifyToken())
+	require.NoError(t, err)
+	require.NoError(t, client.HandleEventsAPIEvent(ctx, st, "T123", event), "a cross-workspace message must not kill tail")
+
+	owner, err := st.ChannelWorkspaceID(ctx, "C111")
 	require.NoError(t, err)
 	require.Equal(t, "Tother", owner, "the original workspace keeps the shared channel")
 }

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -62,6 +62,7 @@ create index idx_messages_workspace_ts on messages(workspace_id, ts desc);
 create index idx_messages_workspace_channel_ts on messages(workspace_id, channel_id, ts desc);
 create index idx_messages_workspace_user_ts on messages(workspace_id, user_id, ts desc);
 create index idx_messages_key_expr on messages((channel_id || '|' || ts));
+create index idx_messages_channel_thread on messages(channel_id, thread_ts);
 
 create table message_files (
   workspace_id text not null,
@@ -111,6 +112,7 @@ create table message_events (
   created_at text not null
 );
 create unique index idx_message_events_identity on message_events(event_key);
+create index idx_message_events_channel_ts on message_events(channel_id, ts);
 
 create table message_event_heads (
   channel_id text not null,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unicode"
@@ -20,7 +21,7 @@ import (
 	"github.com/openclaw/slacrawl/internal/store/storedb"
 )
 
-const schemaVersion = 6
+const schemaVersion = 7
 const PlaceholderUserRawJSON = `{"slacrawl_provider_placeholder":true}`
 
 const (
@@ -130,6 +131,7 @@ create index if not exists idx_messages_workspace_ts on messages(workspace_id, t
 create index if not exists idx_messages_workspace_channel_ts on messages(workspace_id, channel_id, ts desc);
 create index if not exists idx_messages_workspace_user_ts on messages(workspace_id, user_id, ts desc);
 create index if not exists idx_messages_key_expr on messages((channel_id || '|' || ts));
+create index if not exists idx_messages_channel_thread on messages(channel_id, thread_ts);
 
 create table if not exists message_files (
   workspace_id text not null,
@@ -180,6 +182,8 @@ create table if not exists message_events (
 );
 create unique index if not exists idx_message_events_identity
 on message_events(event_key);
+create index if not exists idx_message_events_channel_ts
+on message_events(channel_id, ts);
 ` + messageEventHeadsSchema + `
 create table if not exists sync_state (
   source_name text not null,
@@ -263,6 +267,16 @@ create index if not exists idx_message_files_name on message_files(name);
 
 const schemaV4Migration = messageEventHeadsSchema
 const schemaV5Migration = messageEventHeadTriggerSchema
+
+// schemaV7Migration adds the thread-lookup and event-lookup indexes. Without
+// (channel_id, thread_ts), ChannelThreadRoots' reply-existence probe scans the
+// whole channel per message — O(channel²), measured minutes-to-hours on large
+// channels; with it the same query is milliseconds.
+const schemaV7Migration = `
+create index if not exists idx_messages_channel_thread on messages(channel_id, thread_ts);
+create index if not exists idx_message_events_channel_ts on message_events(channel_id, ts);
+`
+
 const schemaV6EventMigration = `
 drop index if exists idx_message_events_identity;
 create table message_events_v6 (
@@ -2260,11 +2274,30 @@ func replaceUserMentions(value string, mentions []messageMentionDisplay) string 
 		if !strings.HasPrefix(display, "@") {
 			display = "@" + display
 		}
-		value = regexp.MustCompile(`<@`+regexp.QuoteMeta(target)+`(?:\|[^>]+)?>`).ReplaceAllString(value, display)
+		value = mentionTokenRegexp(target).ReplaceAllString(value, display)
 		value = strings.ReplaceAll(value, "@"+target, display)
 		value = strings.ReplaceAll(value, "@"+strings.ToLower(target), display)
 	}
 	return value
+}
+
+// mentionTokenRegexps caches per-target regexps: replaceUserMentions runs once
+// per rendered row times its mentions, and recompiling the same target pattern
+// dominated large listing renders. Target IDs are a small, stable set.
+var (
+	mentionTokenRegexpsMu sync.Mutex
+	mentionTokenRegexps   = map[string]*regexp.Regexp{}
+)
+
+func mentionTokenRegexp(target string) *regexp.Regexp {
+	mentionTokenRegexpsMu.Lock()
+	defer mentionTokenRegexpsMu.Unlock()
+	if re, ok := mentionTokenRegexps[target]; ok {
+		return re
+	}
+	re := regexp.MustCompile(`<@` + regexp.QuoteMeta(target) + `(?:\|[^>]+)?>`)
+	mentionTokenRegexps[target] = re
+	return re
 }
 
 func (s *Store) Mentions(ctx context.Context, workspaceID string, target string, limit int) ([]MentionRow, error) {
@@ -3167,6 +3200,12 @@ func migrateSchema(db *sql.DB, currentVersion int) error {
 			return fmt.Errorf("migrate sqlite schema to v6: %w", err)
 		}
 		currentVersion = 6
+	}
+	if currentVersion < 7 {
+		if _, err := tx.Exec(schemaV7Migration); err != nil {
+			return fmt.Errorf("migrate sqlite schema to v7: %w", err)
+		}
+		currentVersion = 7
 	}
 	if currentVersion != schemaVersion {
 		return fmt.Errorf("no migration path from sqlite schema version %d to %d", currentVersion, schemaVersion)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -29,12 +29,6 @@ const (
 	searchIndexMaintenanceEntityID   = "rowid_rebuild_pending"
 )
 
-const schemaPragmas = `
-pragma foreign_keys = on;
-pragma journal_mode = wal;
-pragma busy_timeout = 5000;
-`
-
 const messageEventHeadsTableSchema = `
 create table if not exists message_event_heads (
   channel_id text not null,
@@ -1358,7 +1352,7 @@ func upsertMessageInTransaction(ctx context.Context, dbtx storedb.DBTX, qtx *sto
 		return false, err
 	}
 
-	filesForSearch := message.Files
+	var filesForSearch []MessageFile
 	if message.Files != nil {
 		existingMedia, err := existingFileMedia(ctx, qtx, message.ChannelID, message.TS)
 		if err != nil {
@@ -2827,6 +2821,64 @@ func RebuildSearchIndexesInTransaction(ctx context.Context, tx *sql.Tx) error {
 	return rebuildSearchIndexesInTransaction(ctx, tx)
 }
 
+// BackfillDeletedSubordinates stamps deletion metadata onto message_files and
+// message_mentions whose parent message carries a deleted_ts. It preserves any
+// deletion_reason already recorded — the parent tombstone explains missing
+// subordinates, it does not override a more specific reason. This is the single
+// owner of the tombstone-propagation SQL; the v6 migration and the share import
+// path both call it so the invariant cannot drift between them again.
+func BackfillDeletedSubordinates(ctx context.Context, tx *sql.Tx) error {
+	if tx == nil {
+		return errors.New("tombstone backfill transaction is required")
+	}
+	if _, err := tx.ExecContext(ctx, backfillDeletedSubordinatesSQL); err != nil {
+		return fmt.Errorf("backfill deleted message subordinates: %w", err)
+	}
+	return nil
+}
+
+const backfillDeletedSubordinatesSQL = `
+update message_files
+set deleted_at = coalesce(nullif(deleted_at, ''), (
+      select m.updated_at from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    )),
+    deletion_source = coalesce(nullif(deletion_source, ''), (
+      select m.source_name from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    )),
+    deletion_reason = coalesce(nullif(deletion_reason, ''), 'parent_message_deleted'),
+    updated_at = coalesce((
+      select m.updated_at from messages m
+      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    ), updated_at)
+where exists (
+  select 1 from messages m
+  where m.channel_id = message_files.channel_id and m.ts = message_files.ts
+    and trim(coalesce(m.deleted_ts, '')) <> ''
+);
+
+update message_mentions
+set deleted_at = coalesce(nullif(deleted_at, ''), (
+      select m.updated_at from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    )),
+    deletion_source = coalesce(nullif(deletion_source, ''), (
+      select m.source_name from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    )),
+    deletion_reason = coalesce(nullif(deletion_reason, ''), 'parent_message_deleted'),
+    updated_at = coalesce((
+      select m.updated_at from messages m
+      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    ), updated_at)
+where exists (
+  select 1 from messages m
+  where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
+    and trim(coalesce(m.deleted_ts, '')) <> ''
+);
+`
+
 func markSearchIndexRebuildPending(ctx context.Context, dbtx storedb.DBTX) error {
 	return storedb.New(dbtx).SetSyncState(ctx, storedb.SetSyncStateParams{
 		SourceName: searchIndexMaintenanceSource, EntityType: searchIndexMaintenanceEntityType,
@@ -3220,48 +3272,10 @@ set updated_at = coalesce((
   where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
 ), '')
 where updated_at = '';
-
-update message_files
-set deleted_at = coalesce(nullif(deleted_at, ''), (
-      select m.updated_at from messages m
-      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
-    )),
-    deletion_source = coalesce(nullif(deletion_source, ''), (
-      select m.source_name from messages m
-      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
-    )),
-    deletion_reason = 'parent_message_deleted',
-    updated_at = coalesce((
-      select m.updated_at from messages m
-      where m.channel_id = message_files.channel_id and m.ts = message_files.ts
-    ), updated_at)
-where exists (
-  select 1 from messages m
-  where m.channel_id = message_files.channel_id and m.ts = message_files.ts
-    and trim(coalesce(m.deleted_ts, '')) <> ''
-);
-
-update message_mentions
-set deleted_at = coalesce(nullif(deleted_at, ''), (
-      select m.updated_at from messages m
-      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
-    )),
-    deletion_source = coalesce(nullif(deletion_source, ''), (
-      select m.source_name from messages m
-      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
-    )),
-    deletion_reason = 'parent_message_deleted',
-    updated_at = coalesce((
-      select m.updated_at from messages m
-      where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
-    ), updated_at)
-where exists (
-  select 1 from messages m
-  where m.channel_id = message_mentions.channel_id and m.ts = message_mentions.ts
-    and trim(coalesce(m.deleted_ts, '')) <> ''
-);
-
 `); err != nil {
+		return err
+	}
+	if err := BackfillDeletedSubordinates(context.Background(), tx); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(`delete from message_fts;` + rebuildMessageFTSRowsSQL + `;

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -894,6 +894,39 @@ where type = 'trigger' and name = 'seed_message_event_head_before_update'
 	require.Equal(t, 1, triggerCount)
 }
 
+func TestOpenMigratesVersion6AddsLookupIndexes(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+drop index idx_messages_channel_thread;
+drop index idx_message_events_channel_ts;
+pragma user_version = 6;
+`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	s, err = Open(dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+
+	var version int
+	require.NoError(t, s.DB().QueryRow(`pragma user_version`).Scan(&version))
+	require.Equal(t, schemaVersion, version)
+	var indexCount int
+	require.NoError(t, s.DB().QueryRow(`
+select count(*)
+from sqlite_master
+where type = 'index'
+  and name in ('idx_messages_channel_thread', 'idx_message_events_channel_ts')
+`).Scan(&indexCount))
+	require.Equal(t, 2, indexCount, "v7 must add the thread and event lookup indexes")
+}
+
 func TestOpenMigratesVersion5SubordinatesToTombstones(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	s, err := Open(dbPath)


### PR DESCRIPTION
Triage pass over `main`. Eight confirmed defects, each with a regression test that fails without the fix.

## Sync: cross-workspace collisions (completes #130)

#130 demoted cross-workspace *channel* collisions to a skip, but two other boundaries stayed fatal:

- **A shared user aborted the whole sync.** `Sync`'s user loop called `UpsertUser` bare. Enterprise Grid user IDs are org-wide and Slack Connect surfaces external members, so a second workspace's sync died *after* channels, DMs and every message had committed but *before* the checkpoint was written — the run was recorded as never having happened.
- **A shared message killed `tail`.** The upsert error propagated out of `HandleEventsAPIEvent` through `handleSocketModeEvent` to `Tail`, terminating the socket-mode loop. #130 made this *more* likely, since the shared channel now permanently stays owned by the first workspace.

Both are now skip-with-warning, matching the desktop importer. The history and thread upserts on the same path are covered too.

## Media: silent attachment loss

- **`MaxBytes+1` overflowed.** `math.MaxInt64` is the natural "no cap" value; incrementing it for the over-limit probe wrapped negative, `io.LimitReader` returned EOF immediately, and every attachment was written as a successfully fetched *empty* file — `sha256("")`, size 0, status `fetched`, no error anywhere.
- **A symlinked media root wedged `purge` permanently.** Parking a large attachment cache on another volume behind a symlink is ordinary, and `files fetch` has always written through one — but every read path (`list`, `remove`, `share`) rejected it. `purge --force` committed the database transaction and then failed post-commit cleanup on every subsequent run. The root is now resolved once; symlinks *inside* the tree are still refused, and the existing escape test still passes.
- **`publish` could emit a media-less manifest.** `errUnsafeMediaPath` was treated as "file absent", so after the repo's `media/` had already been wiped, every row was skipped and the manifest simply claimed the archive has no attachments — silently losing the entire media set for subscribers on their next `--media` import.
- A dead error check in `clearUnmanifestedImportedFileMedia` swallowed every non-`ErrNoRows` query error.

## CLI: byte lengths used where display width was meant

- `trimTo` sliced bytes, so `search`/`messages` output cut multi-byte runes in half and emitted invalid UTF-8; CJK text was also truncated to roughly a third of the intended width.
- `renderTable` measured column widths on the *colorized* cell. `formatScalar` wraps empty, `nil` and bool values in ANSI codes, so those invisible bytes padded the column while the header used its plain length — every table with an empty or non-ASCII cell was misaligned.
- Fetch errors were clamped at 512 bytes mid-rune, and fully non-Latin filenames (`写真.png`) lost their extension entirely, so a published `media/` tree served them as `application/octet-stream`.

## Proof

`go build`, `go test ./...`, `go test -race ./...`, `go vet`, `govulncheck` (no vulnerabilities), `make lint`, `make smoke`, `make snapshot`, `make tidy-check fmt-check` — all clean. Codex autoreview: clean, no accepted findings.

Each fix was verified to fail before the change: the two sync tests, both render tests, and the media tests were run against the reverted logic and observed failing.

One existing test changed rather than being deleted: `TestPurgeCommandReportsPostCommitCleanupFailure` used a symlinked media root *as* its failure trigger, which is exactly the wedge being fixed. It now points at a genuinely broken cache (a root symlinked to a regular file) and still asserts that post-commit cleanup failure is reported.

`go-runewidth` moves from indirect to direct; it was already in the module graph via bubbletea, same version.
