### PR TITLE
chore(release): prepare v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.4 - 2026-08-13
 
 ### Changes
 


### PR DESCRIPTION
Stamps the changelog for the v0.8.4 patch release (read-only local archive queries + metadata control manifest refinements).