### PR TITLE
feat(mcp): add one-shot auth descriptor handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Every source feeds the same SQLite archive and search index.
 | --- | --- | --- |
 | Slack API | `slacrawl sync --source bot` | Token-backed channel history, users, threads, and incremental refreshes |
 | Slack Desktop | `slacrawl sync --source wiretap` | Read-only recovery from local macOS or Linux desktop caches |
-| MCP connector | `slacrawl sync --source mcp --workspace T01234567` | Connector-backed history without a direct Slack API integration |
+| MCP connector | `slacrawl sync --source mcp --workspace T01234567` | Connector-backed history; trusted parents can use `--mcp-auth-fd` for one-shot credentials |
 | External provider | `slacrawl sync --source provider:archive --workspace T01234567` | A trusted local JSONL adapter for another archive |
 | Slack export | `slacrawl import <path> --workspace T01234567` | ZIP or directory exports |
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -164,6 +164,9 @@ Expected flags:
 - `--full`
 - `--latest-only`
 - `--limit <messages>` for bounded external-provider validation imports
+- `--mcp-auth-fd <descriptor>` for one-shot credentials from a trusted parent
+- `--mcp-url <url>` to override the configured HTTP MCP endpoint
+- `--mcp-channel-types <csv>` to override configured MCP channel classes
 - `--concurrency <n>`
 - `--auto-join=<bool>`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,6 +48,11 @@ slacrawl sync --source mcp --workspace T01234567
 slacrawl sync --source wiretap
 ```
 
+Trusted parent processes can pass short-lived MCP credentials without argv,
+environment variables, or named files. See
+[MCP Connector Source](configuration.md#mcp-connector-source) for the
+`--mcp-auth-fd`, `--mcp-url`, and `--mcp-channel-types` workflow.
+
 Import a workspace export with an explicit workspace ID:
 
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,9 +162,31 @@ auth_path = "~/.codex/auth.json"
 
 HTTP authentication order:
 
-1. The configured `token_env` and optional `account_id_env`.
-2. `CODEX_APPS_ACCESS_TOKEN` or `CODEX_CONNECTORS_TOKEN`.
-3. The configured `auth_path`, using Codex's `tokens.access_token` and optional `tokens.account_id` fields.
+1. An inherited descriptor selected by `sync --mcp-auth-fd`; when present,
+   this explicit one-shot credential wins over ambient variables.
+2. The configured `token_env` and optional `account_id_env`.
+3. `CODEX_APPS_ACCESS_TOKEN` or `CODEX_CONNECTORS_TOKEN`.
+4. The configured `auth_path`, using Codex's `tokens.access_token` and optional
+   `tokens.account_id` fields.
+
+`--mcp-auth-fd` is intended for a trusted parent process. It consumes and
+closes an inherited descriptor containing the same JSON shape as `auth_path`,
+with a 64 KiB limit. This keeps a short-lived OAuth token out of argv,
+environment variables, and named files. The same invocation can use
+`--mcp-url` and `--mcp-channel-types` to override the MCP endpoint and visible
+channel classes without rewriting the persistent archive config:
+
+```bash
+slacrawl sync --source mcp --workspace T01234567 \
+  --mcp-url https://mcp.slack.com/mcp \
+  --mcp-channel-types public_channel,private_channel \
+  --mcp-auth-fd 3 --with-media=false
+```
+
+This command still uses normal Slacrawl upserts and cursors. Repeated runs
+deduplicate by Slack-native channel/message identity, overlap the newest
+per-channel cursor by one hour, and revisit stored thread roots. Excluding
+`im,mpim` from `--mcp-channel-types` prevents direct-message ingestion.
 
 `max_pages` bounds each users, channels, channel-history, and thread pagination loop; hitting the bound returns an error instead of silently accepting an incomplete page set. The Codex HTTP connector accepts at most 20 channel or user search results per request. Explicit channel IDs avoid global channel and user enumeration. Normal MCP sync overlaps the latest stored message timestamp per channel by one hour and rechecks persisted thread roots because Slack does not move an old root into channel history when it receives a new reply; `--full` removes the local channel cursor, while `--latest-only` skips channels with no local history. MCP is an explicit source and is not included in `--source all`.
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -498,6 +498,9 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	full := fs.Bool("full", false, "full sync")
 	latestOnly := fs.Bool("latest-only", false, "skip first-time historical backfills")
 	limit := fs.Int("limit", 0, "maximum provider messages (validation imports only)")
+	mcpAuthFD := fs.Int("mcp-auth-fd", -1, "inherited one-shot MCP auth file descriptor")
+	mcpURL := fs.String("mcp-url", "", "override the configured HTTP MCP endpoint")
+	mcpChannelTypes := fs.String("mcp-channel-types", "", "override MCP channel types")
 	concurrency := fs.Int("concurrency", cfg.Sync.Concurrency, "worker count")
 	withMedia := fs.Bool("with-media", cfg.FileMediaEnabled(), "fetch file media after sync")
 	autoJoin := fs.Bool("auto-join", cfg.Sync.AutoJoinResolved(), "auto-join public channels during sync")
@@ -509,6 +512,19 @@ func (a *App) runSync(ctx context.Context, configPath string, args []string, for
 	}
 	if *limit < 0 {
 		return errors.New("limit cannot be negative")
+	}
+	if *mcpAuthFD >= 0 {
+		if *mcpAuthFD < 3 || *mcpAuthFD > 1024 {
+			return errors.New("mcp-auth-fd must be an inherited descriptor between 3 and 1024")
+		}
+		cfg.Slack.MCP.AuthPath = fmt.Sprintf("fd:%d", *mcpAuthFD)
+	}
+	if strings.TrimSpace(*mcpURL) != "" {
+		cfg.Slack.MCP.Transport = "http"
+		cfg.Slack.MCP.BaseURL = strings.TrimSpace(*mcpURL)
+	}
+	if strings.TrimSpace(*mcpChannelTypes) != "" {
+		cfg.Slack.MCP.ChannelTypes = strings.TrimSpace(*mcpChannelTypes)
 	}
 
 	resolvedSource, err := syncer.ParseSource(*source)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -658,6 +658,22 @@ func TestCommandHelpAfterCompleteOptionsDoesNotLoadConfig(t *testing.T) {
 	require.Empty(t, stderr.String())
 }
 
+func TestSyncRejectsInvalidMCPAuthDescriptor(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	cfg := config.Default()
+	cfg.DBPath = filepath.Join(tmp, "slacrawl.db")
+	require.NoError(t, cfg.Save(configPath))
+
+	app := &App{Stdout: io.Discard, Stderr: io.Discard}
+	err := app.Run(context.Background(), []string{
+		"--config", configPath,
+		"sync", "--source", "mcp", "--workspace", "T1", "--mcp-auth-fd", "2",
+	})
+
+	require.ErrorContains(t, err, "mcp-auth-fd must be an inherited descriptor")
+}
+
 func TestCommandHelpRespectsFlagParserBoundaries(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -892,6 +908,7 @@ func TestCompletionBashOutput(t *testing.T) {
 	require.Contains(t, out, "--keep-message-events")
 	require.Contains(t, out, "--workspace --limit --help")
 	require.Contains(t, out, "--workspace --kind --limit --help")
+	require.Contains(t, out, "--mcp-auth-fd --mcp-url --mcp-channel-types")
 }
 
 func TestCompletionZshOutput(t *testing.T) {
@@ -924,6 +941,7 @@ func TestCompletionZshOutput(t *testing.T) {
 	require.Contains(t, out, "--restore[exactly replace snapshot tables instead of merging]")
 	require.Contains(t, out, "--workspace[workspace id]")
 	require.Contains(t, out, "'--limit[row limit]:limit:'")
+	require.Contains(t, out, "--mcp-auth-fd[inherited one-shot MCP auth descriptor]")
 }
 
 func TestReportIncludesArchiveAndShareState(t *testing.T) {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -176,7 +176,7 @@ _slacrawl()
 			COMPREPLY=( $(compgen -W "--repo --remote --branch --ref --restore --no-media --help -h ${global_flags}" -- "${cur}") )
             ;;
         sync)
-            COMPREPLY=( $(compgen -W "--source --workspace --channels --since --full --latest-only --concurrency --with-media --help -h ${global_flags}" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "--source --workspace --channels --since --full --latest-only --mcp-auth-fd --mcp-url --mcp-channel-types --concurrency --with-media --help -h ${global_flags}" -- "${cur}") )
             ;;
         import)
             COMPREPLY=( $(compgen -W "--workspace --dry-run --force --format --help -h ${global_flags}" -- "${cur}") )
@@ -314,7 +314,7 @@ _slacrawl() {
           _arguments '--repo[local clone path]:path:_files' '--remote[git remote]:remote:' '--branch[git branch]:branch:' '--ref[historical Git ref to import; requires --restore]:ref:' '--restore[exactly replace snapshot tables instead of merging]' '--no-media[skip restoring cached media]'
           ;;
         sync)
-          _arguments '--source[sync source]:source:(api bot desktop wiretap mcp connector all)' '--workspace[workspace id]:workspace id:' '--channels[channel ids]:channels:' '--since[start timestamp]:timestamp:' '--full[run full sync]' '--latest-only[skip first-time historical backfills]' '--concurrency[worker count]:count:' '--with-media[fetch file media after sync]'
+          _arguments '--source[sync source]:source:(api bot desktop wiretap mcp connector all)' '--workspace[workspace id]:workspace id:' '--channels[channel ids]:channels:' '--since[start timestamp]:timestamp:' '--full[run full sync]' '--latest-only[skip first-time historical backfills]' '--mcp-auth-fd[inherited one-shot MCP auth descriptor]:descriptor:' '--mcp-url[override configured HTTP MCP endpoint]:url:' '--mcp-channel-types[override MCP channel types]:types:' '--concurrency[worker count]:count:' '--with-media[fetch file media after sync]'
           ;;
         import)
           _arguments '--workspace[workspace id]:workspace id:' '--dry-run[walk and count without writing]' '--force[overwrite existing slack-export rows at the same rank]' '--format[output format]:format:(text json log)'

--- a/internal/slackmcp/adapter_test.go
+++ b/internal/slackmcp/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -316,6 +317,22 @@ func TestResolveAuthPrefersEnvironment(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "env-token", auth.AccessToken)
 	require.Equal(t, "acct-123", auth.AccountID)
+}
+
+func TestResolveAuthDescriptorOverridesAmbientEnvironmentAndIsConsumed(t *testing.T) {
+	t.Setenv("CODEX_APPS_ACCESS_TOKEN", "ambient-token")
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	_, err = writer.Write([]byte(`{"tokens":{"access_token":"one-shot-token","account_id":"test-account"}}`))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	auth, err := resolveAuth(config.MCPConfig{AuthPath: fmt.Sprintf("fd:%d", reader.Fd())})
+	require.NoError(t, err)
+	require.Equal(t, "one-shot-token", auth.AccessToken)
+	require.Equal(t, "test-account", auth.AccountID)
+	_, err = reader.Read(make([]byte, 1))
+	require.Error(t, err, "the one-shot descriptor should be closed after consumption")
 }
 
 func TestResolveSlackToolset(t *testing.T) {

--- a/internal/slackmcp/client.go
+++ b/internal/slackmcp/client.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/openclaw/slacrawl/internal/config"
@@ -351,7 +353,18 @@ type authInfo struct {
 	AccountID   string
 }
 
+const maxAuthFileBytes = 64 * 1024
+
 func resolveAuth(cfg config.MCPConfig) (authInfo, error) {
+	// An inherited descriptor is an explicit one-shot credential handoff. It
+	// must win over ambient Codex/connector variables inherited by the parent.
+	if strings.HasPrefix(strings.TrimSpace(cfg.AuthPath), "fd:") {
+		raw, err := readAuth(cfg.AuthPath)
+		if err != nil {
+			return authInfo{}, fmt.Errorf("read MCP auth descriptor: %w", err)
+		}
+		return decodeAuth(raw, "descriptor")
+	}
 	tokenEnv := cfg.TokenEnv
 	if tokenEnv == "" {
 		tokenEnv = "CODEX_APPS_ACCESS_TOKEN"
@@ -372,10 +385,14 @@ func resolveAuth(cfg config.MCPConfig) (authInfo, error) {
 	if strings.TrimSpace(cfg.AuthPath) == "" {
 		return authInfo{}, fmt.Errorf("MCP token environment variable %s is unset and auth_path is empty", tokenEnv)
 	}
-	raw, err := os.ReadFile(cfg.AuthPath)
+	raw, err := readAuth(cfg.AuthPath)
 	if err != nil {
 		return authInfo{}, fmt.Errorf("read MCP auth file %s: %w", cfg.AuthPath, err)
 	}
+	return decodeAuth(raw, cfg.AuthPath)
+}
+
+func decodeAuth(raw []byte, source string) (authInfo, error) {
 	var payload struct {
 		Tokens *struct {
 			AccessToken string `json:"access_token"`
@@ -383,12 +400,35 @@ func resolveAuth(cfg config.MCPConfig) (authInfo, error) {
 		} `json:"tokens"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
