### PR TITLE
perf: batch ingest paths through per-page write transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Performance
+
+- Batch Slack API, desktop, MCP, and import ingestion into per-page write transactions (~3.4x faster sync writes).
+
 ### Maintenance
 
 - Updated CrawlKit to 0.14.6, fixing the archive TUI filter (typing `q` no longer quits and backspace is rune-safe for CJK/emoji queries) and preventing slow refreshes from stacking overlapping refresh goroutines.

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -22,8 +22,10 @@ import (
 )
 
 const (
-	slackExportSourceName = "slack-export"
-	slackExportSourceRank = 2
+	slackExportSourceName      = "slack-export"
+	slackExportSourceRank      = 2
+	importMessageBatchSize     = 500
+	importCollisionLookupChunk = 499
 )
 
 type ImportReport struct {
@@ -175,6 +177,7 @@ func runImportExecution(ctx context.Context, st *store.Store, ex *importer.Expor
 	progress := make([]importChannelProgress, 0, len(allChannels))
 	for _, channel := range allChannels {
 		row := importChannelProgress{ID: channel.ID, Name: channel.Name, Kind: channel.Kind}
+		batch := store.WriteBatch{Messages: make([]store.MessageWrite, 0, importMessageBatchSize)}
 		candidates := []string{channel.Name}
 		if channel.ID != "" && channel.ID != channel.Name {
 			candidates = append(candidates, channel.ID)
@@ -207,12 +210,21 @@ func runImportExecution(ctx context.Context, st *store.Store, ex *importer.Expor
 				if dryRun {
 					continue
 				}
-				if err := st.UpsertMessage(ctx, message, mentions); err != nil {
-					return ImportReport{}, nil, err
+				batch.Messages = append(batch.Messages, store.MessageWrite{Message: message, Mentions: mentions})
+				if len(batch.Messages) == importMessageBatchSize {
+					if _, err := st.ApplyWriteBatch(ctx, batch); err != nil {
+						return ImportReport{}, nil, err
+					}
+					batch.Messages = batch.Messages[:0]
 				}
 			}
 			if channelRows > 0 {
 				break
+			}
+		}
+		if len(batch.Messages) > 0 {
+			if _, err := st.ApplyWriteBatch(ctx, batch); err != nil {
+				return ImportReport{}, nil, err
 			}
 		}
 		progress = append(progress, row)
@@ -229,6 +241,8 @@ func validateImportMessageKeys(ctx context.Context, st *store.Store, ex *importe
 		}
 		for _, candidate := range candidates {
 			channelRows := 0
+			timestamps := make([]string, 0)
+			seenTimestamps := map[string]struct{}{}
 			for env, iterErr := range ex.Messages(candidate) {
 				if iterErr != nil {
 					return iterErr
@@ -238,12 +252,58 @@ func validateImportMessageKeys(ctx context.Context, st *store.Store, ex *importe
 				if ts == "" {
 					continue
 				}
-				if err := rejectCrossWorkspaceMessageCollision(ctx, st, workspaceID, channel.ID, ts); err != nil {
-					return err
+				if _, seen := seenTimestamps[ts]; !seen {
+					seenTimestamps[ts] = struct{}{}
+					timestamps = append(timestamps, ts)
 				}
+			}
+			if err := rejectCrossWorkspaceMessageCollisions(ctx, st, workspaceID, channel.ID, timestamps); err != nil {
+				return err
 			}
 			if channelRows > 0 {
 				break
+			}
+		}
+	}
+	return nil
+}
+
+func rejectCrossWorkspaceMessageCollisions(ctx context.Context, st *store.Store, workspaceID, channelID string, timestamps []string) error {
+	for start := 0; start < len(timestamps); start += importCollisionLookupChunk {
+		end := min(start+importCollisionLookupChunk, len(timestamps))
+		chunk := timestamps[start:end]
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, channelID)
+		for _, ts := range chunk {
+			args = append(args, ts)
+		}
+		query := `
+select ts, workspace_id
+from messages
+where channel_id = ? and ts in (` + strings.TrimSuffix(strings.Repeat("?,", len(chunk)), ",") + `)
+`
+		rows, err := st.DB().QueryContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		existing := make(map[string]string, len(chunk))
+		for rows.Next() {
+			var ts, existingWorkspaceID string
+			if err := rows.Scan(&ts, &existingWorkspaceID); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			existing[ts] = existingWorkspaceID
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		for _, ts := range chunk {
+			if existingWorkspaceID, ok := existing[ts]; ok && existingWorkspaceID != workspaceID {
+				return fmt.Errorf("message %s/%s already exists in workspace %s; cross-workspace channel/timestamp collisions are not supported", channelID, ts, existingWorkspaceID)
 			}
 		}
 	}

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -518,28 +518,41 @@ func (c *Client) syncChannelMessagesWithSource(ctx context.Context, st *store.St
 			}
 			return fmt.Errorf("channel %s history: %w", channel.ID, err)
 		}
+		batch := store.WriteBatch{Messages: make([]store.MessageWrite, 0, len(resp.Messages))}
+		threadTSs := make([]string, 0)
+		queuedThreads := map[string]struct{}{}
 		for _, rawMsg := range resp.Messages {
 			msg := rawMsg.Message
 			if msg.Channel == "" {
 				msg.Channel = channel.ID
 			}
-			stored := toStoreMessage(workspaceID, msg, source.sourceName, source.sourceRank, rawMsg.RawPayload, now)
-			var err error
-			if enforceRetention {
-				_, err = st.UpsertMessageWithRetention(ctx, stored, toStoreMentions(msg))
-			} else {
-				err = st.UpsertMessage(ctx, stored, toStoreMentions(msg))
-			}
-			if err != nil {
-				if !c.skipMessageCollision(err, workspaceID, channel.ID, msg.Timestamp) {
-					return err
-				}
-				continue
-			}
+			batch.Messages = append(batch.Messages, store.MessageWrite{
+				Message:                toStoreMessage(workspaceID, msg, source.sourceName, source.sourceRank, rawMsg.RawPayload, now),
+				Mentions:               toStoreMentions(msg),
+				EnforceRetention:       enforceRetention,
+				SkipWorkspaceCollision: true,
+			})
 			if msg.ReplyCount > 0 && userRepliesAvailable {
-				if err := syncThreadOnce(msg.Timestamp); err != nil {
-					return err
+				if _, synced := syncedThreads[msg.Timestamp]; !synced {
+					if _, queued := queuedThreads[msg.Timestamp]; !queued {
+						queuedThreads[msg.Timestamp] = struct{}{}
+						threadTSs = append(threadTSs, msg.Timestamp)
+					}
 				}
+			}
+		}
+		if len(batch.Messages) > 0 {
+			result, err := st.ApplyWriteBatch(ctx, batch)
+			if err != nil {
+				return err
+			}
+			for _, skip := range result.CollisionsSkipped {
+				c.skipMessageCollision(skip.Err, workspaceID, skip.ChannelID, skip.TS)
+			}
+		}
+		for _, threadTS := range threadTSs {
+			if err := syncThreadOnce(threadTS); err != nil {
+				return err
 			}
 		}
 		if resp.NextCursor == "" {
@@ -562,23 +575,26 @@ func (c *Client) syncThread(ctx context.Context, st *store.Store, workspaceID st
 		if err != nil {
 			return err
 		}
+		batch := store.WriteBatch{Messages: make([]store.MessageWrite, 0, len(resp.Messages))}
 		for _, rawMsg := range resp.Messages {
 			msg := rawMsg.Message
 			if msg.Channel == "" {
 				msg.Channel = channelID
 			}
-			stored := toStoreMessage(workspaceID, msg, SourceUser, 1, rawMsg.RawPayload, now)
-			var err error
-			if enforceRetention {
-				_, err = st.UpsertMessageWithRetention(ctx, stored, toStoreMentions(msg))
-			} else {
-				err = st.UpsertMessage(ctx, stored, toStoreMentions(msg))
-			}
+			batch.Messages = append(batch.Messages, store.MessageWrite{
+				Message:                toStoreMessage(workspaceID, msg, SourceUser, 1, rawMsg.RawPayload, now),
+				Mentions:               toStoreMentions(msg),
+				EnforceRetention:       enforceRetention,
+				SkipWorkspaceCollision: true,
+			})
+		}
+		if len(batch.Messages) > 0 {
+			result, err := st.ApplyWriteBatch(ctx, batch)
 			if err != nil {
-				if !c.skipMessageCollision(err, workspaceID, channelID, msg.Timestamp) {
-					return err
-				}
-				continue
+				return err
+			}
+			for _, skip := range result.CollisionsSkipped {
+				c.skipMessageCollision(skip.Err, workspaceID, skip.ChannelID, skip.TS)
 			}
 		}
 		if resp.NextCursor == "" {

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -541,6 +541,7 @@ func (c *Client) syncChannelMessagesWithSource(ctx context.Context, st *store.St
 				}
 			}
 		}
+		collidedTSs := map[string]struct{}{}
 		if len(batch.Messages) > 0 {
 			result, err := st.ApplyWriteBatch(ctx, batch)
 			if err != nil {
@@ -548,9 +549,14 @@ func (c *Client) syncChannelMessagesWithSource(ctx context.Context, st *store.St
 			}
 			for _, skip := range result.CollisionsSkipped {
 				c.skipMessageCollision(skip.Err, workspaceID, skip.ChannelID, skip.TS)
+				collidedTSs[skip.TS] = struct{}{}
 			}
 		}
 		for _, threadTS := range threadTSs {
+			// A collided parent belongs to another workspace; its thread does too.
+			if _, collided := collidedTSs[threadTS]; collided {
+				continue
+			}
 			if err := syncThreadOnce(threadTS); err != nil {
 				return err
 			}

--- a/internal/slackdesktop/desktop.go
+++ b/internal/slackdesktop/desktop.go
@@ -483,6 +483,13 @@ func Ingest(ctx context.Context, st *store.Store, sourcePath string, opts Ingest
 			UpdatedAt:   now,
 		})
 	}
+	draftBatch := store.WriteBatch{Messages: make([]store.MessageWrite, 0, len(extracted.Drafts))}
+	type legacyDraftDeletion struct {
+		workspaceID string
+		channelID   string
+		ts          string
+	}
+	legacyDraftDeletions := make([]legacyDraftDeletion, 0)
 	for _, draft := range extracted.Drafts {
 		if len(draft.Destinations) == 0 {
 			continue
@@ -538,13 +545,26 @@ func Ingest(ctx context.Context, st *store.Store, sourcePath string, opts Ingest
 		if message.Text == "" {
 			continue
 		}
-		if err := upsertDesktopMessage(ctx, st, message, nil); err != nil {
+		draftBatch.Messages = append(draftBatch.Messages, store.MessageWrite{
+			Message:                message,
+			SkipWorkspaceCollision: true,
+		})
+		if legacyTS := legacyDraftTS(draft); legacyTS != message.TS {
+			legacyDraftDeletions = append(legacyDraftDeletions, legacyDraftDeletion{
+				workspaceID: workspaceID,
+				channelID:   channelID,
+				ts:          legacyTS,
+			})
+		}
+	}
+	if len(draftBatch.Messages) > 0 {
+		if _, err := st.ApplyWriteBatch(ctx, draftBatch); err != nil {
 			return Source{}, err
 		}
-		if legacyTS := legacyDraftTS(draft); legacyTS != message.TS {
-			if _, err := st.DeleteMessageBySource(ctx, workspaceID, channelID, legacyTS, draftSourceName); err != nil {
-				return Source{}, err
-			}
+	}
+	for _, deletion := range legacyDraftDeletions {
+		if _, err := st.DeleteMessageBySource(ctx, deletion.workspaceID, deletion.channelID, deletion.ts, draftSourceName); err != nil {
+			return Source{}, err
 		}
 	}
 	for _, channel := range channelHints {
@@ -822,17 +842,6 @@ func upsertDesktopUser(ctx context.Context, st *store.Store, user store.User) er
 		return nil
 	}
 	if store.IsWorkspaceCollision(err, "user") {
-		return nil
-	}
-	return err
-}
-
-func upsertDesktopMessage(ctx context.Context, st *store.Store, message store.Message, mentions []store.Mention) error {
-	err := st.UpsertMessage(ctx, message, mentions)
-	if err == nil {
-		return nil
-	}
-	if store.IsWorkspaceCollision(err, "message") {
 		return nil
 	}
 	return err

--- a/internal/slackdesktop/redux.go
+++ b/internal/slackdesktop/redux.go
@@ -252,6 +252,7 @@ func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecod
 				return err
 			}
 		}
+		messageBatch := store.WriteBatch{Messages: make([]store.MessageWrite, 0, min(len(state.Messages), 500))}
 		for _, message := range state.Messages {
 			if message.Channel == "" || message.TS == "" {
 				continue
@@ -286,25 +287,38 @@ func ingestReduxStates(ctx context.Context, st *store.Store, states []ReduxDecod
 			if message.ParentUserID != "" {
 				referencedUsers[message.ParentUserID] = struct{}{}
 			}
-			if err := upsertDesktopMessage(ctx, st, store.Message{
-				ChannelID:      message.Channel,
-				TS:             message.TS,
-				WorkspaceID:    workspaceID,
-				UserID:         message.User,
-				Subtype:        message.Subtype,
-				ClientMsgID:    message.ClientMsgID,
-				ThreadTS:       message.ThreadTS,
-				ParentUserID:   message.ParentUserID,
-				Text:           text,
-				NormalizedText: normalizeReduxMessage(message),
-				ReplyCount:     message.ReplyCount,
-				LatestReply:    message.LatestReply,
-				EditedTS:       editedTS(message),
-				SourceRank:     3,
-				SourceName:     indexedDBSourceName,
-				RawJSON:        store.MarshalRaw(message),
-				UpdatedAt:      now,
-			}, reduxMentions(message.Text)); err != nil {
+			messageBatch.Messages = append(messageBatch.Messages, store.MessageWrite{
+				Message: store.Message{
+					ChannelID:      message.Channel,
+					TS:             message.TS,
+					WorkspaceID:    workspaceID,
+					UserID:         message.User,
+					Subtype:        message.Subtype,
+					ClientMsgID:    message.ClientMsgID,
+					ThreadTS:       message.ThreadTS,
+					ParentUserID:   message.ParentUserID,
+					Text:           text,
+					NormalizedText: normalizeReduxMessage(message),
+					ReplyCount:     message.ReplyCount,
+					LatestReply:    message.LatestReply,
+					EditedTS:       editedTS(message),
+					SourceRank:     3,
+					SourceName:     indexedDBSourceName,
+					RawJSON:        store.MarshalRaw(message),
+					UpdatedAt:      now,
+				},
+				Mentions:               reduxMentions(message.Text),
+				SkipWorkspaceCollision: true,
+			})
+			if len(messageBatch.Messages) == 500 {
+				if _, err := st.ApplyWriteBatch(ctx, messageBatch); err != nil {
+					return err
+				}
+				messageBatch.Messages = messageBatch.Messages[:0]
+			}
+		}
+		if len(messageBatch.Messages) > 0 {
+			if _, err := st.ApplyWriteBatch(ctx, messageBatch); err != nil {
 				return err
 			}
 		}

--- a/internal/slackmcp/sync.go
+++ b/internal/slackmcp/sync.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	SourceName = "mcp"
-	SourceRank = 4
+	SourceName          = "mcp"
+	SourceRank          = 4
+	maxMessageBatchSize = 500
 )
 
 var channelIDRE = regexp.MustCompile(`^[CDG][A-Z0-9]+$`)
@@ -117,17 +118,27 @@ func Sync(ctx context.Context, st *store.Store, opts Options) (Summary, error) {
 		summary.Channels++
 
 		threadRoots := map[string]struct{}{}
+		batch := store.WriteBatch{Messages: make([]store.MessageWrite, 0, min(len(channelResult.Messages), maxMessageBatchSize))}
 		for _, message := range channelResult.Messages {
-			stored, err := upsertMessage(ctx, st, workspaceID, message, enforceRetention, now)
-			if err != nil {
-				return summary, err
-			}
-			if stored {
-				summary.Messages++
+			batch.Messages = append(batch.Messages, toMessageWrite(workspaceID, message, enforceRetention, now))
+			if len(batch.Messages) == maxMessageBatchSize {
+				result, err := st.ApplyWriteBatch(ctx, batch)
+				if err != nil {
+					return summary, err
+				}
+				summary.Messages += result.MessagesWritten
+				batch.Messages = batch.Messages[:0]
 			}
 			if message.ReplyCount > 0 {
 				threadRoots[message.TS] = struct{}{}
 			}
+		}
+		if len(batch.Messages) > 0 {
+			result, err := st.ApplyWriteBatch(ctx, batch)
+			if err != nil {
+				return summary, err
+			}
+			summary.Messages += result.MessagesWritten
 		}
 		if tools.readThread == "" {
 			continue
@@ -180,21 +191,24 @@ func syncThread(ctx context.Context, st *store.Store, client *Client, tools tool
 	if thread.Parent != nil && (len(thread.Replies) > 0 || thread.Parent.ReplyCount > 0 || strings.TrimSpace(thread.Parent.LatestReply) != "") {
 		thread.Parent.ReplyCount = max(thread.Parent.ReplyCount, len(thread.Replies))
 		thread.Parent.LatestReply = latestReplyTS(thread.Parent.LatestReply, thread.Replies)
-		if _, err := upsertMessage(ctx, st, workspaceID, *thread.Parent, enforceRetention, now); err != nil {
+		if _, err := st.ApplyWriteBatch(ctx, store.WriteBatch{Messages: []store.MessageWrite{
+			toMessageWrite(workspaceID, *thread.Parent, enforceRetention, now),
+		}}); err != nil {
 			return 0, err
 		}
 	}
-	stored := 0
+	batch := store.WriteBatch{Messages: make([]store.MessageWrite, 0, len(thread.Replies))}
 	for _, reply := range thread.Replies {
-		written, err := upsertMessage(ctx, st, workspaceID, reply, enforceRetention, now)
-		if err != nil {
-			return 0, err
-		}
-		if written {
-			stored++
-		}
+		batch.Messages = append(batch.Messages, toMessageWrite(workspaceID, reply, enforceRetention, now))
 	}
-	return stored, nil
+	if len(batch.Messages) == 0 {
+		return 0, nil
+	}
+	result, err := st.ApplyWriteBatch(ctx, batch)
+	if err != nil {
+		return 0, err
+	}
+	return result.MessagesWritten, nil
 }
 
 func resolveChannels(ctx context.Context, client *Client, tools toolset, selectors []string) ([]ChannelRecord, error) {
@@ -334,7 +348,7 @@ func toStoreUser(workspaceID string, user UserRecord, now time.Time) store.User 
 	}
 }
 
-func upsertMessage(ctx context.Context, st *store.Store, workspaceID string, message MessageRecord, enforceRetention bool, now time.Time) (bool, error) {
+func toMessageWrite(workspaceID string, message MessageRecord, enforceRetention bool, now time.Time) store.MessageWrite {
 	threadTS := message.ThreadTS
 	if threadTS == message.TS {
 		threadTS = ""
@@ -373,10 +387,12 @@ func upsertMessage(ctx context.Context, st *store.Store, workspaceID string, mes
 		UpdatedAt:      now,
 		Files:          nil,
 	}
-	if enforceRetention {
-		return st.UpsertMessageByPriorityWithRetention(ctx, stored, storedMentions)
+	return store.MessageWrite{
+		Message:                stored,
+		Mentions:               storedMentions,
+		PreserveHigherPriority: true,
+		EnforceRetention:       enforceRetention,
 	}
-	return st.UpsertMessageByPriority(ctx, stored, storedMentions)
 }
 
 func latestReplyTS(current string, replies []MessageRecord) string {

--- a/internal/store/batch_test.go
+++ b/internal/store/batch_test.go
@@ -126,6 +126,48 @@ func TestApplyWriteBatchRollsBackMessagesAndCheckpointOnFailure(t *testing.T) {
 	assertBatchCount(t, st, `select count(*) from sync_state where source_name = 'provider:test'`, 0)
 }
 
+func TestApplyWriteBatchCanSkipMessageWorkspaceCollisions(t *testing.T) {
+	t.Run("skip collision", func(t *testing.T) {
+		st := openBatchTestStore(t)
+		ctx := context.Background()
+		now := time.Now().UTC()
+		seedBatchCatalog(t, st, "T1", "C1", "U1", now)
+		seedBatchCatalog(t, st, "T2", "C2", "U2", now)
+		require.NoError(t, st.UpsertMessage(ctx, batchMessage("C2", "2.000002", "T2", "existing", now), nil))
+
+		result, err := st.ApplyWriteBatch(ctx, WriteBatch{Messages: []MessageWrite{
+			{Message: batchMessage("C1", "1.000001", "T1", "first", now)},
+			{Message: batchMessage("C2", "2.000002", "T1", "collision", now), SkipWorkspaceCollision: true},
+			{Message: batchMessage("C1", "3.000003", "T1", "last", now)},
+		}})
+		require.NoError(t, err)
+		require.Equal(t, 2, result.MessagesWritten)
+		require.Len(t, result.CollisionsSkipped, 1)
+		require.Equal(t, "C2", result.CollisionsSkipped[0].ChannelID)
+		require.Equal(t, "2.000002", result.CollisionsSkipped[0].TS)
+		require.Error(t, result.CollisionsSkipped[0].Err)
+		require.True(t, IsWorkspaceCollision(result.CollisionsSkipped[0].Err, "message"))
+		assertBatchCount(t, st, `select count(*) from messages where workspace_id = 'T1' and channel_id = 'C1'`, 2)
+		assertBatchCount(t, st, `select count(*) from messages where workspace_id = 'T2' and channel_id = 'C2' and text = 'existing'`, 1)
+	})
+
+	t.Run("abort collision", func(t *testing.T) {
+		st := openBatchTestStore(t)
+		ctx := context.Background()
+		now := time.Now().UTC()
+		seedBatchCatalog(t, st, "T1", "C1", "U1", now)
+		seedBatchCatalog(t, st, "T2", "C2", "U2", now)
+		require.NoError(t, st.UpsertMessage(ctx, batchMessage("C2", "2.000002", "T2", "existing", now), nil))
+
+		_, err := st.ApplyWriteBatch(ctx, WriteBatch{Messages: []MessageWrite{
+			{Message: batchMessage("C1", "1.000001", "T1", "first", now)},
+			{Message: batchMessage("C2", "2.000002", "T1", "collision", now)},
+		}})
+		require.ErrorContains(t, err, "already belongs to workspace")
+		assertBatchCount(t, st, `select count(*) from messages where workspace_id = 'T1' and channel_id = 'C1'`, 0)
+	})
+}
+
 func TestApplyWriteBatchRollsBackWhenCheckpointWriteFails(t *testing.T) {
 	st := openBatchTestStore(t)
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -393,6 +393,7 @@ type MessageWrite struct {
 	Mentions               []Mention
 	PreserveHigherPriority bool
 	EnforceRetention       bool
+	SkipWorkspaceCollision bool
 	// SkipUnchangedProviderRow avoids derived-index rewrites for provider rows
 	// whose scalar state, mentions, and event head already match. It is not a
 	// general repair path and deliberately refuses messages with file payloads.
@@ -414,8 +415,15 @@ type WriteBatch struct {
 	SyncStates []SyncStateWrite
 }
 
+type CollisionSkip struct {
+	ChannelID string
+	TS        string
+	Err       error
+}
+
 type WriteBatchResult struct {
-	MessagesWritten int
+	MessagesWritten   int
+	CollisionsSkipped []CollisionSkip
 }
 
 type Mention struct {
@@ -1015,6 +1023,10 @@ func (s *Store) ApplyWriteBatch(ctx context.Context, batch WriteBatch) (WriteBat
 		}
 		written, err := upsertMessageInTransaction(ctx, dbtx, qtx, write.Message, write.Mentions, write.PreserveHigherPriority, write.EnforceRetention)
 		if err != nil {
+			if write.SkipWorkspaceCollision && IsWorkspaceCollision(err, "message") {
+				result.CollisionsSkipped = append(result.CollisionsSkipped, CollisionSkip{ChannelID: write.Message.ChannelID, TS: write.Message.TS, Err: err})
+				continue
+			}
 			return WriteBatchResult{}, err
 		}
 		if written {


### PR DESCRIPTION
Every ingest path except the provider ran one `BEGIN IMMEDIATE` transaction per message (~10 statements each, serialized through `MaxOpenConns(1)`). Benchmarking showed tx-per-page is ~3.4x faster. This converts the remaining paths to accumulate a page of messages into `store.WriteBatch` and commit per page, following the provider idiom:

- **slackapi**: history pages and thread-reply pages batch per API page; thread syncs run after the page commits, and thread-skip/channel-skip sync-state bookkeeping stays outside the batch.
- **slackmcp**: channel messages flush every 500; `summary.Messages` now comes from `WriteBatchResult.MessagesWritten` (identical semantics). Thread parents are batched separately from replies so the reply count stays exact.
- **slackdesktop**: redux states and drafts batch per state/pass; legacy-draft deletions run after the batch commit.
- **cli/import**: batches 500 messages per flush; `validateImportMessageKeys` replaces per-message point queries with a chunked bulk `IN`-list lookup (499/chunk, matching the store preflight precedent), preserving the exact error text.

New additive store flag `MessageWrite.SkipWorkspaceCollision` turns cross-workspace message collisions into clean in-batch skips. This is transactionally safe: in the batch flow a collision only surfaces after a zero-row upsert, before any writes for that message. `WriteBatchResult.CollisionsSkipped` reports the skipped keys so the Slack API sync replays each through `skipMessageCollision`, preserving the per-message warning logs #131 introduced — and a collided parent's thread is not queued for thread sync, matching #131's skip semantics. Desktop paths keep their historical silent skip. Covered by tests in `internal/store/batch_test.go` (skip-and-commit and default-abort cases).

Intentional semantic shift: a mid-page write failure now rolls back the whole page instead of leaving earlier messages committed — the intended atomicity of page-sized transactions.

Proof: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...` all green on top of `10e287b`.
