### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Maintenance
+
+- Updated the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
+
 ## v0.8.4 - 2026-08-13
 
 ### Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for contributing. This project is still early, so the main goal is to kee
 
 Requirements:
 
-- Go `1.26.5+`
+- Go `1.26.6+`
 - SQLite with FTS5 support
 
 Build and test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 ARG ALPINE_VERSION=3.23
 
-FROM golang:${GO_VERSION}-alpine AS build
+FROM golang:${GO_VERSION}-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS build
 RUN apk add --no-cache ca-certificates git
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install openclaw/tap/slacrawl
 
 The tap can trail the newest release. [GitHub Releases](https://github.com/openclaw/slacrawl/releases/latest) provides signed and notarized macOS archives, Linux archives, and Debian/RPM packages for AMD64 and ARM64.
 
-To build the latest source, install Go 1.26.5 or newer, then run:
+To build the latest source, install Go 1.26.6 or newer, then run:
 
 ```sh
 git clone https://github.com/openclaw/slacrawl.git

--- a/SPEC.md
+++ b/SPEC.md
@@ -54,7 +54,7 @@ Out of scope for V1:
 An agent should assume:
 
 - shell: `zsh`
-- Go `1.26.5+` is installed
+- Go `1.26.6+` is installed
 - desktop-local Slack data may exist under:
   - `~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack`
   - `${XDG_CONFIG_HOME}/Slack`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/slacrawl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.16.1


### PR DESCRIPTION
Raises the minimum Go toolchain and active build documentation to 1.26.6, and pins the Docker build stage to the fresh 1.26.6-alpine manifest digest. This clears GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218. Verified with the exact Go 1.26.6 build and test suite, govulncheck, a live CLI smoke, and the Docker build stage.