### PR TITLE
fix(mcp): honor context on stdio spawn and stdin write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Stop MCP stdio servers and unblock full stdin pipes when sync is canceled. Thanks @SebTardif! (#164)
+
 ### Maintenance
 
 - Updated Go to 1.27.0, SQLite to 1.57.0, Go runtime and test dependencies, Alpine to 3.24, pre-commit hooks to 6.0.0, and CodeQL and TruffleHog action pins.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,6 +188,8 @@ The subprocess receives a minimal environment plus known Slack/Codex token varia
 
 Tool discovery selects either the Codex Slack connector contract or the reference `slack_list_channels`, `slack_get_channel_history`, `slack_get_thread_replies`, and `slack_get_users` contract.
 
+Ctrl-C cancels MCP sync and stops its stdio server, including when the server stops reading requests and fills the stdin pipe.
+
 ## External Archive Providers
 
 Use `[[providers]]` to adapt another local archive to the canonical SQLite

--- a/internal/mcpclient/client_test.go
+++ b/internal/mcpclient/client_test.go
@@ -143,6 +143,60 @@ func TestStdioClientUsesMinimalEnvironment(t *testing.T) {
 	require.JSONEq(t, `{"allowed":"visible","secret":""}`, text)
 }
 
+func TestNewStdioRejectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client, err := NewStdio(ctx, StdioOptions{Command: "/bin/sleep", Args: []string{"30"}})
+	if client != nil {
+		_ = client.Close()
+	}
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, client)
+}
+
+func TestNewStdioStopsChildWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client, err := NewStdio(ctx, StdioOptions{Command: "/bin/sleep", Args: []string{"30"}})
+	require.NoError(t, err)
+	cancel()
+	select {
+	case <-client.waitCh:
+		_ = client.stdin.Close()
+	case <-time.After(5 * time.Second):
+		_ = client.Close()
+		t.Fatal("MCP stdio child still running after spawn context cancel")
+	}
+}
+
+func TestStdioWriteUnblocksWhenContextCanceled(t *testing.T) {
+	client, err := NewStdio(context.Background(), StdioOptions{Command: "/bin/sleep", Args: []string{"30"}})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- client.write(ctx, map[string]any{
+			"jsonrpc": "2.0",
+			"method":  "initialize",
+			"params":  map[string]any{"blob": strings.Repeat("x", 2<<20)},
+		})
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("write returned before cancel: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("write stayed blocked after context cancel")
+	}
+}
+
 func TestMCPStdioHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_MCP_STDIO_HELPER") != "1" {
 		return

--- a/internal/mcpclient/stdio.go
+++ b/internal/mcpclient/stdio.go
@@ -51,9 +51,12 @@ type StdioClient struct {
 	waitErr         error
 }
 
