### PR TITLE
fix: skip cross-workspace user collisions during bot sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Slack Connect shared channels no longer abort workspace syncs: when a channel already belongs to another workspace in the archive, the bot sync skips it with a warning and keeps syncing the remaining channels instead of failing the whole run.
+- Cross-workspace users no longer abort bot syncs: repeated `USLACKBOT` records and Slack Connect members already owned by another workspace are skipped with a warning while the first workspace keeps the user row.
 
 ## v0.8.1 - 2026-08-02
 

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -278,6 +278,21 @@ func (c *Client) Sync(ctx context.Context, st *store.Store, opts SyncOptions) er
 	}
 	for _, user := range users {
 		if err := st.UpsertUser(ctx, toStoreUser(workspaceID, user, now)); err != nil {
+			if store.IsWorkspaceCollision(err, "user") {
+				// Slack's built-in slackbot has the literal ID USLACKBOT in every
+				// workspace, and Slack Connect can expose externally owned members.
+				// The workspace that recorded the user first keeps the row.
+				logger := c.logger
+				if logger == nil {
+					logger = slog.Default()
+				}
+				logger.Warn("skipping user owned by another workspace",
+					"workspace_id", workspaceID,
+					"user_id", user.ID,
+					"err", err,
+				)
+				continue
+			}
 			return err
 		}
 	}

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -1028,6 +1028,41 @@ func newSkipChannelSlackServer(t *testing.T) *mockSlackServer {
 	return mock
 }
 
+func newSkipUserSlackServer(t *testing.T) *mockSlackServer {
+	t.Helper()
+	mock := &mockSlackServer{counts: map[string]int{}, lastOld: map[string]string{}}
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			_, _ = w.Write([]byte(`{"ok":true,"team":"Test Team","team_id":"T123","user":"bot","user_id":"Ubot","bot_id":"B123"}`))
+		case "/conversations.list":
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[
+				{"id":"C111","name":"private-ish","is_channel":true,"is_private":true,"is_archived":false,"is_shared":false,"is_general":false,"topic":{"value":""},"purpose":{"value":""}},
+				{"id":"C222","name":"general","is_channel":true,"is_private":false,"is_archived":false,"is_shared":false,"is_general":true,"topic":{"value":"topic"},"purpose":{"value":"purpose"}}
+			],"response_metadata":{"next_cursor":""}}`))
+		case "/conversations.history":
+			values := mustFormValues(r)
+			switch values.Get("channel") {
+			case "C111":
+				_, _ = w.Write([]byte(`{"ok":false,"error":"not_in_channel"}`))
+			case "C222":
+				_, _ = w.Write([]byte(`{"ok":true,"messages":[{"type":"message","channel":"C222","user":"U123","text":"accessible message","ts":"1710000000.000100"}],"response_metadata":{"next_cursor":""}}`))
+			default:
+				http.NotFound(w, r)
+			}
+		case "/users.list":
+			_, _ = w.Write([]byte(`{"ok":true,"members":[
+				{"id":"USLACKBOT","name":"slackbot"},
+				{"id":"U123","name":"alice"}
+			],"response_metadata":{"next_cursor":""}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return mock
+}
+
 func newInvalidUserSlackServer(t *testing.T) *mockSlackServer {
 	t.Helper()
 	mock := &mockSlackServer{counts: map[string]int{}, lastOld: map[string]string{}}
@@ -1654,6 +1689,42 @@ func TestSyncSkipsChannelOwnedByAnotherWorkspace(t *testing.T) {
 	owner, err := st.ChannelWorkspaceID(context.Background(), "C111")
 	require.NoError(t, err)
 	require.Equal(t, "Tother", owner, "the original workspace keeps the shared channel")
+}
+
+func TestSyncSkipsUserOwnedByAnotherWorkspace(t *testing.T) {
+	server := newSkipUserSlackServer(t)
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{
+		Bot: "xoxb-test",
+	}, server.URL()+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	st := mustStore(t)
+	defer func() { require.NoError(t, st.Close()) }()
+
+	now := time.Now().UTC()
+	// USLACKBOT is present in every Slack workspace, and Slack Connect can
+	// expose externally owned members. Seed the user as owned by a different
+	// workspace; the sync for T123 must keep that row and continue.
+	require.NoError(t, st.UpsertWorkspace(context.Background(), store.Workspace{ID: "Tother", Name: "other", RawJSON: "{}", UpdatedAt: now}))
+	require.NoError(t, st.UpsertUser(context.Background(), store.User{ID: "USLACKBOT", WorkspaceID: "Tother", Name: "slackbot", RawJSON: "{}", UpdatedAt: now}))
+
+	err := client.Sync(context.Background(), st, SyncOptions{})
+	require.NoError(t, err, "one cross-workspace user must not abort the sync")
+
+	owner, err := st.UserWorkspaceID(context.Background(), "USLACKBOT")
+	require.NoError(t, err)
+	require.Equal(t, "Tother", owner, "the original workspace keeps the shared user")
+
+	owner, err = st.UserWorkspaceID(context.Background(), "U123")
+	require.NoError(t, err)
+	require.Equal(t, "T123", owner, "other users must still sync")
+
+	rows, err := st.Messages(context.Background(), "", "C222", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "channel messages must remain stored after the trailing user collision")
+	require.Equal(t, "accessible message", rows[0].Text)
 }
 
 func TestSyncSkipsExcludedChannels(t *testing.T) {


### PR DESCRIPTION
## What Problem This Solves

Bot syncs of a multi-workspace archive abort at the trailing users snapshot: Slack's built-in slackbot has the literal ID `USLACKBOT` in every workspace, so the first workspace to record it owns the row and every later workspace's sync exits with `WorkspaceCollisionError`. Slack Connect can surface externally owned members the same way. Messages import fine; the run still ends nonzero and the workspace sync-state stamp is never written.

## Why This Change Was Made

#130 fixed exactly this failure class for channels (Slack Connect shared channels) by demoting the collision to a skip-with-warning at the API sync boundary. The users snapshot was the missed sibling surface; the desktop import path (`upsertDesktopUser`) already tolerates user collisions the same way. The first workspace keeps the user row; all other upsert errors stay fatal.

## User Impact

Multi-workspace archives sync cleanly again. Live repro: a Foundation-workspace bot sync on a database that also holds a desktop import of another workspace imported all messages but exited nonzero on `USLACKBOT` every run.

## Evidence

- Regression test `TestSyncSkipsUserOwnedByAnotherWorkspace`: seeds `USLACKBOT` under another workspace, proves the sync completes, the original workspace keeps the row, other users still sync, and channel messages persist.
- `GOWORK=off go test ./...` green; `make lint` (vet + govulncheck) clean.
