### PR TITLE
chore: release 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.8.7 - 2026-09-05
+
+**Highlights:** Stop Slack member-directory sync from hanging when `users.list` repeats a page cursor.
 
 ### Fixes
 


### PR DESCRIPTION
Prepare patch release 0.8.7 for September 5, 2026. Date the changelog, keep Fixes before Maintenance and contributor credit, and lead with the users.list pagination hang fix.

The runtime version remains injected by GoReleaser. A local release-version build reports `0.8.7`; the changelog-only change passed independent P0–P2 review. The unified release workflow will run only after CI and Docker pass on the resulting main commit.