-		return authInfo{}, fmt.Errorf("parse MCP auth file %s: %w", cfg.AuthPath, err)
+		return authInfo{}, fmt.Errorf("parse MCP auth %s: %w", source, err)
 	}
 	if payload.Tokens == nil || strings.TrimSpace(payload.Tokens.AccessToken) == "" {
-		return authInfo{}, fmt.Errorf("MCP auth file %s does not contain tokens.access_token", cfg.AuthPath)
+		return authInfo{}, fmt.Errorf("MCP auth %s does not contain tokens.access_token", source)
 	}
 	return authInfo{AccessToken: strings.TrimSpace(payload.Tokens.AccessToken), AccountID: strings.TrimSpace(payload.Tokens.AccountID)}, nil
+}
+
+func readAuth(path string) ([]byte, error) {
+	if value, ok := strings.CutPrefix(strings.TrimSpace(path), "fd:"); ok {
+		descriptor, err := strconv.ParseUint(value, 10, 32)
+		if err != nil || descriptor < 3 || descriptor > 1024 {
+			return nil, errors.New("invalid MCP auth file descriptor")
+		}
+		file := os.NewFile(uintptr(descriptor), "mcp-auth")
+		if file == nil {
+			return nil, errors.New("invalid MCP auth file descriptor")
+		}
+		defer func() { _ = file.Close() }()
+		raw, err := io.ReadAll(io.LimitReader(file, maxAuthFileBytes+1))
+		if err != nil {
+			return nil, err
+		}
+		if len(raw) > maxAuthFileBytes {
+			return nil, errors.New("MCP auth payload is too large")
+		}
+		return raw, nil
+	}
+	return os.ReadFile(path)
 }
 
 func filterSlackTools(tools []mcpclient.Tool, connectorID string) ([]mcpclient.Tool, error) {


### PR DESCRIPTION
## Summary

- accept MCP OAuth credentials from an inherited, one-shot file descriptor
- allow per-invocation MCP URL and channel-type overrides without rewriting archive config
- document the secure parent-process workflow and complete shell flags

The descriptor is consumed and closed, bounded to 64 KiB, and takes precedence over ambient connector environment variables. This keeps short-lived user tokens out of argv, environment variables, and named files while preserving Slacrawl's existing incremental upserts and thread repair.

## Validation

- `GOWORK=off go test ./internal/slackmcp ./internal/cli`
- `GOWORK=off go test -count=1 ./...`
- `make check` passed module verification, formatting, vet, vulnerability scan, dead-code analysis, tests, and CLI smoke; the final release snapshot step could not run locally because `goreleaser` is not installed
