### PR TITLE
feat: refine crawlkit control metadata manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+- Refined the `metadata` control manifest: Slack-accurate branding, scheduler-friendly `sync` argv, added `search`/`watch` capabilities, and moved it to a tested `controlManifest` helper.
+
 ## v0.8.3 - 2026-08-07
 
 ### Performance

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -115,7 +115,7 @@ func (a *App) Run(ctx context.Context, args []string) error {
 	case "check-update":
 		return a.runCheckUpdate(ctx, rest[1:], outputFormat)
 	case "metadata":
-		return a.runMetadata(rest[1:], outputFormat)
+		return a.runMetadata(configPath, rest[1:], outputFormat)
 	case "init":
 		return normalizeCommandHelp(a.runInit(configPath, rest[1:], outputFormat))
 	case "doctor":
@@ -464,7 +464,7 @@ func (a *App) runStatus(ctx context.Context, configPath string, args []string, f
 	return a.writeOutput("Status", statusResponse{Status: status, ArchiveProfile: archiveProfile, Share: shareState}, format, true)
 }
 
-func (a *App) runMetadata(args []string, format OutputFormat) error {
+func (a *App) runMetadata(configPath string, args []string, format OutputFormat) error {
 	fs := flag.NewFlagSet("metadata", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
 	jsonOut := fs.Bool("json", false, "write crawlkit metadata JSON")
@@ -480,37 +480,7 @@ func (a *App) runMetadata(args []string, format OutputFormat) error {
 	if fs.NArg() != 0 {
 		return errors.New("metadata takes flags only")
 	}
-	defaults := config.Default()
-	configPath, err := config.DefaultConfigPath()
-	if err != nil {
-		return err
-	}
-	manifest := control.NewManifest("slacrawl", "Slack Crawl", "slacrawl")
-	manifest.Description = "Local-first Slack archive crawler."
-	manifest.Branding = control.Branding{SymbolName: "bubble.left.and.bubble.right", AccentColor: "#36c5f0", BundleIdentifier: "com.tinyspeck.slackmacgap"}
-	manifest.Paths = control.Paths{
-		DefaultConfig:   configPath,
-		ConfigEnv:       "SLACRAWL_CONFIG",
-		DefaultDatabase: defaults.DBPath,
-		DefaultCache:    defaults.CacheDir,
-		DefaultLogs:     defaults.LogDir,
-		DefaultShare:    defaults.Share.RepoPath,
-	}
-	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "tap", "tui", "git-share", "sql"}
-	manifest.Privacy = control.Privacy{ContainsPrivateMessages: true, ExportsSecrets: false, LocalOnlyScopes: []string{"slack", "desktop-cache", "sqlite", "git-share"}}
-	manifest.Commands = map[string]control.Command{
-		"status":      {Title: "Status", Argv: []string{"slacrawl", "status", "--json"}, JSON: true},
-		"doctor":      {Title: "Doctor", Argv: []string{"slacrawl", "doctor", "--json"}, JSON: true},
-		"sync":        {Title: "Sync", Argv: []string{"slacrawl", "--json", "sync"}, JSON: true, Mutates: true},
-		"tap":         {Title: "Import desktop cache", Argv: []string{"slacrawl", "--json", "sync", "--source", "desktop"}, JSON: true, Mutates: true},
-		"tui":         {Title: "Terminal browser", Argv: []string{"slacrawl", "tui"}},
-		"tui-json":    {Title: "Terminal browser rows", Argv: []string{"slacrawl", "tui", "--json"}, JSON: true},
-		"publish":     {Title: "Publish share", Argv: []string{"slacrawl", "--json", "publish"}, JSON: true, Mutates: true},
-		"subscribe":   {Title: "Subscribe share", Argv: []string{"slacrawl", "--json", "subscribe"}, JSON: true, Mutates: true},
-		"update":      {Title: "Update share", Argv: []string{"slacrawl", "--json", "update"}, JSON: true, Mutates: true},
-		"legacy-json": {Title: "Legacy JSON flag", Argv: []string{"slacrawl", "--json"}, JSON: true, Legacy: true},
-	}
-	return a.writeOutput("Metadata", manifest, format, false)
+	return a.writeOutput("Metadata", controlManifest(configPath), format, false)
 }
 
 func (a *App) runSync(ctx context.Context, configPath string, args []string, format OutputFormat) error {

--- a/internal/cli/control.go
+++ b/internal/cli/control.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"github.com/openclaw/crawlkit/control"
+	"github.com/openclaw/slacrawl/internal/config"
+)
+
+func controlManifest(configPath string) control.Manifest {
+	defaults := config.Default()
+	manifest := control.NewManifest("slacrawl", "Slack Crawl", "slacrawl")
+	manifest.Description = "Local-first Slack archive crawler."
+	manifest.Branding = control.Branding{
+		SymbolName:       "number",
+		AccentColor:      "#4a154b",
+		BundleIdentifier: "com.tinyspeck.slackmacgap",
+	}
+	manifest.Paths = control.Paths{
+		DefaultConfig:   configPath,
+		ConfigEnv:       "SLACRAWL_CONFIG",
+		DefaultDatabase: defaults.DBPath,
+		DefaultCache:    defaults.CacheDir,
+		DefaultLogs:     defaults.LogDir,
+		DefaultShare:    defaults.Share.RepoPath,
+	}
+	manifest.Capabilities = []string{"metadata", "doctor", "status", "sync", "search", "watch", "tap", "tui", "sql", "git-share"}
+	manifest.Privacy = control.Privacy{
+		ContainsPrivateMessages: true,
+		ExportsSecrets:          false,
+		LocalOnlyScopes:         []string{"slack", "desktop-cache", "sqlite", "git-share"},
+	}
+	manifest.Commands = map[string]control.Command{
+		"doctor":      {Title: "Doctor", Argv: []string{"slacrawl", "--json", "doctor"}, JSON: true},
+		"status":      {Title: "Status", Argv: []string{"slacrawl", "--json", "status"}, JSON: true},
+		"sync":        {Title: "Sync", Argv: []string{"slacrawl", "--json", "sync", "--source", "all", "--latest-only"}, JSON: true, Mutates: true},
+		"search":      {Title: "Search", Argv: []string{"slacrawl", "--json", "search"}, JSON: true},
+		"tap":         {Title: "Import desktop cache", Argv: []string{"slacrawl", "--json", "sync", "--source", "desktop"}, JSON: true, Mutates: true},
+		"tui":         {Title: "Terminal browser", Argv: []string{"slacrawl", "tui"}},
+		"tui-json":    {Title: "Terminal browser rows", Argv: []string{"slacrawl", "tui", "--json"}, JSON: true},
+		"publish":     {Title: "Publish share", Argv: []string{"slacrawl", "--json", "publish"}, JSON: true, Mutates: true},
+		"subscribe":   {Title: "Subscribe share", Argv: []string{"slacrawl", "--json", "subscribe"}, JSON: true, Mutates: true},
+		"update":      {Title: "Update share", Argv: []string{"slacrawl", "--json", "update"}, JSON: true, Mutates: true},
+		"legacy-json": {Title: "Legacy JSON flag", Argv: []string{"slacrawl", "--json"}, JSON: true, Legacy: true},
+	}
+	return manifest
+}

--- a/internal/cli/control_test.go
+++ b/internal/cli/control_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/openclaw/crawlkit/control"
+	"github.com/openclaw/slacrawl/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControlManifest(t *testing.T) {
+	manifest := controlManifest("/tmp/slacrawl-config.toml")
+	defaults := config.Default()
+
+	require.Equal(t, control.SchemaVersion, manifest.SchemaVersion)
+	require.Equal(t, "slacrawl", manifest.ID)
+	require.Equal(t, "Slack Crawl", manifest.DisplayName)
+	require.Equal(t, "Local-first Slack archive crawler.", manifest.Description)
+	require.Equal(t, "number", manifest.Branding.SymbolName)
+	require.Equal(t, "#4a154b", manifest.Branding.AccentColor)
+	require.Equal(t, "com.tinyspeck.slackmacgap", manifest.Branding.BundleIdentifier)
+	require.Equal(t, "/tmp/slacrawl-config.toml", manifest.Paths.DefaultConfig)
+	require.Equal(t, "SLACRAWL_CONFIG", manifest.Paths.ConfigEnv)
+	require.Equal(t, defaults.DBPath, manifest.Paths.DefaultDatabase)
+	require.Equal(t, defaults.CacheDir, manifest.Paths.DefaultCache)
+	require.Equal(t, defaults.LogDir, manifest.Paths.DefaultLogs)
+	require.Equal(t, defaults.Share.RepoPath, manifest.Paths.DefaultShare)
+	require.Equal(t, []string{"metadata", "doctor", "status", "sync", "search", "watch", "tap", "tui", "sql", "git-share"}, manifest.Capabilities)
+	require.Equal(t, control.Privacy{
+		ContainsPrivateMessages: true,
+		LocalOnlyScopes:         []string{"slack", "desktop-cache", "sqlite", "git-share"},
+	}, manifest.Privacy)
+	require.Equal(t, map[string]control.Command{
+		"doctor":      {Title: "Doctor", Argv: []string{"slacrawl", "--json", "doctor"}, JSON: true},
+		"status":      {Title: "Status", Argv: []string{"slacrawl", "--json", "status"}, JSON: true},
+		"sync":        {Title: "Sync", Argv: []string{"slacrawl", "--json", "sync", "--source", "all", "--latest-only"}, JSON: true, Mutates: true},
+		"search":      {Title: "Search", Argv: []string{"slacrawl", "--json", "search"}, JSON: true},
+		"tap":         {Title: "Import desktop cache", Argv: []string{"slacrawl", "--json", "sync", "--source", "desktop"}, JSON: true, Mutates: true},
+		"tui":         {Title: "Terminal browser", Argv: []string{"slacrawl", "tui"}},
+		"tui-json":    {Title: "Terminal browser rows", Argv: []string{"slacrawl", "tui", "--json"}, JSON: true},
+		"publish":     {Title: "Publish share", Argv: []string{"slacrawl", "--json", "publish"}, JSON: true, Mutates: true},
+		"subscribe":   {Title: "Subscribe share", Argv: []string{"slacrawl", "--json", "subscribe"}, JSON: true, Mutates: true},
+		"update":      {Title: "Update share", Argv: []string{"slacrawl", "--json", "update"}, JSON: true, Mutates: true},
+		"legacy-json": {Title: "Legacy JSON flag", Argv: []string{"slacrawl", "--json"}, JSON: true, Legacy: true},
+	}, manifest.Commands)
+}


### PR DESCRIPTION
## Summary

Main already shipped the CrawlKit control manifest. This PR refines that existing surface without dropping its established paths, privacy declaration, capabilities, or commands.

- use Slack-accurate branding and a scheduler-friendly all-source, latest-only `sync` argv
- advertise the existing `search` and `watch` capabilities while preserving `tap`, `tui`, `sql`, and `git-share`
- resolve `default_config` from the active `--config` path while retaining `SLACRAWL_CONFIG`
- extract manifest construction into `controlManifest` and cover its exact values with a focused test

## Verification

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `go run ./cmd/slacrawl metadata --json`
