### PR TITLE
chore(release): prepare v0.9.1

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       repository-type: openclaw
+      homebrew-formula: slacrawl
       nfpm: auto
     secrets:
       MACOS_SIGNING_P12: ${{ secrets.MACOS_SIGNING_P12 }}
@@ -29,3 +30,4 @@ jobs:
       ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
       ASC_PRIVATE_KEY_P8: ${{ secrets.ASC_PRIVATE_KEY_P8 }}
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.9.1 - 2026-09-11
 
 **Highlights:** Refresh archive runtime dependencies and security analysis tooling while retaining the Go 1.27.0 minimum.
 
 - Update CrawlKit to 0.16.2, terminal character widths to go-runewidth 0.0.30, and Go network, operating-system, and Unicode text support to x/net 0.59.0, x/sys 0.48.0, and x/text 0.42.0; retain SQLite 1.58.0 with its required libc 1.75.6 runtime.
+- Automatically update the Homebrew formula after verified releases and verify its archive checksums before completing the release workflow.
 - Update govulncheck to 1.8.0, deadcode to 0.50.0, and the pinned CodeQL action to 4.38.0.
 - Update the optional APT/RPM publishing workflows to Cloudsmith CLI 1.27.0.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,10 @@ workflow, a thin caller of `openclaw/release-workflows`' reusable Go CLI
 pipeline. The shared workflow owns the annotated version tag, builds the
 GoReleaser matrix and Linux packages, signs and notarizes the macOS binaries as
 OpenClaw Foundation Team ID `FWJYW4S8P8`, publishes only independently verified
-bytes, and opens the next `Unreleased` changelog PR. Slacrawl has a formula in
-`openclaw/homebrew-tap`, but this caller does not enable automatic Homebrew
-handoff, so the tap can lag GitHub Releases. Separate tap updates are not a
-success criterion for this workflow.
+bytes, updates the `slacrawl` formula in `openclaw/homebrew-tap`, verifies the
+formula's archive checksums, and opens the next `Unreleased` changelog PR.
+Homebrew handoff uses the repository's `HOMEBREW_TAP_TOKEN` secret and must
+succeed before the release workflow completes.
 
 ```bash
 gh workflow run release-unified.yml --repo openclaw/slacrawl -f version=X.Y.Z


### PR DESCRIPTION
Prepare the authorized 0.9.1 maintenance release with the September 11 changelog date and existing Highlights line.

Enable the shared release pipeline Homebrew handoff for `slacrawl`, using the existing repository `HOMEBREW_TAP_TOKEN`. The pipeline verifies the formula against the published archive hashes before completing. Update contributor documentation and release notes to match.

Versioning follows 0.9.0: GoReleaser injects the release version into the CLI through ldflags; source builds keep the development sentinel.

Validation: actionlint and diff checks passed. The runtime changes were tested and live-proven in #175. The release will be dispatched only after CI, Docker, and CodeQL pass on the merged release commit.
