### PR TITLE
chore(release): prepare v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.2 - 2026-08-06
 
 ### Fixes
 


### PR DESCRIPTION
Flips Unreleased to v0.8.2 - 2026-08-06 ahead of the unified release dispatch.