### PR TITLE
chore(release): prepare v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.8.5 - 2026-08-14
 
 ### Maintenance
 
 - Updated the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
-
 ## v0.8.4 - 2026-08-13
 
 ### Changes


### PR DESCRIPTION
Stamps the changelog for v0.8.5.