### PR TITLE
chore(release): prepare v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.3 - 2026-08-07
 
 ### Performance
 


### PR DESCRIPTION
Flips Unreleased to v0.8.3 - 2026-08-07 ahead of the unified release dispatch.

Ships the per-page ingest batching (#138) and the CrawlKit 0.14.6 bump (#136) that landed after v0.8.2.

Local proof on this tree: `go build`, `go test ./...`, `go test -race ./...`, `go vet`, `govulncheck` (no vulnerabilities), `make lint`, `make smoke`, `make tidy-check fmt-check` — all clean.