### PR TITLE
chore: open next unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## v0.8.2 - 2026-08-06
 
 ### Fixes


### PR DESCRIPTION
Reopens the Unreleased changelog section after the v0.8.2 release.