### PR TITLE
ci: bump codeql-action init and analyze to v4.37.6 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,9 +30,9 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: go
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6


### PR DESCRIPTION
Bumps both `github/codeql-action/init` and `github/codeql-action/analyze` from
v4.37.4 to v4.37.6 in a single commit.

Dependabot split this into two PRs (#140 for `init`, #141 for `analyze`), but
the two actions must run at the same version. Either PR alone leaves the
workflow mismatched and CodeQL fails with a configuration error:

```
##[error]Loaded a configuration file for version '4.37.6', but running version '4.37.4'
CodeQL job status was configuration error.
```

That is why both dependabot PRs are red on an otherwise green tree. Landing the
two bumps together is the only combination that passes.

The pinned SHA `5595ccaf912efad79be6eef63a5619ff05969be3` was verified against
upstream rather than taken on trust: the annotated tag `v4.37.6` in
`github/codeql-action` is object `9e3211c9a3b9311dfe05da2ed48eea3386f042dd`,
which dereferences to that commit.

Closes #140. Closes #141.
