### PR TITLE
chore: prepare v0.8.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.6 - 2026-08-31
 
 ### Fixes
 


### PR DESCRIPTION
Prepare v0.8.6 by converting the existing Unreleased heading to a dated release section. Preserve all three credited fixes and the maintenance notes verbatim so the unified release workflow can extract its required changelog section.

Validated with the shared workflow's exact release-notes extractor, `git diff --check`, and Codex autoreview (no actionable findings).