-func NewStdio(_ context.Context, opts StdioOptions) (*StdioClient, error) {
+func NewStdio(ctx context.Context, opts StdioOptions) (*StdioClient, error) {
 	if strings.TrimSpace(opts.Command) == "" {
 		return nil, errors.New("MCP stdio command is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 	if opts.ProtocolVersion == "" {
 		opts.ProtocolVersion = DefaultProtocolVersion
@@ -64,7 +67,7 @@ func NewStdio(_ context.Context, opts StdioOptions) (*StdioClient, error) {
 	if opts.ClientVersion == "" {
 		opts.ClientVersion = "dev"
 	}
-	cmd := exec.Command(opts.Command, opts.Args...)
+	cmd := exec.CommandContext(ctx, opts.Command, opts.Args...)
 	cmd.Env = stdioEnvironment(opts)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -277,10 +280,31 @@ func (c *StdioClient) write(ctx context.Context, value any) error {
 	}
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
-	if _, err := c.stdin.Write(append(raw, '\n')); err != nil {
-		return fmt.Errorf("write MCP stdio request: %w", err)
+	if err := ctx.Err(); err != nil {
+		return err
 	}
-	return nil
+	// Write from a goroutine so a child that stops reading stdin cannot
+	// park the caller after context cancel. Closing stdin and killing the
+	// process unblocks a full pipe, matching provider.Sync.
+	errCh := make(chan error, 1)
+	go func() {
+		_, writeErr := c.stdin.Write(append(raw, '\n'))
+		errCh <- writeErr
+	}()
+	select {
+	case <-ctx.Done():
+		_ = c.stdin.Close()
+		if c.cmd != nil && c.cmd.Process != nil {
+			_ = c.cmd.Process.Kill()
+		}
+		<-errCh
+		return ctx.Err()
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("write MCP stdio request: %w", err)
+		}
+		return nil
+	}
 }
 
 func (c *StdioClient) readLoop(stdout io.Reader) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `slacrawl sync --source mcp` with `transport = stdio` would hang forever when the MCP child stopped reading stdin. Ctrl-C canceled the Go context, but spawn used `exec.Command` and `stdin.Write` ignored that cancel, so the CLI never reached `Close()` and never killed the child.

## Why This Change Was Made

`NewStdio` now starts the child with `CommandContext` and fails immediately if the spawn context is already done. Stdin writes run in a goroutine and, on cancel, close the pipe and kill the child so a full pipe cannot park the caller. JSON-RPC framing is unchanged. This does not restack the desktop Node decoder bound ([#163](https://github.com/openclaw/slacrawl/pull/163)), the HTTP client timeout ([#126](https://github.com/openclaw/slacrawl/pull/126)), or the repeated-cursor guard ([#159](https://github.com/openclaw/slacrawl/pull/159)).

## User Impact

A stuck stdio MCP server no longer holds the CLI after cancel. `sync --source mcp` can return when the user stops the command, matching how `provider.Sync` already treats a hung provider child.

## Evidence

Call chain: `slacrawl sync --source mcp` with `transport = stdio` -> `slackmcp.Sync` -> `slackmcp.New` -> `mcpclient.NewStdio` -> `Initialize` / `CallToolText` -> `write`. The spawn used `exec.Command` (context discarded) since MCP stdio landed in [#46](https://github.com/openclaw/slacrawl/pull/46) on 2026-06-06 (84 days). `write` checked `ctx.Err()` once, then blocked on `stdin.Write`. `provider.Sync` already uses `CommandContext` and an async stdin write.

Before the patch, a 2MiB stdin write to a child that never reads (`sleep`) stayed blocked after a 400ms deadline:

```console
$ /tmp/f004proof.bin old-write
old write start
old write still blocked elapsed=401ms
```

After the patch, the same public `NewStdio` + `CallToolText` path against `/bin/sleep` returns when the 400ms deadline fires, and an already-canceled spawn context does not start a child:

```console
$ /tmp/f004proof.bin new-write
new write start
new write err=context deadline exceeded elapsed=403ms

$ /tmp/f004proof.bin new-spawn
new spawn start
new spawn err=context canceled elapsed=0s
```

## Real behavior proof

- **Behavior or issue addressed:** MCP stdio spawn and stdin write ignored cancel, so a child that stopped reading stdin parked `sync --source mcp` through Ctrl-C.
- **Real environment tested:** macOS, Go 1.27.0. Patched slacrawl at `/tmp/oc-pr-slacrawl-F004`. Child: `/bin/sleep` (never reads stdin). Proof binary built from `./tmpproof` against the patched module.
- **Exact steps or command run after this patch:** Built `/tmp/f004proof.bin` from the patched module and ran `old-write` (blocking `stdin.Write`), then `new-write` (`CallToolText` with a 2MiB payload and a 400ms deadline) and `new-spawn` (already-canceled `NewStdio` context).
- **Evidence after fix:** terminal output from the patched `NewStdio` / `CallToolText` binary:

  ```console
  old write start
  old write still blocked elapsed=401ms
  new write start
  new write err=context deadline exceeded elapsed=403ms
  new spawn start
  new spawn err=context canceled elapsed=0s
  ```

- **Observed result after fix:** `CallToolText` returned `context deadline exceeded` in 403ms instead of staying blocked on a full stdin pipe. `NewStdio` with a canceled context returned `context canceled` immediately and did not leave a sleep child running.
- **What was not tested:** A live Slack MCP npm server (`@modelcontextprotocol/server-slack`) that hangs after a real tools/call, and a Ctrl-C against that server from an operator terminal.
