### PR TITLE
fix(api): stop users.list pagination on a repeated cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Stop member-directory sync with a clear error when Slack repeats a `users.list` page cursor instead of requesting pages indefinitely. Thanks @SebTardif! (#169)
 - Limit release-check HTTP requests to 30 seconds through CrawlKit 0.14.8 so an unresponsive server cannot hang `check-update` indefinitely.
 
 ## v0.8.6 - 2026-08-31

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,7 +48,7 @@ slacrawl sync --source mcp --workspace T01234567
 slacrawl sync --source wiretap
 ```
 
-Slack API pagination stops with a `repeated cursor` error if a response revisits a page cursor, preventing a stuck sync. Pages already stored remain available for the next incremental sync.
+Slack API pagination, including the member directory (`users.list`), stops with a `repeated cursor` error if a response revisits a page cursor, preventing a stuck sync. Pages already stored remain available for the next incremental sync.
 
 Import a workspace export with an explicit workspace ID:
 

--- a/internal/slackapi/api.go
+++ b/internal/slackapi/api.go
@@ -945,9 +945,37 @@ func rawPayloadFromMessageJSON(rawMessage json.RawMessage) any {
 }
 
 func (c *Client) getUsers(ctx context.Context, client *slack.Client) ([]slack.User, error) {
-	return retry(ctx, c.sleep, 3, func() ([]slack.User, error) {
-		return client.GetUsersContext(ctx)
-	})
+	var (
+		cursor string
+		users  []slack.User
+		seen   = map[string]bool{}
+	)
+	for {
+		type result struct {
+			users      []slack.User
+			nextCursor string
+		}
+		page, err := retry(ctx, c.sleep, 3, func() (result, error) {
+			pager := client.GetUsersPaginated(slack.GetUsersOptionLimit(200), slack.GetUsersOptionCursor(cursor))
+			next, callErr := pager.Next(ctx)
+			if callErr != nil {
+				return result{}, callErr
+			}
+			return result{users: next.Users, nextCursor: next.Cursor}, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, page.users...)
+		if page.nextCursor == "" {
+			return users, nil
+		}
+		if seen[page.nextCursor] {
+			return nil, fmt.Errorf("users.list repeated cursor %q", page.nextCursor)
+		}
+		seen[page.nextCursor] = true
+		cursor = page.nextCursor
+	}
 }
 
 func (c *Client) joinConversation(ctx context.Context, channelID string) error {

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -1931,3 +1931,53 @@ func TestSyncThreadRejectsRepeatedCursor(t *testing.T) {
 	require.ErrorContains(t, err, `conversations.replies repeated cursor "stuck"`)
 	require.Equal(t, 2, calls)
 }
+
+func TestGetUsersRejectsRepeatedCursor(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/users.list", r.URL.Path)
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"members":[{"id":"U123","name":"alice"}],"response_metadata":{"next_cursor":"stuck"}}`))
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{Bot: "xoxb-test"}, server.URL+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := client.getUsers(ctx, client.bot)
+	require.ErrorContains(t, err, `users.list repeated cursor "stuck"`)
+	require.Equal(t, 2, calls)
+	t.Logf("getUsers stuck next_cursor: %v", err)
+}
+
+func TestGetUsersWalksDistinctCursors(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/users.list", r.URL.Path)
+		calls++
+		cursor := mustFormValues(r).Get("cursor")
+		w.Header().Set("Content-Type", "application/json")
+		switch cursor {
+		case "":
+			_, _ = w.Write([]byte(`{"ok":true,"members":[{"id":"U1","name":"alice"}],"response_metadata":{"next_cursor":"page2"}}`))
+		case "page2":
+			_, _ = w.Write([]byte(`{"ok":true,"members":[{"id":"U2","name":"bob"}],"response_metadata":{"next_cursor":""}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{Bot: "xoxb-test"}, server.URL+"/", server.Client())
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	users, err := client.getUsers(context.Background(), client.bot)
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	require.Equal(t, "U1", users[0].ID)
+	require.Equal(t, "U2", users[1].ID)
+	require.Equal(t, 2, calls)
+}

--- a/internal/slackapi/api_test.go
+++ b/internal/slackapi/api_test.go
@@ -1981,3 +1981,58 @@ func TestGetUsersWalksDistinctCursors(t *testing.T) {
 	require.Equal(t, "U2", users[1].ID)
 	require.Equal(t, 2, calls)
 }
+
+func TestGetUsersRejectsCursorCycle(t *testing.T) {
+	var cursors []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := mustFormValues(r).Get("cursor")
+		cursors = append(cursors, cursor)
+		next := "page-a"
+		if cursor == "page-a" {
+			next = "page-b"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"ok":true,"members":[],"response_metadata":{"next_cursor":%q}}`, next)
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{Bot: "xoxb-test"}, server.URL+"/", server.Client())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	users, err := client.getUsers(ctx, client.bot)
+	require.ErrorContains(t, err, `users.list repeated cursor "page-a"`)
+	require.Nil(t, users)
+	require.Equal(t, []string{"", "page-a", "page-b"}, cursors)
+}
+
+func TestGetUsersRetriesOnlyRateLimitedPage(t *testing.T) {
+	var cursors []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := mustFormValues(r).Get("cursor")
+		cursors = append(cursors, cursor)
+		if len(cursors) == 2 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if cursor == "" {
+			_, _ = w.Write([]byte(`{"ok":true,"members":[{"id":"U1"}],"response_metadata":{"next_cursor":"page2"}}`))
+		} else {
+			_, _ = w.Write([]byte(`{"ok":true,"members":[{"id":"U2"}],"response_metadata":{"next_cursor":""}}`))
+		}
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(config.Tokens{Bot: "xoxb-test"}, server.URL+"/", server.Client())
+	var delays []time.Duration
+	client.sleep = func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	}
+	users, err := client.getUsers(context.Background(), client.bot)
+	require.NoError(t, err)
+	require.Equal(t, []slack.User{{ID: "U1"}, {ID: "U2"}}, users)
+	require.Equal(t, []string{"", "page2", "page2"}, cursors)
+	require.Equal(t, []time.Duration{time.Second}, delays)
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `slacrawl sync` (or doctor/repair paths that load the member directory) would hang until the process was killed when Slack kept returning the same `users.list` `next_cursor`. Channel, history, thread, and DM pagers already stop on a repeated token. The member walk still handed the full walk to slack-go, which follows `next_cursor` until it is empty.

## Why This Change Was Made

A stuck Slack cursor is a hang, not a slow page. [#159](https://github.com/openclaw/slacrawl/pull/159) added a seen-map on `conversations.list`, `conversations.history`, `conversations.replies`, and DM listing. `getUsers` still called `GetUsersContext` as one shot, so a repeated member-directory cursor kept `slacrawl sync` requesting forever (each request still had the 60s HTTP timeout). This pages `users.list` in slacrawl with the same fail-closed check.

The unguarded member walk dates to [`588584e`](https://github.com/openclaw/slacrawl/commit/588584e4ea53416c4186d62498aeb5f7400627ce) (`feat: sync post-bootstrap updates`, 2026-03-08). It has been present for 180 days. Same class as [openclaw/notcrawl#102](https://github.com/openclaw/notcrawl/pull/102) and [openclaw/discrawl#181](https://github.com/openclaw/discrawl/pull/181).

## User Impact

A wedged `users.list` pager now stops with a clear `users.list repeated cursor` error instead of spinning until someone kills the sync. Successful pages (empty cursor, or a new cursor) are unchanged.

## Evidence

terminal output from the patched Slack client. An `httptest` `users.list` pager that always returns `next_cursor=stuck` now fails closed after two pages.

Before this patch the same pager never returned. A 5s deadline expired with:

```console
$ GOWORK=off go test ./internal/slackapi/ -count=1 -timeout 15s -run TestGetUsersRejectsRepeatedCursor
Error: Error "Post \"http://127.0.0.1:59290/users.list\": context deadline exceeded" does not contain "users.list repeated cursor \"stuck\""
FAIL    github.com/openclaw/slacrawl/internal/slackapi  5.258s
```

After this patch ([`2f79bb80f4f2`](https://github.com/SebTardif/slacrawl/commit/2f79bb80f4f2d4a5bde710b0d17c7eb2bf624900)) the same pager returns immediately:

```console
$ GOWORK=off go test ./internal/slackapi/ -count=1 -timeout 15s -run TestGetUsersRejectsRepeatedCursor -v
=== RUN   TestGetUsersRejectsRepeatedCursor
    api_test.go:1953: getUsers stuck next_cursor: users.list repeated cursor "stuck"
--- PASS: TestGetUsersRejectsRepeatedCursor (0.00s)
ok      github.com/openclaw/slacrawl/internal/slackapi  0.255s
```

Two distinct pages then an empty cursor still collect both members:

```console
$ GOWORK=off go test ./internal/slackapi/ -count=1 -timeout 15s -run TestGetUsersWalksDistinctCursors -v
=== RUN   TestGetUsersWalksDistinctCursors
--- PASS: TestGetUsersWalksDistinctCursors (0.00s)
ok      github.com/openclaw/slacrawl/internal/slackapi  0.253s
```

## Real behavior proof

- **Behavior or issue addressed:** `slacrawl sync` (and doctor/repair that call `getUsers`) hung when Slack repeated a `users.list` `next_cursor`, because slack-go `GetUsersContext` walks pages with no seen-set.
- **Real environment tested:** Windows 11, Go 1.27.0, slacrawl at [`2f79bb80f4f2`](https://github.com/SebTardif/slacrawl/commit/2f79bb80f4f2d4a5bde710b0d17c7eb2bf624900) on branch `fix/users-list-seen-token`.
- **Exact steps or command run after this patch:** `GOWORK=off go test ./internal/slackapi/ -count=1 -timeout 15s -run TestGetUsersRejectsRepeatedCursor -v` and the matching distinct-cursor command against an `httptest` Slack `users.list` endpoint.
- **Evidence after fix:** terminal output from the patched Slack client is in Evidence above. The stuck pager returns `users.list repeated cursor "stuck"` after two `users.list` POSTs instead of waiting out the deadline.
- **Observed result after fix:** `getUsers` returns `users.list repeated cursor "stuck"` in 0.00s after two pages. Two distinct cursors then an empty cursor still return both members.
- **What was not tested:** a live Slack workspace that actually repeats `users.list` `next_cursor`. Rate-limit retry on a single `users.list` page was not re-run here; that path uses the same `retry` helper as the other Slack pagers.

Related: [#159](https://github.com/openclaw/slacrawl/pull/159)
