### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## Unreleased
+## 0.9.0 - 2026-09-09
 
-- Migrate archives to schema v8 on first writable open, invalidating pre-v8 API history checkpoints once while retaining messages and retention state. Checkpoints are now local-only in Git shares; restore leaves coverage unknown. The next sync may repeat retention-bounded history requests, or all accessible history without a floor. Stop old processes and keep a consistent pre-upgrade backup; in-place downgrade is unsupported.
-- Keep saved configuration files owner-only on POSIX systems, including when subscribing without importing an archive.
+- Migrate archives to schema v8 on first writable open, invalidating pre-v8 API history checkpoints once while retaining messages and retention state. Checkpoints are now local-only in Git shares; restore leaves coverage unknown. The next sync may repeat retention-bounded history requests, or all accessible history without a floor. Stop old processes and keep a consistent pre-upgrade backup; in-place downgrade is unsupported. See [archive schema upgrades](docs/configuration.md#archive-schema-upgrades).
+- Keep saved configuration files owner-only (`0600`) on POSIX systems, including existing configs and when subscribing without importing an archive. Saving removes group/other read access.
 - Update CrawlKit to v0.15.0 while retaining the Go 1.27.0 minimum and preferred Go 1.27.1 toolchain.
 - Retry unfinished API history intervals after partial failures instead of advancing from the newest saved message; legacy and desktop-only histories establish coverage with a retention-bounded backfill.
 - Bind automatic MCP Codex credentials to the HTTPS ChatGPT origin and reject credential-bearing redirects outside that origin; dedicated custom-server tokens remain supported.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,10 @@ workflow, a thin caller of `openclaw/release-workflows`' reusable Go CLI
 pipeline. The shared workflow owns the annotated version tag, builds the
 GoReleaser matrix and Linux packages, signs and notarizes the macOS binaries as
 OpenClaw Foundation Team ID `FWJYW4S8P8`, publishes only independently verified
-bytes, and opens the next `Unreleased` changelog PR. Slacrawl has no formula in
-`openclaw/homebrew-tap`, so releases do not dispatch a Homebrew handoff.
+bytes, and opens the next `Unreleased` changelog PR. Slacrawl has a formula in
+`openclaw/homebrew-tap`, but this caller does not enable automatic Homebrew
+handoff, so the tap can lag GitHub Releases. Separate tap updates are not a
+success criterion for this workflow.
 
 ```bash
 gh workflow run release-unified.yml --repo openclaw/slacrawl -f version=X.Y.Z

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,10 @@
 
 `slacrawl` is configured with TOML at `~/.slacrawl/config.toml` by default.
 
+Starting with Slacrawl v0.9.0, config-saving commands use owner-only permissions
+(`0600`) on POSIX systems, including when saving existing configs. Saving removes
+group/other read access; shared-account configurations must plan for owner access.
+
 Config path resolution, runtime directories, status payloads, and token
 diagnostic formatting are normalized through `crawlkit`. Slack token scopes,
 workspace selection, API/Desktop source behavior, and schema compatibility stay
@@ -80,8 +84,9 @@ stale_after = "15m"
 
 ## Archive Schema Upgrades
 
-The first writable open of a pre-v8 database upgrades its SQLite schema version
-to 8 in a transaction. This is separate from the TOML configuration version.
+Starting with Slacrawl v0.9.0, the first writable open of a pre-v8 database upgrades
+its SQLite schema version to 8 in a transaction. This is separate from the TOML
+configuration version.
 Read-only inspection with automatic share updates disabled can inspect a valid
 v7 archive without migrating it; `init` only writes configuration. A command such
 as `sync` opens the archive writable and can migrate it even if it subsequently
@@ -99,6 +104,8 @@ requests from the existing retention floor. Without a floor, it can scan all
 accessible history, with corresponding API cost and rate-limit delays. A newer
 saved message does not prove that older history was read. Successful scans earn
 local completion checkpoints; interrupted scans retain their pending interval.
+`--latest-only` selects previously observed channels; it does not bound the
+history interval or request count.
 
 Git-share snapshots retain manifest version 1 and their existing table format,
 but these API coverage checkpoints are local-only and are not exported. Imports
@@ -107,14 +114,18 @@ merge preserves the destination's own checkpoints, while explicit restore clears
 coverage and leaves it unknown. Data-only snapshots do not back up API completion
 state.
 
-Before upgrading, stop every old process accessing the database and retain a
-consistent pre-upgrade backup. Use SQLite-consistent backup procedures or a
-properly stopped archive; copying only a live database's main file can omit WAL
-data. Old binaries reject schema v8 on a new open, but that check does not stop
-already-open clients. Do not mix old and new running processes.
+Before the first writable open, stop every old process accessing the database.
+Complete a consistent pre-upgrade backup using SQLite's
+[Online Backup API](https://sqlite.org/backup.html) and verify that the backup
+opens independently with the expected schema and data. Retain the old binary and
+configuration alongside the database backup. Copying only a live database's main
+file can omit WAL data. Old binaries reject schema v8 on a new open, but that
+check does not stop already-open clients. Do not mix old and new running processes.
 
 Recovery with an older binary requires restoring the consistent pre-upgrade
-backup after stopping the upgraded processes. Do not lower `user_version` or
+database backup and configuration after stopping the upgraded processes. Account
+for writes since that backup: restoring it discards those writes unless a
+separately reviewed recovery preserves them. Do not lower `user_version` or
 attempt an in-place downgrade. A data-only snapshot readable by an older binary
 does not make old-version syncing or opening an upgraded database safe.
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Prepares Slacrawl v0.9.0 with explicit upgrade and recovery guidance for schema
v8, local-only API history coverage, credential boundaries and saved-config
permissions. Related source work: https://github.com/openclaw/slacrawl/pull/172.

## Why This Change Was Made

This is a documentation-only release preparation on
`3e6905019c48dbe724317dac17cac220d9d6064d`: date the existing seven release notes,
link the migration guide, clarify verified SQLite-consistent backup and rollback,
and correct the Homebrew handoff description. Only `CHANGELOG.md`,
`docs/configuration.md` and `CONTRIBUTING.md` change. Production code, tests,
dependencies, release workflows and packaging are unchanged.

The Homebrew formula exists, but this caller does not enable automatic handoff.
The tap can lag GitHub Releases; this PR neither updates it nor changes release
automation. Publication still requires separate explicit authorization after
this PR's review and final-main CI.

## User Impact

The owner explicitly accepts the following release operator contract:

- Stop all old clients before the first writable upgrade. Complete and verify a
  SQLite-consistent pre-upgrade backup. Rollback uses the old binary and
  pre-upgrade database/config after stopping upgraded clients, accounts for
  post-backup writes, and never lowers `user_version` or downgrades in place.
  API history requests may increase; `--latest-only` does not bound their history
  interval or request count.
- Custom MCP origins require dedicated credentials. POSIX config saves use
  `0600`, including existing files, removing group/other read access and affecting
  shared-account configurations.

This is release acceptance, not authorization or proof of a live canary,
installation, backup, archive migration, provider sync or worker change.

Historical review is preserved accurately:
https://github.com/openclaw/slacrawl/pull/172#issuecomment-5592742593 reported
Findings None and Security None, but revision 7 retained two operational
Before merge checkboxes. It was not a clean/ready verdict or a submitted
approval. The explicit acceptance above carries those operational decisions
forward; it does not replace this PR's required genuine review, current-head
ClawSweeper disposition, resolved threads or executed CI gates.

## Evidence

- `git diff --check`: passed.
- `GOWORK=off go mod verify`: passed; all modules verified.
- `GOWORK=off go mod tidy -diff`: passed with no changes.
- Scoped Sol/high autoreview: no actionable findings.
- Exact three-file scope verified. All seven existing notes remain; the first
  two are clarified, the other five and older release sections are unchanged.
  No production, test, dependency, workflow or packaging changes.
- Reused existing source/migration/older-reader proof for unchanged source,
  explicitly approved by the owner. No duplicate migration harness, local
  full-suite run or live-archive test is claimed.
- Executed checks on the exact base passed:
  [CI](https://github.com/openclaw/slacrawl/actions/runs/34326655622),
  [CodeQL](https://github.com/openclaw/slacrawl/actions/runs/34326655676),
  [secret scanning](https://github.com/openclaw/slacrawl/actions/runs/34326655673),
  [Docker](https://github.com/openclaw/slacrawl/actions/runs/34326655758).
  The prep PR and final main must pass their own configured hosted gates.
- No release workflow dispatched, tag created, asset published, tap or
  Cloudsmith change, live store access or canary execution.
